### PR TITLE
Fix: Bridge process crash and message forwarding stability (macOS/tmux)

### DIFF
--- a/ccb
+++ b/ccb
@@ -335,11 +335,19 @@ if ! tmux has-session -t "$TMUX_SESSION" 2>/dev/null; then
 fi
 tmux pipe-pane -o -t "$TMUX_SESSION" "cat >> '$TMUX_LOG_FILE'"
 
-"$PYTHON_BIN" "$BRIDGE_SCRIPT" --runtime-dir "$RUNTIME_DIR" --session-id "$SESSION_ID" >>"$RUNTIME_DIR/bridge.log" 2>&1 &
-BRIDGE_PID=$!
-echo $BRIDGE_PID > "$RUNTIME_DIR/bridge.pid"
+echo "=== Wrapper Start ===" > "$RUNTIME_DIR/debug.log"
+date >> "$RUNTIME_DIR/debug.log"
+pwd >> "$RUNTIME_DIR/debug.log"
+env >> "$RUNTIME_DIR/debug.log"
+echo "Python: $PYTHON_BIN" >> "$RUNTIME_DIR/debug.log"
+echo "Script: $BRIDGE_SCRIPT" >> "$RUNTIME_DIR/debug.log"
 
-trap 'kill -TERM "$BRIDGE_PID" 2>/dev/null' EXIT
+nohup "$PYTHON_BIN" "$BRIDGE_SCRIPT" --runtime-dir "$RUNTIME_DIR" --session-id "$SESSION_ID" >>"$RUNTIME_DIR/bridge.log" 2>&1 &
+BRIDGE_PID=$!
+echo "Bridge PID: $BRIDGE_PID" >> "$RUNTIME_DIR/debug.log"
+echo $BRIDGE_PID > "$RUNTIME_DIR/bridge.pid"
+disown $BRIDGE_PID
+
 exec tmux attach -t "$TMUX_SESSION"
 '''
         script_file = runtime / "wrapper.sh"

--- a/lib/codex_comm.py
+++ b/lib/codex_comm.py
@@ -319,17 +319,17 @@ class CodexCommunicator:
                     return False, f"WezTerm pane 不存在: {self.pane_id}"
                 return True, "会话正常"
 
-            # tmux 模式：依赖 wrapper 写入 codex.pid 与 FIFO
-            codex_pid_file = self.runtime_dir / "codex.pid"
-            if not codex_pid_file.exists():
-                return False, "Codex进程PID文件不存在"
-
-            with open(codex_pid_file, "r", encoding="utf-8") as f:
-                codex_pid = int(f.read().strip())
-            try:
-                os.kill(codex_pid, 0)
-            except OSError:
-                return False, f"Codex进程(PID:{codex_pid})已退出"
+            # tmux 模式：检查 tmux 会话是否存活
+            # 注意：不再检查 codex.pid，因为 wrapper.sh 使用 exec tmux attach 后 PID 会失效
+            tmux_session = self.session_info.get("tmux_session")
+            if tmux_session and probe_terminal:
+                import subprocess
+                result = subprocess.run(
+                    ["tmux", "has-session", "-t", tmux_session],
+                    capture_output=True
+                )
+                if result.returncode != 0:
+                    return False, f"Tmux会话不存在: {tmux_session}"
 
             if not self.input_fifo.exists():
                 return False, "通信管道不存在"

--- a/lib/codex_dual_bridge.py
+++ b/lib/codex_dual_bridge.py
@@ -46,6 +46,17 @@ class DualBridge:
 
         terminal_type = os.environ.get("CODEX_TERMINAL", "tmux")
         pane_id = os.environ.get("CODEX_WEZTERM_PANE") if terminal_type == "wezterm" else os.environ.get("CODEX_TMUX_SESSION")
+        
+        # If pane_id not in env, try to read from .codex-session file
+        if not pane_id and terminal_type == "tmux":
+            session_file = Path.cwd() / ".codex-session"
+            if session_file.exists():
+                try:
+                    data = json.loads(session_file.read_text())
+                    pane_id = data.get("tmux_session")
+                except Exception:
+                    pass
+        
         if not pane_id:
             raise RuntimeError(f"缺少 {'CODEX_WEZTERM_PANE' if terminal_type == 'wezterm' else 'CODEX_TMUX_SESSION'} 环境变量")
 

--- a/lib/terminal.py
+++ b/lib/terminal.py
@@ -38,7 +38,7 @@ class TmuxBackend(TerminalBackend):
         encoded = (sanitized + "\n").encode("utf-8")
         subprocess.run(["tmux", "load-buffer", "-b", buffer_name, "-"], input=encoded, check=True)
         subprocess.run(["tmux", "paste-buffer", "-t", session, "-b", buffer_name, "-p"], check=True)
-        time.sleep(0.02)
+        time.sleep(0.5)
         subprocess.run(["tmux", "send-keys", "-t", session, "Enter"], check=True)
         subprocess.run(["tmux", "delete-buffer", "-b", buffer_name], stderr=subprocess.DEVNULL)
 


### PR DESCRIPTION
This PR fixes critical stability issues on macOS/tmux where the bridge process terminates immediately or messages fail to send.

### Fixes
1.  **Bridge Process Killed:** The 'exec tmux attach' in wrapper.sh was causing the background bridge process to die via SIGHUP. Fixed by launching with 'nohup ... & disown'.
2.  **Missing Env Vars:** Background bridge process sometimes dropped env vars. Added fallback to read session name from '.codex-session' file.
3.  **Health Check Bug:** 'cping' failed because it checked the wrapper's PID (in codex.pid) instead of the actual tmux session. Updated check logic.
4.  **Long Text Truncated:** Increased tmux paste buffer delay from 0.02s to 0.5s to fix truncation issues with long prompts (e.g. for Gemini).

### Testing
Verified with complex multi-turn debates between Claude, Codex, and Gemini. All components now work stably.