### PR TITLE
fix(windows): add UTF-8 encoding for subprocess calls in terminal backends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 .claude-session
 .claude/
 *.mp4
+tmp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-- 该文件夹是 claude_code_bridge (ccb) 开发文件夹，要注意兼容性，同时修改代码注意同时修改install，安装使用install安装，完成后要git增加版本并推送
+- This is the claude_code_bridge (ccb) development folder. Pay attention to compatibility. When modifying code, also update install scripts. Use install.sh/install.ps1 to install. After completion, git commit and push.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,48 @@
+# AGPL-3.0 - GNU Affero General Public License v3.0
+
+## English
+
+This software is licensed under the AGPL-3.0 license, which means:
+
+- **Attribution Required**: You must give appropriate credit, provide a link to the license, and indicate if changes were made. When using Claude Code Bridge (CCB), please credit the original project.
+
+- **Open Source Required**: If you modify this software and distribute it or run it as a service, you must release your source code under AGPL-3.0.
+
+- **Network Use (Copyleft)**: If you run this software as a network service (e.g., SaaS), users interacting with it over the network must be able to receive the source code.
+
+- **No Closed-Source Use**: You cannot use this software in proprietary/closed-source projects unless you open-source the entire project under AGPL-3.0.
+
+**In short**: You can use Claude Code Bridge for free, but if you build upon it, your code must also be open-sourced under AGPL-3.0 with attribution to this project. Closed-source commercial use requires a separate license.
+
+For commercial licensing inquiries (closed-source use), please contact the maintainer.
+
+---
+
+## 中文
+
+本软件采用 AGPL-3.0 许可协议，这意味着：
+
+- **署名要求**：您必须注明出处，提供许可协议链接，并说明是否进行了修改。使用 Claude Code Bridge (CCB) 时，请注明项目来源。
+
+- **开源要求**：如果您修改此软件并将其分发或作为服务运行，则必须根据 AGPL-3.0 发布您的源代码。
+
+- **网络使用（Copyleft）**：如果您将此软件作为网络服务（例如 SaaS）运行，则通过网络与其交互的用户必须能够接收源代码。
+
+- **禁止闭源使用**：您不能在专有/闭源项目中使用此软件，除非您将整个项目根据 AGPL-3.0 开源。
+
+**简单来说**：您可以免费使用 Claude Code Bridge，但如果您基于它进行开发，您的代码也必须根据 AGPL-3.0 开源，并注明本项目。闭源商业用途需要单独的许可证。
+
+对于商业许可咨询（闭源使用），请联系维护者。
+
+---
+
+## Full License Text
+
+GNU AFFERO GENERAL PUBLIC LICENSE
+Version 3, 19 November 2007
+
+Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+For the complete license text, see: https://www.gnu.org/licenses/agpl-3.0.txt

--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ ccb update              # Update to latest version
 - Python 3.10+
 - tmux or WezTerm (at least one; WezTerm recommended)
 
+> **⚠️ Windows Users:** Always install WezTerm using the **native Windows .exe installer** from [wezfurlong.org/wezterm](https://wezfurlong.org/wezterm/), even if you use WSL. Do NOT install WezTerm inside WSL. After installation, configure WezTerm to connect to WSL via `wsl.exe` as the default shell. This ensures proper split-pane functionality.
+
 ## Uninstall
 
 ```bash
@@ -370,8 +372,9 @@ ccb update              # 更新到最新版本
 ## 依赖
 
 - Python 3.10+
-- tmux 或 WezTerm（至少安装一个），强烈推荐wezterm
+- tmux 或 WezTerm（至少安装一个），强烈推荐 WezTerm
 
+> **⚠️ Windows 用户注意：** 必须使用 **Windows 原生 .exe 安装包** 安装 WezTerm（[下载地址](https://wezfurlong.org/wezterm/)），即使你使用 WSL 也是如此。**不要在 WSL 内部安装 WezTerm**。安装完成后，可在 WezTerm 设置中将默认 shell 配置为 `wsl.exe`，即可无缝接入 WSL 环境，同时保证分屏功能正常工作。
 
 ## 卸载
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Windows | macOS | Linux — One Tool, All Platforms**
 
-[![Version](https://img.shields.io/badge/version-2.1-orange.svg)]()
+[![Version](https://img.shields.io/badge/version-2.2-orange.svg)]()
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![Platform](https://img.shields.io/badge/platform-Linux%20%7C%20macOS%20%7C%20Windows-lightgrey.svg)]()

--- a/bin/cask
+++ b/bin/cask
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-cask - 将消息转发到 Codex 会话
+cask - Forward message to Codex session
 """
 from __future__ import annotations
 import json
@@ -19,7 +19,7 @@ from terminal import get_backend_for_session, get_pane_id_from_session
 
 
 def _usage() -> None:
-    print("用法: cask <消息>", file=sys.stderr)
+    print("Usage: cask <message>", file=sys.stderr)
 
 
 def _load_session() -> Optional[dict]:
@@ -48,10 +48,10 @@ def _load_session() -> Optional[dict]:
 def _resolve_session() -> Tuple[dict, str]:
     data = _load_session()
     if not data:
-        raise RuntimeError("❌ 未找到 Codex 会话，请先运行 ccb up codex")
+        raise RuntimeError("❌ Codex session not found, please run ccb up codex first")
     pane_id = get_pane_id_from_session(data)
     if not pane_id:
-        raise RuntimeError("❌ 会话配置无效")
+        raise RuntimeError("❌ Session config invalid")
     return data, pane_id
 
 
@@ -69,12 +69,12 @@ def main(argv: list[str]) -> int:
         data, pane_id = _resolve_session()
         backend = get_backend_for_session(data)
         if not backend:
-            raise RuntimeError("❌ 无法初始化终端后端")
+            raise RuntimeError("❌ Cannot initialize terminal backend")
         if not backend.is_alive(pane_id):
             terminal = data.get("terminal", "tmux")
-            raise RuntimeError(f"❌ {terminal} 会话不存在: {pane_id}\n提示: 请确认 ccb 正在运行")
+            raise RuntimeError(f"❌ {terminal} session not found: {pane_id}\nHint: Please confirm ccb is running")
         backend.send_text(pane_id, raw_command)
-        print(f"✅ 已发送到 Codex ({pane_id})")
+        print(f"✅ Sent to Codex ({pane_id})")
         return 0
     except Exception as exc:
         print(exc, file=sys.stderr)

--- a/bin/cask
+++ b/bin/cask
@@ -12,6 +12,8 @@ from typing import Optional, Tuple
 script_dir = Path(__file__).resolve().parent
 lib_dir = script_dir.parent / "lib"
 sys.path.insert(0, str(lib_dir))
+from compat import setup_windows_encoding
+setup_windows_encoding()
 
 from terminal import get_backend_for_session, get_pane_id_from_session
 

--- a/bin/cask-w
+++ b/bin/cask-w
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """
-cask-w - Sync send message to Codex and wait for reply
+cask-w - Send message to Codex and wait for reply in background
 """
 from __future__ import annotations
+import os
 import sys
 from pathlib import Path
 
@@ -21,10 +22,6 @@ def main(argv: list[str]) -> int:
         print("❌ Message cannot be empty", file=sys.stderr)
         return 1
 
-    # Early startup signal for background mode detection
-    print("🚀 cask-w started", flush=True)
-
-    # Lazy imports after startup signal
     if sys.platform == "win32":
         from compat import setup_windows_encoding
         setup_windows_encoding()
@@ -33,8 +30,57 @@ def main(argv: list[str]) -> int:
 
     try:
         comm = CodexCommunicator(lazy_init=True)
-        reply = comm.ask_sync(message)
-        return 0 if reply else 1
+
+        # Check session health
+        healthy, status = comm._check_session_health_impl(probe_terminal=False)
+        if not healthy:
+            print(f"❌ Session error: {status}", file=sys.stderr)
+            return 1
+
+        # Send message
+        from i18n import t
+        print(f"🔔 {t('sending_to', provider='Codex')}", flush=True)
+        marker, state = comm._send_message(message)
+        print("✅ Message sent, waiting for reply in background...", flush=True)
+
+        # Fork background process to wait for reply
+        pid = os.fork() if hasattr(os, 'fork') else None
+
+        if pid is None:
+            # Windows: no fork, wait synchronously with short timeout
+            import time
+            message_reply, new_state = comm.log_reader.wait_for_message(state, 30.0)
+            if message_reply:
+                print(f"🤖 {t('reply_from', provider='Codex')}")
+                print(message_reply)
+            else:
+                print("⏰ Timeout waiting for reply")
+            return 0
+        elif pid == 0:
+            # Child process: wait for reply silently
+            import time
+            try:
+                # Detach from terminal
+                os.setsid()
+                sys.stdin.close()
+                sys.stdout = open(os.devnull, 'w')
+                sys.stderr = open(os.devnull, 'w')
+
+                # Wait for reply (up to 5 minutes)
+                message_reply, new_state = comm.log_reader.wait_for_message(state, 300.0)
+
+                # Save reply to cache file for cpend to read
+                if message_reply:
+                    cache_dir = Path.home() / ".cache" / "ccb"
+                    cache_dir.mkdir(parents=True, exist_ok=True)
+                    reply_file = cache_dir / "codex_last_reply.txt"
+                    reply_file.write_text(message_reply, encoding="utf-8")
+            except Exception:
+                pass
+            os._exit(0)
+        else:
+            # Parent process: return immediately
+            return 0
 
     except Exception as exc:
         print(exc, file=sys.stderr)

--- a/bin/cask-w
+++ b/bin/cask-w
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-cask-w - 同步发送消息到 Codex 并等待回复
+cask-w - Sync send message to Codex and wait for reply
 """
 from __future__ import annotations
 import sys
@@ -17,12 +17,12 @@ from codex_comm import CodexCommunicator
 
 def main(argv: list[str]) -> int:
     if len(argv) <= 1:
-        print("用法: cask-w <消息>", file=sys.stderr)
+        print("Usage: cask-w <message>", file=sys.stderr)
         return 1
 
     message = " ".join(argv[1:]).strip()
     if not message:
-        print("❌ 消息内容不能为空", file=sys.stderr)
+        print("❌ Message cannot be empty", file=sys.stderr)
         return 1
 
     try:

--- a/bin/cask-w
+++ b/bin/cask-w
@@ -25,6 +25,9 @@ def main(argv: list[str]) -> int:
         print("❌ Message cannot be empty", file=sys.stderr)
         return 1
 
+    # Early startup signal for background mode detection
+    print("🚀 cask-w started", flush=True)
+
     try:
         comm = CodexCommunicator()
         reply = comm.ask_sync(message, timeout=0)

--- a/bin/cask-w
+++ b/bin/cask-w
@@ -9,10 +9,6 @@ from pathlib import Path
 script_dir = Path(__file__).resolve().parent
 lib_dir = script_dir.parent / "lib"
 sys.path.insert(0, str(lib_dir))
-from compat import setup_windows_encoding
-setup_windows_encoding()
-
-from codex_comm import CodexCommunicator
 
 
 def main(argv: list[str]) -> int:
@@ -28,8 +24,15 @@ def main(argv: list[str]) -> int:
     # Early startup signal for background mode detection
     print("🚀 cask-w started", flush=True)
 
+    # Lazy imports after startup signal
+    if sys.platform == "win32":
+        from compat import setup_windows_encoding
+        setup_windows_encoding()
+
+    from codex_comm import CodexCommunicator
+
     try:
-        comm = CodexCommunicator()
+        comm = CodexCommunicator(lazy_init=True)
         reply = comm.ask_sync(message, timeout=0)
         return 0 if reply else 1
 

--- a/bin/cask-w
+++ b/bin/cask-w
@@ -33,7 +33,7 @@ def main(argv: list[str]) -> int:
 
     try:
         comm = CodexCommunicator(lazy_init=True)
-        reply = comm.ask_sync(message, timeout=0)
+        reply = comm.ask_sync(message)
         return 0 if reply else 1
 
     except Exception as exc:

--- a/bin/cask-w
+++ b/bin/cask-w
@@ -9,6 +9,8 @@ from pathlib import Path
 script_dir = Path(__file__).resolve().parent
 lib_dir = script_dir.parent / "lib"
 sys.path.insert(0, str(lib_dir))
+from compat import setup_windows_encoding
+setup_windows_encoding()
 
 from codex_comm import CodexCommunicator
 

--- a/bin/cask-w
+++ b/bin/cask-w
@@ -34,7 +34,7 @@ def main(argv: list[str]) -> int:
         if not session_file.exists():
             return
         try:
-            with session_file.open("r", encoding="utf-8") as handle:
+            with session_file.open("r", encoding="utf-8-sig") as handle:
                 data = json.load(handle)
             data["pending_state"] = {
                 "log_path": str(state.get("log_path")) if state.get("log_path") else None,

--- a/bin/cask-w
+++ b/bin/cask-w
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 """
-cask-w - Send message to Codex and wait for reply in background
+cask-w - Send message to Codex and wait for reply (pure sync mode)
+Designed to be run with Claude Code's run_in_background=true
 """
 from __future__ import annotations
 import os
 import sys
 from pathlib import Path
+import json
 
 script_dir = Path(__file__).resolve().parent
 lib_dir = script_dir.parent / "lib"
@@ -27,6 +29,25 @@ def main(argv: list[str]) -> int:
         setup_windows_encoding()
 
     from codex_comm import CodexCommunicator
+    from i18n import t
+
+    def save_pending_state(state: dict) -> None:
+        session_file = Path.cwd() / ".codex-session"
+        if not session_file.exists():
+            return
+        try:
+            with session_file.open("r", encoding="utf-8") as handle:
+                data = json.load(handle)
+            data["pending_state"] = {
+                "log_path": str(state.get("log_path")) if state.get("log_path") else None,
+                "offset": int(state.get("offset", 0) or 0),
+            }
+            tmp_file = session_file.with_suffix(".tmp")
+            with tmp_file.open("w", encoding="utf-8") as handle:
+                json.dump(data, handle, ensure_ascii=False, indent=2)
+            os.replace(tmp_file, session_file)
+        except Exception:
+            return
 
     try:
         comm = CodexCommunicator(lazy_init=True)
@@ -38,52 +59,38 @@ def main(argv: list[str]) -> int:
             return 1
 
         # Send message
-        from i18n import t
         print(f"🔔 {t('sending_to', provider='Codex')}", flush=True)
         marker, state = comm._send_message(message)
-        print("✅ Message sent, waiting for reply in background...", flush=True)
+        comm._remember_codex_session(state.get("log_path") or comm.log_reader.current_log_path())
 
-        # Double fork to fully detach background process
-        if hasattr(os, 'fork'):
-            pid = os.fork()
-            if pid > 0:
-                # Parent: return immediately
-                return 0
-            # First child: fork again and exit
-            os.setsid()
-            pid2 = os.fork()
-            if pid2 > 0:
-                os._exit(0)  # First child exits
-            # Grandchild: wait for reply silently
-            try:
-                sys.stdin.close()
-                sys.stdout = open(os.devnull, 'w')
-                sys.stderr = open(os.devnull, 'w')
+        # Pure sync wait (default 1 hour, configurable via CCB_SYNC_TIMEOUT)
+        sync_timeout = float(os.environ.get("CCB_SYNC_TIMEOUT", "3600.0"))
+        message_reply, _ = comm.log_reader.wait_for_message(state, sync_timeout)
 
-                # Wait for reply (up to 5 minutes)
-                message_reply, new_state = comm.log_reader.wait_for_message(state, 300.0)
+        # Save to cache
+        cache_dir = Path.home() / ".cache" / "ccb"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        reply_file = cache_dir / "codex_last_reply.txt"
 
-                # Save reply to cache file for cpend to read
-                if message_reply:
-                    cache_dir = Path.home() / ".cache" / "ccb"
-                    cache_dir.mkdir(parents=True, exist_ok=True)
-                    reply_file = cache_dir / "codex_last_reply.txt"
-                    reply_file.write_text(message_reply, encoding="utf-8")
-            except Exception:
-                pass
-            os._exit(0)
+        if message_reply:
+            print(f"🤖 {t('reply_from', provider='Codex')}")
+            print(message_reply)
+            reply_file.write_text(message_reply, encoding="utf-8")
         else:
-            # Windows: no fork, wait synchronously with short timeout
-            message_reply, new_state = comm.log_reader.wait_for_message(state, 30.0)
-            if message_reply:
-                print(f"🤖 {t('reply_from', provider='Codex')}")
-                print(message_reply)
-            else:
-                print("⏰ Timeout waiting for reply")
-            return 0
+            print(f"⏰ Timeout after {int(sync_timeout)}s")
+            save_pending_state(state)
+        return 0
 
+    except KeyboardInterrupt:
+        # Best-effort: preserve pending state so /cpend can fetch later.
+        try:
+            save_pending_state(locals().get("state", {}) if isinstance(locals().get("state"), dict) else {})
+        except Exception:
+            pass
+        print("❌ Interrupted", file=sys.stderr)
+        return 130
     except Exception as exc:
-        print(exc, file=sys.stderr)
+        print(f"❌ {exc}", file=sys.stderr)
         return 1
 
 

--- a/bin/cask-w
+++ b/bin/cask-w
@@ -43,25 +43,19 @@ def main(argv: list[str]) -> int:
         marker, state = comm._send_message(message)
         print("✅ Message sent, waiting for reply in background...", flush=True)
 
-        # Fork background process to wait for reply
-        pid = os.fork() if hasattr(os, 'fork') else None
-
-        if pid is None:
-            # Windows: no fork, wait synchronously with short timeout
-            import time
-            message_reply, new_state = comm.log_reader.wait_for_message(state, 30.0)
-            if message_reply:
-                print(f"🤖 {t('reply_from', provider='Codex')}")
-                print(message_reply)
-            else:
-                print("⏰ Timeout waiting for reply")
-            return 0
-        elif pid == 0:
-            # Child process: wait for reply silently
-            import time
+        # Double fork to fully detach background process
+        if hasattr(os, 'fork'):
+            pid = os.fork()
+            if pid > 0:
+                # Parent: return immediately
+                return 0
+            # First child: fork again and exit
+            os.setsid()
+            pid2 = os.fork()
+            if pid2 > 0:
+                os._exit(0)  # First child exits
+            # Grandchild: wait for reply silently
             try:
-                # Detach from terminal
-                os.setsid()
                 sys.stdin.close()
                 sys.stdout = open(os.devnull, 'w')
                 sys.stderr = open(os.devnull, 'w')
@@ -79,7 +73,13 @@ def main(argv: list[str]) -> int:
                 pass
             os._exit(0)
         else:
-            # Parent process: return immediately
+            # Windows: no fork, wait synchronously with short timeout
+            message_reply, new_state = comm.log_reader.wait_for_message(state, 30.0)
+            if message_reply:
+                print(f"🤖 {t('reply_from', provider='Codex')}")
+                print(message_reply)
+            else:
+                print("⏰ Timeout waiting for reply")
             return 0
 
     except Exception as exc:

--- a/bin/cask-w
+++ b/bin/cask-w
@@ -12,6 +12,8 @@ import json
 script_dir = Path(__file__).resolve().parent
 lib_dir = script_dir.parent / "lib"
 sys.path.insert(0, str(lib_dir))
+from compat import setup_windows_encoding
+setup_windows_encoding()
 
 
 def main(argv: list[str]) -> int:
@@ -23,10 +25,6 @@ def main(argv: list[str]) -> int:
     if not message:
         print("❌ Message cannot be empty", file=sys.stderr)
         return 1
-
-    if sys.platform == "win32":
-        from compat import setup_windows_encoding
-        setup_windows_encoding()
 
     from codex_comm import CodexCommunicator
     from i18n import t

--- a/bin/cpend
+++ b/bin/cpend
@@ -22,6 +22,21 @@ except ImportError as exc:
     sys.exit(1)
 
 
+def _load_cached_reply() -> str | None:
+    """Load cached reply from background cask-w process"""
+    cache_file = Path.home() / ".cache" / "ccb" / "codex_last_reply.txt"
+    if not cache_file.exists():
+        return None
+    try:
+        content = cache_file.read_text(encoding="utf-8").strip()
+        if content:
+            cache_file.unlink()  # Clear after reading
+            return content
+    except Exception:
+        pass
+    return None
+
+
 def _load_pending_state() -> dict:
     """Load pending state saved by cask-w timeout from .codex-session"""
     session_file = Path.cwd() / ".codex-session"
@@ -53,6 +68,13 @@ def _clear_pending_state() -> None:
 
 def main() -> int:
     try:
+        # First check cached reply from background cask-w
+        cached = _load_cached_reply()
+        if cached:
+            print(f"🤖 Codex reply:")
+            print(cached)
+            return 0
+
         comm = CodexCommunicator()
 
         pending = _load_pending_state()

--- a/bin/cpend
+++ b/bin/cpend
@@ -13,6 +13,8 @@ sys.path.insert(0, str(lib_dir))
 from compat import setup_windows_encoding
 setup_windows_encoding()
 
+from i18n import t
+
 try:
     from codex_comm import CodexCommunicator
 except ImportError as exc:
@@ -69,10 +71,10 @@ def main() -> int:
         if output:
             print(output)
         else:
-            print('No Codex reply available')
+            print(t('no_reply_available', provider='Codex'))
         return 0
     except Exception as exc:
-        print(f"❌ Execution failed: {exc}")
+        print(f"❌ {t('execution_failed', error=exc)}")
         return 1
 
 

--- a/bin/cpend
+++ b/bin/cpend
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-cpend - 查看 Codex 最新回复
+cpend - View latest Codex reply
 """
 
 import json
@@ -16,12 +16,12 @@ setup_windows_encoding()
 try:
     from codex_comm import CodexCommunicator
 except ImportError as exc:
-    print(f"导入失败: {exc}")
+    print(f"Import failed: {exc}")
     sys.exit(1)
 
 
 def _load_pending_state() -> dict:
-    """从 .codex-session 加载 cask-w 超时时保存的状态"""
+    """Load pending state saved by cask-w timeout from .codex-session"""
     session_file = Path.cwd() / ".codex-session"
     if not session_file.exists():
         return {}
@@ -34,7 +34,7 @@ def _load_pending_state() -> dict:
 
 
 def _clear_pending_state() -> None:
-    """清除 pending_state"""
+    """Clear pending_state"""
     session_file = Path.cwd() / ".codex-session"
     if not session_file.exists():
         return
@@ -69,10 +69,10 @@ def main() -> int:
         if output:
             print(output)
         else:
-            print('暂无 Codex 回复')
+            print('No Codex reply available')
         return 0
     except Exception as exc:
-        print(f"❌ 执行失败: {exc}")
+        print(f"❌ Execution failed: {exc}")
         return 1
 
 

--- a/bin/cpend
+++ b/bin/cpend
@@ -10,6 +10,8 @@ from pathlib import Path
 script_dir = Path(__file__).resolve().parent
 lib_dir = script_dir.parent / "lib"
 sys.path.insert(0, str(lib_dir))
+from compat import setup_windows_encoding
+setup_windows_encoding()
 
 try:
     from codex_comm import CodexCommunicator

--- a/bin/cpend
+++ b/bin/cpend
@@ -14,6 +14,7 @@ from compat import setup_windows_encoding
 setup_windows_encoding()
 
 from i18n import t
+from session_utils import safe_write_session
 
 try:
     from codex_comm import CodexCommunicator
@@ -43,9 +44,10 @@ def _load_pending_state() -> dict:
     if not session_file.exists():
         return {}
     try:
-        with session_file.open("r", encoding="utf-8") as f:
+        with session_file.open("r", encoding="utf-8-sig") as f:
             data = json.load(f)
-        return data.get("pending_state", {})
+        pending = data.get("pending_state", {})
+        return pending if isinstance(pending, dict) else {}
     except Exception:
         return {}
 
@@ -56,12 +58,11 @@ def _clear_pending_state() -> None:
     if not session_file.exists():
         return
     try:
-        with session_file.open("r", encoding="utf-8") as f:
+        with session_file.open("r", encoding="utf-8-sig") as f:
             data = json.load(f)
         if "pending_state" in data:
             del data["pending_state"]
-            with session_file.open("w", encoding="utf-8") as f:
-                json.dump(data, f, ensure_ascii=False, indent=2)
+            safe_write_session(session_file, json.dumps(data, ensure_ascii=False, indent=2))
     except Exception:
         pass
 
@@ -79,15 +80,24 @@ def main() -> int:
 
         pending = _load_pending_state()
         if pending and pending.get("log_path"):
-            state = {
-                "log_path": Path(pending["log_path"]),
-                "offset": pending.get("offset", 0),
-            }
-            message, _ = comm.log_reader.try_get_message(state)
-            if message:
-                _clear_pending_state()
-                print(message)
-                return 0
+            try:
+                log_path = Path(str(pending.get("log_path"))).expanduser()
+            except Exception:
+                log_path = None
+
+            # Avoid falling back to "global latest" if the pending log path is missing,
+            # otherwise cpend may display an unrelated reply from another project.
+            if log_path and log_path.exists():
+                try:
+                    offset = int(pending.get("offset", 0) or 0)
+                except Exception:
+                    offset = 0
+                state = {"log_path": str(log_path), "offset": offset}
+                message, _ = comm.log_reader.try_get_message(state)
+                if message:
+                    _clear_pending_state()
+                    print(message)
+                    return 0
 
         output = comm.consume_pending(display=False)
         if output:

--- a/bin/cping
+++ b/bin/cping
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
-cping 命令入口点
-测试与 Codex 的连通性
+cping command entry point
+Test connectivity with Codex
 """
 
 import sys
@@ -25,13 +25,13 @@ try:
             return 0 if healthy else 1
 
         except Exception as e:
-            print(f"❌ 连通性测试失败: {e}")
+            print(f"❌ Connectivity test failed: {e}")
             return 1
 
     if __name__ == "__main__":
         sys.exit(main())
 
 except ImportError as e:
-    print(f"❌ 导入模块失败: {e}")
-    print("请确保 codex_comm.py 在同一目录下")
+    print(f"❌ Module import failed: {e}")
+    print("Please ensure codex_comm.py is in the same directory")
     sys.exit(1)

--- a/bin/cping
+++ b/bin/cping
@@ -8,10 +8,11 @@ import sys
 import os
 from pathlib import Path
 
-# 添加lib目录到Python路径
 script_dir = Path(__file__).resolve().parent
 lib_dir = script_dir.parent / "lib"
 sys.path.insert(0, str(lib_dir))
+from compat import setup_windows_encoding
+setup_windows_encoding()
 
 try:
     from codex_comm import CodexCommunicator

--- a/bin/gask
+++ b/bin/gask
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-gask - 异步发送消息到 Gemini
+gask - Async send message to Gemini
 """
 
 from __future__ import annotations
@@ -19,12 +19,12 @@ from gemini_comm import GeminiCommunicator
 
 def main(argv: list[str]) -> int:
     if len(argv) <= 1:
-        print("用法: gask <消息>", file=sys.stderr)
+        print("Usage: gask <message>", file=sys.stderr)
         return 1
 
     message = " ".join(argv[1:]).strip()
     if not message:
-        print("❌ 消息内容不能为空", file=sys.stderr)
+        print("❌ Message cannot be empty", file=sys.stderr)
         return 1
 
     try:

--- a/bin/gask
+++ b/bin/gask
@@ -11,6 +11,8 @@ from pathlib import Path
 script_dir = Path(__file__).resolve().parent
 lib_dir = script_dir.parent / "lib"
 sys.path.insert(0, str(lib_dir))
+from compat import setup_windows_encoding
+setup_windows_encoding()
 
 from gemini_comm import GeminiCommunicator
 

--- a/bin/gask-w
+++ b/bin/gask-w
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """
-gask-w - Sync send message to Gemini and wait for reply
+gask-w - Send message to Gemini and wait for reply in background
 """
 from __future__ import annotations
+import os
 import sys
 from pathlib import Path
 
@@ -21,10 +22,6 @@ def main(argv: list[str]) -> int:
         print("❌ Message cannot be empty", file=sys.stderr)
         return 1
 
-    # Early startup signal for background mode detection
-    print("🚀 gask-w started", flush=True)
-
-    # Lazy imports after startup signal
     if sys.platform == "win32":
         from compat import setup_windows_encoding
         setup_windows_encoding()
@@ -33,8 +30,56 @@ def main(argv: list[str]) -> int:
 
     try:
         comm = GeminiCommunicator(lazy_init=True)
-        reply = comm.ask_sync(message)
-        return 0 if reply else 1
+
+        # Check session health
+        healthy, status = comm._check_session_health_impl(probe_terminal=False)
+        if not healthy:
+            print(f"❌ Session error: {status}", file=sys.stderr)
+            return 1
+
+        # Send message
+        from i18n import t
+        print(f"🔔 {t('sending_to', provider='Gemini')}", flush=True)
+        comm._send_via_terminal(message)
+        state = comm.log_reader.capture_state()
+        print("✅ Message sent, waiting for reply in background...", flush=True)
+
+        # Fork background process to wait for reply
+        pid = os.fork() if hasattr(os, 'fork') else None
+
+        if pid is None:
+            # Windows: no fork, wait synchronously with short timeout
+            message_reply, new_state = comm.log_reader.wait_for_message(state, 30.0)
+            if message_reply:
+                print(f"🤖 {t('reply_from', provider='Gemini')}")
+                print(message_reply)
+            else:
+                print("⏰ Timeout waiting for reply")
+            return 0
+        elif pid == 0:
+            # Child process: wait for reply silently
+            try:
+                # Detach from terminal
+                os.setsid()
+                sys.stdin.close()
+                sys.stdout = open(os.devnull, 'w')
+                sys.stderr = open(os.devnull, 'w')
+
+                # Wait for reply (up to 5 minutes)
+                message_reply, new_state = comm.log_reader.wait_for_message(state, 300.0)
+
+                # Save reply to cache file for gpend to read
+                if message_reply:
+                    cache_dir = Path.home() / ".cache" / "ccb"
+                    cache_dir.mkdir(parents=True, exist_ok=True)
+                    reply_file = cache_dir / "gemini_last_reply.txt"
+                    reply_file.write_text(message_reply, encoding="utf-8")
+            except Exception:
+                pass
+            os._exit(0)
+        else:
+            # Parent process: return immediately
+            return 0
 
     except Exception as exc:
         print(exc, file=sys.stderr)

--- a/bin/gask-w
+++ b/bin/gask-w
@@ -7,6 +7,7 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
+import json
 
 script_dir = Path(__file__).resolve().parent
 lib_dir = script_dir.parent / "lib"
@@ -30,6 +31,29 @@ def main(argv: list[str]) -> int:
     from gemini_comm import GeminiCommunicator
     from i18n import t
 
+    def save_pending_state(state: dict) -> None:
+        session_file = Path.cwd() / ".gemini-session"
+        if not session_file.exists():
+            return
+        try:
+            with session_file.open("r", encoding="utf-8") as handle:
+                data = json.load(handle)
+            data["pending_state"] = {
+                "session_path": str(state.get("session_path")) if state.get("session_path") else None,
+                "msg_count": int(state.get("msg_count", 0) or 0),
+                "mtime": float(state.get("mtime", 0.0) or 0.0),
+                "mtime_ns": int(state.get("mtime_ns", 0) or 0),
+                "size": int(state.get("size", 0) or 0),
+                "last_gemini_id": state.get("last_gemini_id"),
+                "last_gemini_hash": state.get("last_gemini_hash"),
+            }
+            tmp_file = session_file.with_suffix(".tmp")
+            with tmp_file.open("w", encoding="utf-8") as handle:
+                json.dump(data, handle, ensure_ascii=False, indent=2)
+            os.replace(tmp_file, session_file)
+        except Exception:
+            return
+
     try:
         comm = GeminiCommunicator(lazy_init=True)
 
@@ -41,12 +65,14 @@ def main(argv: list[str]) -> int:
 
         # Send message
         print(f"🔔 {t('sending_to', provider='Gemini')}", flush=True)
-        state = comm.log_reader.capture_state()
-        comm._send_via_terminal(message)
+        marker, state = comm._send_message(message)
+        comm._remember_gemini_session(state.get("session_path") or comm.log_reader.current_session_path())
 
         # Pure sync wait (default 1 hour, configurable via CCB_SYNC_TIMEOUT)
         sync_timeout = float(os.environ.get("CCB_SYNC_TIMEOUT", "3600.0"))
-        message_reply, _ = comm.log_reader.wait_for_message(state, sync_timeout)
+        message_reply, new_state = comm.log_reader.wait_for_message(state, sync_timeout)
+        state = new_state or state
+        comm._remember_gemini_session(state.get("session_path") or comm.log_reader.current_session_path())
 
         # Save to cache
         cache_dir = Path.home() / ".cache" / "ccb"
@@ -59,8 +85,16 @@ def main(argv: list[str]) -> int:
             reply_file.write_text(message_reply, encoding="utf-8")
         else:
             print(f"⏰ Timeout after {int(sync_timeout)}s")
+            save_pending_state(state)
         return 0
 
+    except KeyboardInterrupt:
+        try:
+            save_pending_state(locals().get("state", {}) if isinstance(locals().get("state"), dict) else {})
+        except Exception:
+            pass
+        print("❌ Interrupted", file=sys.stderr)
+        return 130
     except Exception as exc:
         print(f"❌ {exc}", file=sys.stderr)
         return 1

--- a/bin/gask-w
+++ b/bin/gask-w
@@ -11,10 +11,6 @@ from pathlib import Path
 script_dir = Path(__file__).resolve().parent
 lib_dir = script_dir.parent / "lib"
 sys.path.insert(0, str(lib_dir))
-from compat import setup_windows_encoding
-setup_windows_encoding()
-
-from gemini_comm import GeminiCommunicator
 
 
 def main(argv: list[str]) -> int:
@@ -30,8 +26,15 @@ def main(argv: list[str]) -> int:
     # Early startup signal for background mode detection
     print("🚀 gask-w started", flush=True)
 
+    # Lazy imports after startup signal
+    if sys.platform == "win32":
+        from compat import setup_windows_encoding
+        setup_windows_encoding()
+
+    from gemini_comm import GeminiCommunicator
+
     try:
-        comm = GeminiCommunicator()
+        comm = GeminiCommunicator(lazy_init=True)
         reply = comm.ask_sync(message, timeout=0)
         return 0 if reply else 1
 

--- a/bin/gask-w
+++ b/bin/gask-w
@@ -27,6 +27,9 @@ def main(argv: list[str]) -> int:
         print("❌ Message cannot be empty", file=sys.stderr)
         return 1
 
+    # Early startup signal for background mode detection
+    print("🚀 gask-w started", flush=True)
+
     try:
         comm = GeminiCommunicator()
         reply = comm.ask_sync(message, timeout=0)

--- a/bin/gask-w
+++ b/bin/gask-w
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-gask-w - 同步发送消息到 Gemini 并等待回复
+gask-w - Sync send message to Gemini and wait for reply
 """
 
 from __future__ import annotations
@@ -19,12 +19,12 @@ from gemini_comm import GeminiCommunicator
 
 def main(argv: list[str]) -> int:
     if len(argv) <= 1:
-        print("用法: gask-w <消息>", file=sys.stderr)
+        print("Usage: gask-w <message>", file=sys.stderr)
         return 1
 
     message = " ".join(argv[1:]).strip()
     if not message:
-        print("❌ 消息内容不能为空", file=sys.stderr)
+        print("❌ Message cannot be empty", file=sys.stderr)
         return 1
 
     try:

--- a/bin/gask-w
+++ b/bin/gask-w
@@ -2,9 +2,7 @@
 """
 gask-w - Sync send message to Gemini and wait for reply
 """
-
 from __future__ import annotations
-
 import sys
 from pathlib import Path
 
@@ -35,13 +33,13 @@ def main(argv: list[str]) -> int:
 
     try:
         comm = GeminiCommunicator(lazy_init=True)
-        reply = comm.ask_sync(message, timeout=0)
+        reply = comm.ask_sync(message)
         return 0 if reply else 1
 
     except Exception as exc:
-        print(f"❌ {exc}", file=sys.stderr)
+        print(exc, file=sys.stderr)
         return 1
 
 
 if __name__ == "__main__":
-    sys.exit(main(sys.argv))
+    raise SystemExit(main(sys.argv))

--- a/bin/gask-w
+++ b/bin/gask-w
@@ -11,6 +11,8 @@ from pathlib import Path
 script_dir = Path(__file__).resolve().parent
 lib_dir = script_dir.parent / "lib"
 sys.path.insert(0, str(lib_dir))
+from compat import setup_windows_encoding
+setup_windows_encoding()
 
 from gemini_comm import GeminiCommunicator
 

--- a/bin/gask-w
+++ b/bin/gask-w
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """
-gask-w - Send message to Gemini and wait for reply in background
+gask-w - Send message to Gemini and wait for reply (pure sync mode)
+Designed to be run with Claude Code's run_in_background=true
 """
 from __future__ import annotations
 import os
@@ -27,6 +28,7 @@ def main(argv: list[str]) -> int:
         setup_windows_encoding()
 
     from gemini_comm import GeminiCommunicator
+    from i18n import t
 
     try:
         comm = GeminiCommunicator(lazy_init=True)
@@ -38,53 +40,29 @@ def main(argv: list[str]) -> int:
             return 1
 
         # Send message
-        from i18n import t
         print(f"🔔 {t('sending_to', provider='Gemini')}", flush=True)
-        comm._send_via_terminal(message)
         state = comm.log_reader.capture_state()
-        print("✅ Message sent, waiting for reply in background...", flush=True)
+        comm._send_via_terminal(message)
 
-        # Double fork to fully detach background process
-        if hasattr(os, 'fork'):
-            pid = os.fork()
-            if pid > 0:
-                # Parent: return immediately
-                return 0
-            # First child: fork again and exit
-            os.setsid()
-            pid2 = os.fork()
-            if pid2 > 0:
-                os._exit(0)  # First child exits
-            # Grandchild: wait for reply silently
-            try:
-                sys.stdin.close()
-                sys.stdout = open(os.devnull, 'w')
-                sys.stderr = open(os.devnull, 'w')
+        # Pure sync wait (default 1 hour, configurable via CCB_SYNC_TIMEOUT)
+        sync_timeout = float(os.environ.get("CCB_SYNC_TIMEOUT", "3600.0"))
+        message_reply, _ = comm.log_reader.wait_for_message(state, sync_timeout)
 
-                # Wait for reply (up to 5 minutes)
-                message_reply, new_state = comm.log_reader.wait_for_message(state, 300.0)
+        # Save to cache
+        cache_dir = Path.home() / ".cache" / "ccb"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        reply_file = cache_dir / "gemini_last_reply.txt"
 
-                # Save reply to cache file for gpend to read
-                if message_reply:
-                    cache_dir = Path.home() / ".cache" / "ccb"
-                    cache_dir.mkdir(parents=True, exist_ok=True)
-                    reply_file = cache_dir / "gemini_last_reply.txt"
-                    reply_file.write_text(message_reply, encoding="utf-8")
-            except Exception:
-                pass
-            os._exit(0)
+        if message_reply:
+            print(f"🤖 {t('reply_from', provider='Gemini')}")
+            print(message_reply)
+            reply_file.write_text(message_reply, encoding="utf-8")
         else:
-            # Windows: no fork, wait synchronously with short timeout
-            message_reply, new_state = comm.log_reader.wait_for_message(state, 30.0)
-            if message_reply:
-                print(f"🤖 {t('reply_from', provider='Gemini')}")
-                print(message_reply)
-            else:
-                print("⏰ Timeout waiting for reply")
-            return 0
+            print(f"⏰ Timeout after {int(sync_timeout)}s")
+        return 0
 
     except Exception as exc:
-        print(exc, file=sys.stderr)
+        print(f"❌ {exc}", file=sys.stderr)
         return 1
 
 

--- a/bin/gask-w
+++ b/bin/gask-w
@@ -34,7 +34,7 @@ def main(argv: list[str]) -> int:
         if not session_file.exists():
             return
         try:
-            with session_file.open("r", encoding="utf-8") as handle:
+            with session_file.open("r", encoding="utf-8-sig") as handle:
                 data = json.load(handle)
             data["pending_state"] = {
                 "session_path": str(state.get("session_path")) if state.get("session_path") else None,

--- a/bin/gask-w
+++ b/bin/gask-w
@@ -54,6 +54,17 @@ def main(argv: list[str]) -> int:
         except Exception:
             return
 
+    # Save to cache
+    cache_dir = Path.home() / ".cache" / "ccb"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    reply_file = cache_dir / "gemini_last_reply.txt"
+    # Clear stale cache
+    if reply_file.exists():
+        try:
+            reply_file.unlink()
+        except Exception:
+            pass
+
     try:
         comm = GeminiCommunicator(lazy_init=True)
 

--- a/bin/gask-w
+++ b/bin/gask-w
@@ -44,23 +44,19 @@ def main(argv: list[str]) -> int:
         state = comm.log_reader.capture_state()
         print("✅ Message sent, waiting for reply in background...", flush=True)
 
-        # Fork background process to wait for reply
-        pid = os.fork() if hasattr(os, 'fork') else None
-
-        if pid is None:
-            # Windows: no fork, wait synchronously with short timeout
-            message_reply, new_state = comm.log_reader.wait_for_message(state, 30.0)
-            if message_reply:
-                print(f"🤖 {t('reply_from', provider='Gemini')}")
-                print(message_reply)
-            else:
-                print("⏰ Timeout waiting for reply")
-            return 0
-        elif pid == 0:
-            # Child process: wait for reply silently
+        # Double fork to fully detach background process
+        if hasattr(os, 'fork'):
+            pid = os.fork()
+            if pid > 0:
+                # Parent: return immediately
+                return 0
+            # First child: fork again and exit
+            os.setsid()
+            pid2 = os.fork()
+            if pid2 > 0:
+                os._exit(0)  # First child exits
+            # Grandchild: wait for reply silently
             try:
-                # Detach from terminal
-                os.setsid()
                 sys.stdin.close()
                 sys.stdout = open(os.devnull, 'w')
                 sys.stderr = open(os.devnull, 'w')
@@ -78,7 +74,13 @@ def main(argv: list[str]) -> int:
                 pass
             os._exit(0)
         else:
-            # Parent process: return immediately
+            # Windows: no fork, wait synchronously with short timeout
+            message_reply, new_state = comm.log_reader.wait_for_message(state, 30.0)
+            if message_reply:
+                print(f"🤖 {t('reply_from', provider='Gemini')}")
+                print(message_reply)
+            else:
+                print("⏰ Timeout waiting for reply")
             return 0
 
     except Exception as exc:

--- a/bin/gask-w
+++ b/bin/gask-w
@@ -12,6 +12,8 @@ import json
 script_dir = Path(__file__).resolve().parent
 lib_dir = script_dir.parent / "lib"
 sys.path.insert(0, str(lib_dir))
+from compat import setup_windows_encoding
+setup_windows_encoding()
 
 
 def main(argv: list[str]) -> int:
@@ -23,10 +25,6 @@ def main(argv: list[str]) -> int:
     if not message:
         print("❌ Message cannot be empty", file=sys.stderr)
         return 1
-
-    if sys.platform == "win32":
-        from compat import setup_windows_encoding
-        setup_windows_encoding()
 
     from gemini_comm import GeminiCommunicator
     from i18n import t

--- a/bin/gpend
+++ b/bin/gpend
@@ -21,8 +21,30 @@ except ImportError as exc:
     sys.exit(1)
 
 
+def _load_cached_reply() -> str | None:
+    """Load cached reply from background gask-w process"""
+    cache_file = Path.home() / ".cache" / "ccb" / "gemini_last_reply.txt"
+    if not cache_file.exists():
+        return None
+    try:
+        content = cache_file.read_text(encoding="utf-8").strip()
+        if content:
+            cache_file.unlink()  # Clear after reading
+            return content
+    except Exception:
+        pass
+    return None
+
+
 def main() -> int:
     try:
+        # First check cached reply from background gask-w
+        cached = _load_cached_reply()
+        if cached:
+            print(f"🤖 Gemini reply:")
+            print(cached)
+            return 0
+
         comm = GeminiCommunicator()
         output = comm.consume_pending(display=False)
         if output:

--- a/bin/gpend
+++ b/bin/gpend
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-gpend - 查看 Gemini 最新回复
+gpend - View latest Gemini reply
 """
 
 import sys
@@ -15,7 +15,7 @@ setup_windows_encoding()
 try:
     from gemini_comm import GeminiCommunicator
 except ImportError as exc:
-    print(f"导入失败: {exc}")
+    print(f"Import failed: {exc}")
     sys.exit(1)
 
 
@@ -26,10 +26,10 @@ def main() -> int:
         if output:
             print(output)
         else:
-            print('暂无 Gemini 回复')
+            print('No Gemini reply available')
         return 0
     except Exception as exc:
-        print(f"❌ 执行失败: {exc}")
+        print(f"❌ Execution failed: {exc}")
         return 1
 
 

--- a/bin/gpend
+++ b/bin/gpend
@@ -12,6 +12,8 @@ sys.path.insert(0, str(lib_dir))
 from compat import setup_windows_encoding
 setup_windows_encoding()
 
+from i18n import t
+
 try:
     from gemini_comm import GeminiCommunicator
 except ImportError as exc:
@@ -26,10 +28,10 @@ def main() -> int:
         if output:
             print(output)
         else:
-            print('No Gemini reply available')
+            print(t('no_reply_available', provider='Gemini'))
         return 0
     except Exception as exc:
-        print(f"❌ Execution failed: {exc}")
+        print(f"❌ {t('execution_failed', error=exc)}")
         return 1
 
 

--- a/bin/gpend
+++ b/bin/gpend
@@ -9,6 +9,8 @@ from pathlib import Path
 script_dir = Path(__file__).resolve().parent
 lib_dir = script_dir.parent / "lib"
 sys.path.insert(0, str(lib_dir))
+from compat import setup_windows_encoding
+setup_windows_encoding()
 
 try:
     from gemini_comm import GeminiCommunicator

--- a/bin/gping
+++ b/bin/gping
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-gping - 测试 Gemini 连通性
+gping - Test Gemini connectivity
 """
 
 import sys
@@ -22,12 +22,12 @@ try:
             print(message)
             return 0 if healthy else 1
         except Exception as e:
-            print(f"❌ Gemini 连通性测试失败: {e}")
+            print(f"❌ Gemini connectivity test failed: {e}")
             return 1
 
     if __name__ == "__main__":
         sys.exit(main())
 
 except ImportError as e:
-    print(f"❌ 导入模块失败: {e}")
+    print(f"❌ Module import failed: {e}")
     sys.exit(1)

--- a/bin/gping
+++ b/bin/gping
@@ -9,6 +9,8 @@ from pathlib import Path
 script_dir = Path(__file__).resolve().parent
 lib_dir = script_dir.parent / "lib"
 sys.path.insert(0, str(lib_dir))
+from compat import setup_windows_encoding
+setup_windows_encoding()
 
 try:
     from gemini_comm import GeminiCommunicator

--- a/ccb
+++ b/ccb
@@ -26,6 +26,7 @@ sys.path.insert(0, str(script_dir / "lib"))
 from terminal import TmuxBackend, WeztermBackend, Iterm2Backend, detect_terminal, is_wsl, get_shell_type
 from compat import setup_windows_encoding
 from ccb_config import get_backend_env
+from session_utils import safe_write_session, check_session_writable
 
 setup_windows_encoding()
 
@@ -537,6 +538,14 @@ exec tmux attach -t "$TMUX_SESSION"
 
     def _write_codex_session(self, runtime, tmux_session, input_fifo, output_fifo, pane_id=None):
         session_file = Path.cwd() / ".codex-session"
+
+        # 预检查权限
+        writable, reason, fix = check_session_writable(session_file)
+        if not writable:
+            print(f"❌ 无法写入 {session_file.name}: {reason}", file=sys.stderr)
+            print(f"💡 解决方案: {fix}", file=sys.stderr)
+            return False
+
         data = {}
         if session_file.exists():
             try:
@@ -557,10 +566,23 @@ exec tmux attach -t "$TMUX_SESSION"
             "active": True,
             "started_at": time.strftime("%Y-%m-%d %H:%M:%S"),
         })
-        session_file.write_text(json.dumps(data, ensure_ascii=False, indent=2))
+
+        ok, err = safe_write_session(session_file, json.dumps(data, ensure_ascii=False, indent=2))
+        if not ok:
+            print(err, file=sys.stderr)
+            return False
+        return True
 
     def _write_gemini_session(self, runtime, tmux_session, pane_id=None):
         session_file = Path.cwd() / ".gemini-session"
+
+        # 预检查权限
+        writable, reason, fix = check_session_writable(session_file)
+        if not writable:
+            print(f"❌ 无法写入 {session_file.name}: {reason}", file=sys.stderr)
+            print(f"💡 解决方案: {fix}", file=sys.stderr)
+            return False
+
         data = {
             "session_id": self.session_id,
             "runtime_dir": str(runtime),
@@ -571,7 +593,12 @@ exec tmux attach -t "$TMUX_SESSION"
             "active": True,
             "started_at": time.strftime("%Y-%m-%d %H:%M:%S"),
         }
-        session_file.write_text(json.dumps(data, ensure_ascii=False, indent=2))
+
+        ok, err = safe_write_session(session_file, json.dumps(data, ensure_ascii=False, indent=2))
+        if not ok:
+            print(err, file=sys.stderr)
+            return False
+        return True
 
     def _claude_project_dir(self, work_dir: Path) -> Path:
         projects_root = Path.home() / ".claude" / "projects"

--- a/ccb
+++ b/ccb
@@ -1086,9 +1086,52 @@ def cmd_update(args):
             print(f"⚠️ Git pull failed: {result.stderr.strip()}")
             print("Falling back to tarball download...")
 
+    def _pick_temp_base_dir() -> Path:
+        candidates: list[Path] = []
+        for key in ("CCB_TMPDIR", "TMPDIR", "TEMP", "TMP"):
+            value = (os.environ.get(key) or "").strip()
+            if value:
+                candidates.append(Path(value).expanduser())
+        try:
+            candidates.append(Path(tempfile.gettempdir()))
+        except Exception:
+            pass
+        candidates.extend(
+            [
+                Path("/tmp"),
+                Path("/var/tmp"),
+                Path("/usr/tmp"),
+                Path.home() / ".cache" / "ccb" / "tmp",
+                install_dir / ".tmp",
+                Path.cwd() / ".tmp",
+            ]
+        )
+
+        for base in candidates:
+            try:
+                base.mkdir(parents=True, exist_ok=True)
+                probe = base / f".ccb_tmp_probe_{os.getpid()}_{int(time.time() * 1000)}"
+                probe.write_bytes(b"1")
+                probe.unlink(missing_ok=True)
+                return base
+            except Exception:
+                continue
+
+        raise RuntimeError(
+            "❌ No usable temporary directory found.\n"
+            "Fix options:\n"
+            "  - Create /tmp (Linux/WSL): sudo mkdir -p /tmp && sudo chmod 1777 /tmp\n"
+            "  - Or set TMPDIR/CCB_TMPDIR to a writable path (e.g. export TMPDIR=$HOME/.cache/tmp)"
+        )
+
     # Method 2: Download tarball
     tarball_url = f"{repo_url}/archive/refs/heads/main.tar.gz"
-    tmp_dir = Path(tempfile.gettempdir()) / "ccb_update"
+    try:
+        tmp_base = _pick_temp_base_dir()
+    except Exception as exc:
+        print(str(exc))
+        return 1
+    tmp_dir = tmp_base / "ccb_update"
 
     try:
         print(f"📥 Downloading latest version...")

--- a/ccb
+++ b/ccb
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """
-ccb (Claude Code Bridge) - 统一 AI 启动器
-支持 Claude + Codex / Claude + Gemini / 三者同时
-支持 tmux、WezTerm 和 iTerm2 终端
+ccb (Claude Code Bridge) - Unified AI Launcher
+Supports Claude + Codex / Claude + Gemini / all three simultaneously
+Supports tmux, WezTerm and iTerm2 terminals
 """
 
 import sys
@@ -87,32 +87,32 @@ class AILauncher:
         self.processes = {}
 
     def _detect_terminal_type(self):
-        # 环境变量强制指定
+        # Forced by environment variable
         forced = (os.environ.get("CCB_TERMINAL") or os.environ.get("CODEX_TERMINAL") or "").strip().lower()
         if forced in {"wezterm", "tmux"}:
             return forced
 
-        # 在 WezTerm pane 内时，强制使用 wezterm，完全不依赖 tmux
+        # When inside WezTerm pane, force wezterm, no tmux dependency
         if os.environ.get("WEZTERM_PANE"):
             return "wezterm"
-        # 只有在 iTerm2 环境中才用 iTerm2 分屏
+        # Only use iTerm2 split when in iTerm2 environment
         if os.environ.get("ITERM_SESSION_ID"):
             return "iterm2"
 
-        # 使用 detect_terminal() 自动检测（WezTerm 优先）
+        # Use detect_terminal() for auto-detection (WezTerm preferred)
         detected = detect_terminal()
         if detected:
             return detected
 
-        # 兜底：如果都没有，返回 None 让后续逻辑处理
+        # Fallback: if nothing found, return None for later handling
         return None
 
     def _detect_launch_terminal(self):
-        """选择用于启动新窗口的终端程序（仅 tmux 模式下使用）"""
-        # WezTerm 模式不需要外部终端程序
+        """Select terminal program for launching new windows (tmux mode only)"""
+        # WezTerm mode doesn't need external terminal program
         if self.terminal_type == "wezterm":
             return None
-        # tmux 模式下选择终端
+        # tmux mode: select terminal
         terminals = ["gnome-terminal", "konsole", "alacritty", "xterm"]
         for term in terminals:
             if shutil.which(term):
@@ -120,7 +120,7 @@ class AILauncher:
         return "tmux"
 
     def _launch_script_in_macos_terminal(self, script_file: Path) -> bool:
-        """macOS: 使用 Terminal.app 打开新窗口执行脚本（避免 tmux launcher 嵌套导致交互失败）"""
+        """macOS: Use Terminal.app to open new window for script (avoid tmux launcher nesting issues)"""
         if platform.system() != "Darwin":
             return False
         if not shutil.which("osascript"):
@@ -140,35 +140,35 @@ class AILauncher:
         return True
 
     def _start_provider(self, provider: str) -> bool:
-        # 处理未检测到终端的情况
+        # Handle case when no terminal detected
         if self.terminal_type is None:
-            print("❌ 未检测到可用的终端后端（WezTerm 或 tmux）")
-            print("   解决方案:")
-            print("   - 安装 WezTerm（推荐）: https://wezfurlong.org/wezterm/")
-            print("   - 或安装 tmux")
-            print("   - 或设置环境变量 CCB_TERMINAL=wezterm 并配置 CODEX_WEZTERM_BIN")
+            print("❌ No terminal backend detected (WezTerm or tmux)")
+            print("   Solutions:")
+            print("   - Install WezTerm (recommended): https://wezfurlong.org/wezterm/")
+            print("   - Or install tmux")
+            print("   - Or set CCB_TERMINAL=wezterm and configure CODEX_WEZTERM_BIN")
             return False
 
-        # WezTerm 模式：完全不依赖 tmux
+        # WezTerm mode: no tmux dependency
         if self.terminal_type == "wezterm":
-            print(f"🚀 启动 {provider.capitalize()} 后端 (wezterm)...")
+            print(f"🚀 Starting {provider.capitalize()} backend (wezterm)...")
             return self._start_provider_wezterm(provider)
         elif self.terminal_type == "iterm2":
             return self._start_provider_iterm2(provider)
 
-        # tmux 模式：检查 tmux 是否可用
+        # tmux mode: check if tmux is available
         if not shutil.which("tmux"):
-            # 尝试 fallback 到 WezTerm
+            # Try fallback to WezTerm
             if detect_terminal() == "wezterm":
                 self.terminal_type = "wezterm"
-                print(f"🚀 启动 {provider.capitalize()} 后端 (wezterm - tmux 不可用)...")
+                print(f"🚀 Starting {provider.capitalize()} backend (wezterm - tmux unavailable)...")
                 return self._start_provider_wezterm(provider)
             else:
-                print("❌ tmux 未安装，且 WezTerm 不可用")
-                print("   解决方案: 安装 WezTerm（推荐）或 tmux")
+                print("❌ tmux not installed and WezTerm unavailable")
+                print("   Solution: Install WezTerm (recommended) or tmux")
                 return False
 
-        print(f"🚀 启动 {provider.capitalize()} 后端 (tmux)...")
+        print(f"🚀 Starting {provider.capitalize()} backend (tmux)...")
 
         tmux_session = f"{provider}-{int(time.time()) % 100000}-{os.getpid()}"
         self.tmux_sessions[provider] = tmux_session
@@ -178,7 +178,7 @@ class AILauncher:
         elif provider == "gemini":
             return self._start_gemini(tmux_session)
         else:
-            print(f"❌ 未知的 provider: {provider}")
+            print(f"❌ Unknown provider: {provider}")
             return False
 
     def _start_provider_wezterm(self, provider: str) -> bool:
@@ -206,12 +206,12 @@ class AILauncher:
         if provider == "codex":
             input_fifo = runtime / "input.fifo"
             output_fifo = runtime / "output.fifo"
-            # WezTerm 模式通过 pane 注入文本，不强依赖 FIFO；Windows/WSL 场景也不一定支持 mkfifo。
+            # WezTerm mode injects text via pane, no strong FIFO dependency; Windows/WSL may not support mkfifo
             self._write_codex_session(runtime, None, input_fifo, output_fifo, pane_id=pane_id)
         else:
             self._write_gemini_session(runtime, None, pane_id=pane_id)
 
-        print(f"✅ {provider.capitalize()} 已启动 (wezterm pane: {pane_id})")
+        print(f"✅ {provider.capitalize()} started (wezterm pane: {pane_id})")
         return True
 
     def _start_provider_iterm2(self, provider: str) -> bool:
@@ -219,7 +219,7 @@ class AILauncher:
         runtime.mkdir(parents=True, exist_ok=True)
 
         start_cmd = self._get_start_cmd(provider)
-        # iTerm2 分屏里，进程退出会导致 pane 直接关闭；默认保持 pane 打开便于查看退出信息。
+        # In iTerm2 split, process exit will close pane; keep pane open by default to view exit info
         keep_open = os.environ.get("CODEX_ITERM2_KEEP_OPEN", "1").lower() not in {"0", "false", "no", "off"}
         if keep_open:
             start_cmd = (
@@ -245,12 +245,12 @@ class AILauncher:
         if provider == "codex":
             input_fifo = runtime / "input.fifo"
             output_fifo = runtime / "output.fifo"
-            # iTerm2 模式通过 pane 注入文本，不强依赖 FIFO
+            # iTerm2 mode injects text via pane, no strong FIFO dependency
             self._write_codex_session(runtime, None, input_fifo, output_fifo, pane_id=pane_id)
         else:
             self._write_gemini_session(runtime, None, pane_id=pane_id)
 
-        print(f"✅ {provider.capitalize()} 已启动 (iterm2 session: {pane_id})")
+        print(f"✅ {provider.capitalize()} started (iterm2 session: {pane_id})")
         return True
 
     def _work_dir_strings(self, work_dir: Path) -> list[str]:
@@ -414,8 +414,8 @@ class AILauncher:
 
     def _get_start_cmd(self, provider: str) -> str:
         if provider == "codex":
-            # NOTE: Codex TUI 有 paste-burst 检测；终端注入（wezterm send-text/tmux paste-buffer）
-            # 往往会被识别为“粘贴”，导致回车仅换行不提交。默认关闭该检测，保证自动通信可用。
+            # NOTE: Codex TUI has paste-burst detection; terminal injection (wezterm send-text/tmux paste-buffer)
+            # is often detected as "paste", causing Enter to only line-break not submit. Disable detection by default.
             return self._build_codex_start_cmd()
         elif provider == "gemini":
             return self._build_gemini_start_cmd()
@@ -487,7 +487,7 @@ exec tmux attach -t "$TMUX_SESSION"
         else:
             subprocess.Popen([terminal, "-e", str(script_file)])
 
-        print(f"✅ Codex 已启动 (tmux: {tmux_session})")
+        print(f"✅ Codex started (tmux: {tmux_session})")
         return True
 
     def _start_gemini(self, tmux_session: str) -> bool:
@@ -500,7 +500,7 @@ exec tmux attach -t "$TMUX_SESSION"
 
         self._write_gemini_session(runtime, tmux_session)
 
-        # 创建启动脚本
+        # Create startup script
         wrapper = f'''#!/bin/bash
 	cd "{os.getcwd()}"
 	tmux new-session -d -s "{tmux_session}" 2>/dev/null || true
@@ -515,7 +515,7 @@ exec tmux attach -t "$TMUX_SESSION"
             if self._launch_script_in_macos_terminal(script_file):
                 pass
             else:
-                # 纯 tmux 模式
+                # Pure tmux mode
                 subprocess.run(["tmux", "new-session", "-d", "-s", tmux_session], check=True, cwd=os.getcwd())
                 backend = TmuxBackend()
                 deadline = time.time() + 1.0
@@ -530,20 +530,20 @@ exec tmux attach -t "$TMUX_SESSION"
                         time.sleep(sleep_s)
                         sleep_s = min(0.2, sleep_s * 2)
         else:
-            # 打开新终端窗口
+            # Open new terminal window
             subprocess.Popen([terminal, "--", str(script_file)])
 
-        print(f"✅ Gemini 已启动 (tmux: {tmux_session})")
+        print(f"✅ Gemini started (tmux: {tmux_session})")
         return True
 
     def _write_codex_session(self, runtime, tmux_session, input_fifo, output_fifo, pane_id=None):
         session_file = Path.cwd() / ".codex-session"
 
-        # 预检查权限
+        # Pre-check permissions
         writable, reason, fix = check_session_writable(session_file)
         if not writable:
-            print(f"❌ 无法写入 {session_file.name}: {reason}", file=sys.stderr)
-            print(f"💡 解决方案: {fix}", file=sys.stderr)
+            print(f"❌ Cannot write {session_file.name}: {reason}", file=sys.stderr)
+            print(f"💡 Fix: {fix}", file=sys.stderr)
             return False
 
         data = {}
@@ -576,11 +576,11 @@ exec tmux attach -t "$TMUX_SESSION"
     def _write_gemini_session(self, runtime, tmux_session, pane_id=None):
         session_file = Path.cwd() / ".gemini-session"
 
-        # 预检查权限
+        # Pre-check permissions
         writable, reason, fix = check_session_writable(session_file)
         if not writable:
-            print(f"❌ 无法写入 {session_file.name}: {reason}", file=sys.stderr)
-            print(f"💡 解决方案: {fix}", file=sys.stderr)
+            print(f"❌ Cannot write {session_file.name}: {reason}", file=sys.stderr)
+            print(f"💡 Fix: {fix}", file=sys.stderr)
             return False
 
         data = {
@@ -689,7 +689,7 @@ exec tmux attach -t "$TMUX_SESSION"
         )
 
     def _start_claude(self) -> int:
-        print("🚀 启动 Claude...")
+        print("🚀 Starting Claude...")
 
         env = os.environ.copy()
         if "codex" in self.providers:
@@ -744,29 +744,29 @@ exec tmux attach -t "$TMUX_SESSION"
             cmd.extend(["--session-id", new_id])
             self._write_local_claude_session(new_id, active=True)
 
-        print(f"📋 会话ID: {self.session_id}")
-        print(f"📁 运行目录: {self.runtime_dir}")
-        print(f"🔌 活跃后端: {', '.join(self.providers)}")
+        print(f"📋 Session ID: {self.session_id}")
+        print(f"📁 Runtime dir: {self.runtime_dir}")
+        print(f"🔌 Active backends: {', '.join(self.providers)}")
         print()
-        print("🎯 可用命令:")
+        print("🎯 Available commands:")
         if "codex" in self.providers:
-            print("   cask/cask-w/cping/cpend - Codex 通信")
+            print("   cask/cask-w/cping/cpend - Codex communication")
         if "gemini" in self.providers:
-            print("   gask/gask-w/gping/gpend - Gemini 通信")
+            print("   gask/gask-w/gping/gpend - Gemini communication")
         print()
-        print(f"执行: {' '.join(cmd)}")
+        print(f"Executing: {' '.join(cmd)}")
 
         try:
             return subprocess.run(cmd, stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr, env=env).returncode
         except KeyboardInterrupt:
-            print("\n⚠️ 用户中断")
+            print("\n⚠️ User interrupted")
             return 130
 
     def cleanup(self):
         if self._cleaned:
             return
         self._cleaned = True
-        print("\n🧹 清理会话资源...")
+        print("\n🧹 Cleaning up session resources...")
 
         if self.terminal_type == "wezterm":
             backend = WeztermBackend()
@@ -797,14 +797,14 @@ exec tmux attach -t "$TMUX_SESSION"
         if self.runtime_dir.exists():
             shutil.rmtree(self.runtime_dir, ignore_errors=True)
 
-        print("✅ 清理完成")
+        print("✅ Cleanup complete")
 
     def run_up(self) -> int:
         git_info = _get_git_info()
         version_str = f"v{VERSION}" + (f" ({git_info})" if git_info else "")
         print(f"🚀 Claude Code Bridge {version_str}")
         print(f"📅 {time.strftime('%Y-%m-%d %H:%M:%S')}")
-        print(f"🔌 后端: {', '.join(self.providers)}")
+        print(f"🔌 Backends: {', '.join(self.providers)}")
         print("=" * 50)
 
         atexit.register(self.cleanup)
@@ -823,7 +823,7 @@ exec tmux attach -t "$TMUX_SESSION"
             self._warmup_provider(provider)
 
         if self.no_claude:
-            print("✅ 后端已启动（--no-claude 模式）")
+            print("✅ Backends started (--no-claude mode)")
             print()
             for provider in self.providers:
                 if self.terminal_type == "wezterm":
@@ -839,7 +839,7 @@ exec tmux attach -t "$TMUX_SESSION"
                     if tmux:
                         print(f"   {provider}: tmux attach -t {tmux}")
             print()
-            print(f"终止: ccb kill {' '.join(self.providers)}")
+            print(f"Kill: ccb kill {' '.join(self.providers)}")
             atexit.unregister(self.cleanup)
             return 0
 
@@ -866,7 +866,7 @@ def cmd_status(args):
     for provider in providers:
         session_file = Path.cwd() / f".{provider}-session"
         if not session_file.exists():
-            results[provider] = {"status": "未配置", "active": False}
+            results[provider] = {"status": "Not configured", "active": False}
             continue
 
         try:
@@ -888,16 +888,16 @@ def cmd_status(args):
                 alive = False
 
             results[provider] = {
-                "status": "运行中" if (active and alive) else "已停止",
+                "status": "Running" if (active and alive) else "Stopped",
                 "active": active and alive,
                 "terminal": terminal,
                 "pane_id": pane_id,
                 "runtime_dir": data.get("runtime_dir", ""),
             }
         except Exception as e:
-            results[provider] = {"status": f"错误: {e}", "active": False}
+            results[provider] = {"status": f"Error: {e}", "active": False}
 
-    print("📊 AI 后端状态:")
+    print("📊 AI backend status:")
     for provider, info in results.items():
         icon = "✅" if info.get("active") else "❌"
         print(f"  {icon} {provider.capitalize()}: {info['status']}")
@@ -913,7 +913,7 @@ def cmd_kill(args):
     for provider in providers:
         session_file = Path.cwd() / f".{provider}-session"
         if not session_file.exists():
-            print(f"⚠️ {provider}: 未找到会话文件")
+            print(f"⚠️ {provider}: Session file not found")
             continue
 
         try:
@@ -935,7 +935,7 @@ def cmd_kill(args):
             data["ended_at"] = time.strftime("%Y-%m-%d %H:%M:%S")
             session_file.write_text(json.dumps(data, ensure_ascii=False, indent=2))
 
-            print(f"✅ {provider.capitalize()} 已终止")
+            print(f"✅ {provider.capitalize()} terminated")
         except Exception as e:
             print(f"❌ {provider}: {e}")
 
@@ -948,7 +948,7 @@ def cmd_restore(args):
     for provider in providers:
         session_file = Path.cwd() / f".{provider}-session"
         if not session_file.exists():
-            print(f"⚠️ {provider}: 未找到会话文件")
+            print(f"⚠️ {provider}: Session file not found")
             continue
 
         try:
@@ -1037,14 +1037,14 @@ def cmd_restore(args):
                                 break
 
                 if has_history:
-                    print(f"ℹ️ {provider}: 会话已结束，但可恢复历史会话")
+                    print(f"ℹ️ {provider}: Session ended but history recoverable")
                     if session_id:
-                        print(f"   会话ID: {session_id[:8]}...")
-                    print(f"   使用: ccb up {provider} -r")
+                        print(f"   Session ID: {session_id[:8]}...")
+                    print(f"   Use: ccb up {provider} -r")
                 else:
-                    print(f"⚠️ {provider}: 会话已结束，无可恢复历史")
+                    print(f"⚠️ {provider}: Session ended, no recoverable history")
             else:
-                print(f"⚠️ {provider}: 会话已丢失，使用 ccb up {provider} -r 重启")
+                print(f"⚠️ {provider}: Session lost, use ccb up {provider} -r to restart")
 
         except Exception as e:
             print(f"❌ {provider}: {e}")
@@ -1140,7 +1140,7 @@ def cmd_update(args):
         tmp_dir.mkdir(parents=True, exist_ok=True)
         tarball_path = tmp_dir / "main.tar.gz"
 
-        # 优先使用 curl/wget（更好的证书处理）
+        # Prefer curl/wget (better certificate handling)
         downloaded = False
         if shutil.which("curl"):
             result = subprocess.run(
@@ -1155,12 +1155,12 @@ def cmd_update(args):
             )
             downloaded = result.returncode == 0
         if not downloaded:
-            # 回退到 urllib（可能有 SSL 问题）
+            # Fallback to urllib (may have SSL issues)
             import ssl
             try:
                 urllib.request.urlretrieve(tarball_url, tarball_path)
             except ssl.SSLError:
-                print("⚠️ SSL 证书验证失败，尝试跳过验证...")
+                print("⚠️ SSL certificate verification failed, trying to skip...")
                 ctx = ssl.create_default_context()
                 ctx.check_hostname = False
                 ctx.verify_mode = ssl.CERT_NONE
@@ -1187,7 +1187,7 @@ def cmd_update(args):
         subprocess.run([str(extracted_dir / "install.sh"), "install"], check=True, env=env)
 
         print("✅ Update complete!")
-        print("💡 推荐：安装 WezTerm 作为终端前端（分屏/滚动体验更好），详情见 README。")
+        print("💡 Recommended: Install WezTerm as terminal frontend (better split/scroll experience), see README.")
         return 0
 
     except Exception as e:
@@ -1200,29 +1200,29 @@ def cmd_update(args):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Claude AI 统一启动器", add_help=True)
-    subparsers = parser.add_subparsers(dest="command", help="子命令")
+    parser = argparse.ArgumentParser(description="Claude AI unified launcher", add_help=True)
+    subparsers = parser.add_subparsers(dest="command", help="Subcommands")
 
-    # up 子命令
-    up_parser = subparsers.add_parser("up", help="启动 AI 后端")
-    up_parser.add_argument("providers", nargs="*", choices=["codex", "gemini"], help="要启动的后端")
-    up_parser.add_argument("-r", "--resume", action="store_true", help="恢复上下文")
-    up_parser.add_argument("-a", "--auto", action="store_true", help="全自动权限模式")
-    up_parser.add_argument("--no-claude", action="store_true", help="不启动 Claude 主窗口")
+    # up subcommand
+    up_parser = subparsers.add_parser("up", help="Start AI backends")
+    up_parser.add_argument("providers", nargs="*", choices=["codex", "gemini"], help="Backends to start")
+    up_parser.add_argument("-r", "--resume", action="store_true", help="Resume context")
+    up_parser.add_argument("-a", "--auto", action="store_true", help="Full auto permission mode")
+    up_parser.add_argument("--no-claude", action="store_true", help="Don't start Claude main window")
 
-    # status 子命令
-    status_parser = subparsers.add_parser("status", help="检查状态")
-    status_parser.add_argument("providers", nargs="*", default=[], help="要检查的后端 (codex/gemini)")
+    # status subcommand
+    status_parser = subparsers.add_parser("status", help="Check status")
+    status_parser.add_argument("providers", nargs="*", default=[], help="Backends to check (codex/gemini)")
 
-    # kill 子命令
-    kill_parser = subparsers.add_parser("kill", help="终止会话")
-    kill_parser.add_argument("providers", nargs="*", default=[], help="要终止的后端 (codex/gemini)")
+    # kill subcommand
+    kill_parser = subparsers.add_parser("kill", help="Terminate session")
+    kill_parser.add_argument("providers", nargs="*", default=[], help="Backends to terminate (codex/gemini)")
 
-    # restore 子命令
-    restore_parser = subparsers.add_parser("restore", help="恢复/attach 会话")
-    restore_parser.add_argument("providers", nargs="*", default=[], help="要恢复的后端 (codex/gemini)")
+    # restore subcommand
+    restore_parser = subparsers.add_parser("restore", help="Restore/attach session")
+    restore_parser.add_argument("providers", nargs="*", default=[], help="Backends to restore (codex/gemini)")
 
-    # update 子命令
+    # update subcommand
     update_parser = subparsers.add_parser("update", help="Update to latest version")
 
     args = parser.parse_args()

--- a/ccb
+++ b/ccb
@@ -27,6 +27,7 @@ from terminal import TmuxBackend, WeztermBackend, Iterm2Backend, detect_terminal
 from compat import setup_windows_encoding
 from ccb_config import get_backend_env
 from session_utils import safe_write_session, check_session_writable
+from i18n import t
 
 setup_windows_encoding()
 
@@ -142,16 +143,16 @@ class AILauncher:
     def _start_provider(self, provider: str) -> bool:
         # Handle case when no terminal detected
         if self.terminal_type is None:
-            print("❌ No terminal backend detected (WezTerm or tmux)")
-            print("   Solutions:")
-            print("   - Install WezTerm (recommended): https://wezfurlong.org/wezterm/")
-            print("   - Or install tmux")
-            print("   - Or set CCB_TERMINAL=wezterm and configure CODEX_WEZTERM_BIN")
+            print(f"❌ {t('no_terminal_backend')}")
+            print(f"   {t('solutions')}")
+            print(f"   - {t('install_wezterm')}")
+            print(f"   - {t('or_install_tmux')}")
+            print(f"   - {t('or_set_ccb_terminal')}")
             return False
 
         # WezTerm mode: no tmux dependency
         if self.terminal_type == "wezterm":
-            print(f"🚀 Starting {provider.capitalize()} backend (wezterm)...")
+            print(f"🚀 {t('starting_backend', provider=provider.capitalize(), terminal='wezterm')}")
             return self._start_provider_wezterm(provider)
         elif self.terminal_type == "iterm2":
             return self._start_provider_iterm2(provider)
@@ -161,14 +162,14 @@ class AILauncher:
             # Try fallback to WezTerm
             if detect_terminal() == "wezterm":
                 self.terminal_type = "wezterm"
-                print(f"🚀 Starting {provider.capitalize()} backend (wezterm - tmux unavailable)...")
+                print(f"🚀 {t('starting_backend', provider=provider.capitalize(), terminal='wezterm - tmux unavailable')}")
                 return self._start_provider_wezterm(provider)
             else:
-                print("❌ tmux not installed and WezTerm unavailable")
-                print("   Solution: Install WezTerm (recommended) or tmux")
+                print(f"❌ {t('tmux_not_installed')}")
+                print(f"   {t('install_wezterm_or_tmux')}")
                 return False
 
-        print(f"🚀 Starting {provider.capitalize()} backend (tmux)...")
+        print(f"🚀 {t('starting_backend', provider=provider.capitalize(), terminal='tmux')}")
 
         tmux_session = f"{provider}-{int(time.time()) % 100000}-{os.getpid()}"
         self.tmux_sessions[provider] = tmux_session
@@ -178,7 +179,7 @@ class AILauncher:
         elif provider == "gemini":
             return self._start_gemini(tmux_session)
         else:
-            print(f"❌ Unknown provider: {provider}")
+            print(f"❌ {t('unknown_provider', provider=provider)}")
             return False
 
     def _start_provider_wezterm(self, provider: str) -> bool:
@@ -211,7 +212,7 @@ class AILauncher:
         else:
             self._write_gemini_session(runtime, None, pane_id=pane_id)
 
-        print(f"✅ {provider.capitalize()} started (wezterm pane: {pane_id})")
+        print(f"✅ {t('started_backend', provider=provider.capitalize(), terminal='wezterm pane', pane_id=pane_id)}")
         return True
 
     def _start_provider_iterm2(self, provider: str) -> bool:
@@ -250,7 +251,7 @@ class AILauncher:
         else:
             self._write_gemini_session(runtime, None, pane_id=pane_id)
 
-        print(f"✅ {provider.capitalize()} started (iterm2 session: {pane_id})")
+        print(f"✅ {t('started_backend', provider=provider.capitalize(), terminal='iterm2 session', pane_id=pane_id)}")
         return True
 
     def _work_dir_strings(self, work_dir: Path) -> list[str]:
@@ -335,11 +336,11 @@ class AILauncher:
             session_id, has_history = self._get_latest_codex_session_id()
             if session_id:
                 cmd = f"{cmd} resume {session_id}"
-                print(f"🔁 Resuming Codex session: {session_id[:8]}...")
+                print(f"🔁 {t('resuming_session', provider='Codex', session_id=session_id[:8])}")
                 codex_resumed = True
 
             if not codex_resumed:
-                print("ℹ️ No Codex history found, starting fresh")
+                print(f"ℹ️ {t('no_history_fresh', provider='Codex')}")
         return cmd
 
     def _get_latest_gemini_project_hash(self) -> tuple[str | None, bool]:
@@ -371,9 +372,9 @@ class AILauncher:
             _, has_history = self._get_latest_gemini_project_hash()
             if has_history:
                 cmd = f"{cmd} --resume latest"
-                print("🔁 Resuming Gemini session...")
+                print(f"🔁 {t('resuming_session', provider='Gemini', session_id='')}")
             else:
-                print("ℹ️ No Gemini history found, starting fresh")
+                print(f"ℹ️ {t('no_history_fresh', provider='Gemini')}")
         return cmd
 
     def _warmup_provider(self, provider: str, timeout: float = 8.0) -> bool:
@@ -490,7 +491,7 @@ exec tmux attach -t "$TMUX_SESSION"
         else:
             subprocess.Popen([terminal, "-e", str(script_file)])
 
-        print(f"✅ Codex started (tmux: {tmux_session})")
+        print(f"✅ {t('started_backend', provider='Codex', terminal='tmux', pane_id=tmux_session)}")
         return True
 
     def _start_gemini(self, tmux_session: str) -> bool:
@@ -536,7 +537,7 @@ exec tmux attach -t "$TMUX_SESSION"
             # Open new terminal window
             subprocess.Popen([terminal, "--", str(script_file)])
 
-        print(f"✅ Gemini started (tmux: {tmux_session})")
+        print(f"✅ {t('started_backend', provider='Gemini', terminal='tmux', pane_id=tmux_session)}")
         return True
 
     def _write_codex_session(self, runtime, tmux_session, input_fifo, output_fifo, pane_id=None):
@@ -692,7 +693,7 @@ exec tmux attach -t "$TMUX_SESSION"
         )
 
     def _start_claude(self) -> int:
-        print("🚀 Starting Claude...")
+        print(f"🚀 {t('starting_claude')}")
 
         env = os.environ.copy()
         if "codex" in self.providers:
@@ -736,10 +737,10 @@ exec tmux attach -t "$TMUX_SESSION"
             # Only resume if Claude can actually find the session on disk.
             if local_session_id and (Path.home() / ".claude" / "session-env" / local_session_id).exists():
                 cmd.extend(["--resume", local_session_id])
-                print(f"🔁 Resuming Claude session: {local_session_id[:8]}...")
+                print(f"🔁 {t('resuming_claude', session_id=local_session_id[:8])}")
             else:
                 local_session_id = None
-                print("ℹ️ No local Claude session found, starting fresh")
+                print(f"ℹ️ {t('no_claude_session')}")
 
         # Always start Claude with an explicit session id when not resuming, so the id is local and resettable.
         if not local_session_id:
@@ -762,14 +763,14 @@ exec tmux attach -t "$TMUX_SESSION"
         try:
             return subprocess.run(cmd, stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr, env=env).returncode
         except KeyboardInterrupt:
-            print("\n⚠️ User interrupted")
+            print(f"\n⚠️ {t('user_interrupted')}")
             return 130
 
     def cleanup(self):
         if self._cleaned:
             return
         self._cleaned = True
-        print("\n🧹 Cleaning up session resources...")
+        print(f"\n🧹 {t('cleaning_up')}")
 
         if self.terminal_type == "wezterm":
             backend = WeztermBackend()
@@ -800,7 +801,7 @@ exec tmux attach -t "$TMUX_SESSION"
         if self.runtime_dir.exists():
             shutil.rmtree(self.runtime_dir, ignore_errors=True)
 
-        print("✅ Cleanup complete")
+        print(f"✅ {t('cleanup_complete')}")
 
     def run_up(self) -> int:
         git_info = _get_git_info()
@@ -826,7 +827,7 @@ exec tmux attach -t "$TMUX_SESSION"
             self._warmup_provider(provider)
 
         if self.no_claude:
-            print("✅ Backends started (--no-claude mode)")
+            print(f"✅ {t('backends_started_no_claude')}")
             print()
             for provider in self.providers:
                 if self.terminal_type == "wezterm":
@@ -900,7 +901,7 @@ def cmd_status(args):
         except Exception as e:
             results[provider] = {"status": f"Error: {e}", "active": False}
 
-    print("📊 AI backend status:")
+    print(f"📊 {t('backend_status')}")
     for provider, info in results.items():
         icon = "✅" if info.get("active") else "❌"
         print(f"  {icon} {provider.capitalize()}: {info['status']}")

--- a/ccb
+++ b/ccb
@@ -125,6 +125,19 @@ def _work_dir_match_keys(work_dir: Path) -> set[str]:
     return keys
 
 
+def _extract_session_work_dir_norm(session_data: dict) -> str:
+    """Extract a normalized work dir marker from a session file payload."""
+    if not isinstance(session_data, dict):
+        return ""
+    raw_norm = session_data.get("work_dir_norm")
+    if isinstance(raw_norm, str) and raw_norm.strip():
+        return _normalize_path_for_match(raw_norm)
+    raw = session_data.get("work_dir")
+    if isinstance(raw, str) and raw.strip():
+        return _normalize_path_for_match(raw)
+    return ""
+
+
 def _get_git_info() -> str:
     try:
         result = subprocess.run(
@@ -386,11 +399,13 @@ class AILauncher:
         sid = data.get("claude_session_id") or data.get("session_id")
         if isinstance(sid, str) and sid.strip():
             # Guard against path-format mismatch (Windows case/slash differences, MSYS paths, etc.).
-            recorded = data.get("work_dir")
-            if isinstance(recorded, str) and recorded.strip():
-                current_keys = _work_dir_match_keys(Path.cwd())
-                if current_keys and _normalize_path_for_match(recorded) not in current_keys:
-                    return None
+            recorded_norm = _extract_session_work_dir_norm(data)
+            if not recorded_norm:
+                # Old/foreign session file without a recorded work dir: refuse to resume to avoid cross-project reuse.
+                return None
+            current_keys = _work_dir_match_keys(Path.cwd())
+            if current_keys and recorded_norm not in current_keys:
+                return None
             return sid.strip()
         return None
 
@@ -421,7 +436,11 @@ class AILauncher:
             data = self._read_json_file(project_session)
             cached = data.get("codex_session_id")
             if isinstance(cached, str) and cached:
-                return cached, True
+                recorded_norm = _extract_session_work_dir_norm(data)
+                if recorded_norm:
+                    work_keys = _work_dir_match_keys(Path.cwd())
+                    if not work_keys or recorded_norm in work_keys:
+                        return cached, True
 
         # Fallback: scan Codex session logs for the latest session bound to this cwd.
         # This handles cases where `.codex-session` exists but never got updated with `codex_session_id`
@@ -1120,7 +1139,12 @@ def cmd_restore(args):
                 if provider == "codex":
                     session_id = data.get("codex_session_id")
                     if isinstance(session_id, str) and session_id:
-                        has_history = True
+                        recorded_norm = _extract_session_work_dir_norm(data)
+                        work_keys = _work_dir_match_keys(Path.cwd())
+                        if recorded_norm and (not work_keys or recorded_norm in work_keys):
+                            has_history = True
+                        else:
+                            session_id = None
                     else:
                         # Fallback: scan ~/.codex/sessions for latest session bound to this cwd.
                         root = Path(os.environ.get("CODEX_SESSION_ROOT") or (Path.home() / ".codex" / "sessions")).expanduser()

--- a/ccb
+++ b/ccb
@@ -110,6 +110,26 @@ class AILauncher:
                 return term
         return "tmux"
 
+    def _launch_script_in_macos_terminal(self, script_file: Path) -> bool:
+        """macOS: 使用 Terminal.app 打开新窗口执行脚本（避免 tmux launcher 嵌套导致交互失败）"""
+        if platform.system() != "Darwin":
+            return False
+        if not shutil.which("osascript"):
+            return False
+        env = os.environ.copy()
+        env["CCB_WRAPPER_SCRIPT"] = str(script_file)
+        subprocess.Popen(
+            [
+                "osascript",
+                "-e",
+                'tell application "Terminal" to do script "/bin/bash " & quoted form of (system attribute "CCB_WRAPPER_SCRIPT")',
+                "-e",
+                'tell application "Terminal" to activate',
+            ],
+            env=env,
+        )
+        return True
+
     def _start_provider(self, provider: str) -> bool:
         # 处理未检测到终端的情况
         if self.terminal_type is None:
@@ -431,7 +451,6 @@ CODEX_START_CMD={json.dumps(start_cmd)}
 if ! tmux has-session -t "$TMUX_SESSION" 2>/dev/null; then
     cd "$WORK_DIR"
     tmux new-session -d -s "$TMUX_SESSION" "$CODEX_START_CMD"
-    sleep 1
 fi
 tmux pipe-pane -o -t "$TMUX_SESSION" "cat >> '$TMUX_LOG_FILE'"
 
@@ -450,7 +469,10 @@ exec tmux attach -t "$TMUX_SESSION"
 
         terminal = self._detect_launch_terminal()
         if terminal == "tmux":
-            subprocess.run(["tmux", "new-session", "-d", "-s", f"launcher-{tmux_session}", str(script_file)], check=True)
+            if self._launch_script_in_macos_terminal(script_file):
+                pass
+            else:
+                subprocess.run(["tmux", "new-session", "-d", "-s", f"launcher-{tmux_session}", str(script_file)], check=True)
         else:
             subprocess.Popen([terminal, "-e", str(script_file)])
 
@@ -479,10 +501,23 @@ exec tmux attach -t "$TMUX_SESSION"
 
         terminal = self._detect_launch_terminal()
         if terminal == "tmux":
-            # 纯 tmux 模式
-            subprocess.run(["tmux", "new-session", "-d", "-s", tmux_session], check=True, cwd=os.getcwd())
-            time.sleep(0.3)
-            subprocess.run(["tmux", "send-keys", "-t", tmux_session, start_cmd, "Enter"], check=True)
+            if self._launch_script_in_macos_terminal(script_file):
+                pass
+            else:
+                # 纯 tmux 模式
+                subprocess.run(["tmux", "new-session", "-d", "-s", tmux_session], check=True, cwd=os.getcwd())
+                backend = TmuxBackend()
+                deadline = time.time() + 1.0
+                sleep_s = 0.05
+                while True:
+                    try:
+                        backend.send_text(tmux_session, start_cmd)
+                        break
+                    except subprocess.CalledProcessError:
+                        if time.time() >= deadline:
+                            raise
+                        time.sleep(sleep_s)
+                        sleep_s = min(0.2, sleep_s * 2)
         else:
             # 打开新终端窗口
             subprocess.Popen([terminal, "--", str(script_file)])
@@ -720,10 +755,7 @@ exec tmux attach -t "$TMUX_SESSION"
         for provider in providers:
             if not self._start_provider(provider):
                 return 1
-            time.sleep(1)
             self._warmup_provider(provider)
-
-        time.sleep(2)
 
         if self.no_claude:
             print("✅ 后端已启动（--no-claude 模式）")

--- a/ccb
+++ b/ccb
@@ -347,20 +347,23 @@ class AILauncher:
         Returns (project_hash, has_any_history_for_cwd).
         Gemini CLI stores sessions under ~/.gemini/tmp/<sha256(cwd)>/chats/.
         """
-        # Only trust local project state; deleting local dotfiles should reset resume behavior.
-        project_session = Path.cwd() / ".gemini-session"
-        if not project_session.exists():
-            return None, False
+        # Calculate hash the same way Gemini CLI does (sha256 of absolute path)
+        import hashlib
         try:
-            data = json.loads(project_session.read_text())
+            normalized = str(Path.cwd().expanduser().absolute())
         except Exception:
-            data = {}
-        if not isinstance(data, dict):
-            return None, True
-        project_hash = data.get("gemini_project_hash")
-        if isinstance(project_hash, str) and project_hash.strip():
-            return project_hash.strip(), True
-        return None, True
+            normalized = str(Path.cwd())
+        project_hash = hashlib.sha256(normalized.encode()).hexdigest()
+
+        # Check if actual session files exist
+        gemini_root = Path(os.environ.get("GEMINI_ROOT") or (Path.home() / ".gemini" / "tmp")).expanduser()
+        chats_dir = gemini_root / project_hash / "chats"
+        if not chats_dir.exists():
+            return None, False
+        session_files = list(chats_dir.glob("session-*.json"))
+        if not session_files:
+            return None, False
+        return project_hash, True
 
     def _build_gemini_start_cmd(self) -> str:
         cmd = "gemini --yolo" if self.auto else "gemini"

--- a/ccb
+++ b/ccb
@@ -1255,61 +1255,124 @@ def cmd_restore(args):
     return 0
 
 
+def _get_version_info(dir_path: Path) -> dict:
+    """Get commit hash, date and version from install directory"""
+    info = {"commit": None, "date": None, "version": None}
+    ccb_file = dir_path / "ccb"
+    if ccb_file.exists():
+        try:
+            content = ccb_file.read_text(encoding='utf-8', errors='replace')
+            for line in content.split('\n')[:60]:
+                line = line.strip()
+                if line.startswith('VERSION') and '=' in line:
+                    info["version"] = line.split('=')[1].strip().strip('"').strip("'")
+                elif line.startswith('GIT_COMMIT') and '=' in line:
+                    val = line.split('=')[1].strip().strip('"').strip("'")
+                    if val:
+                        info["commit"] = val
+                elif line.startswith('GIT_DATE') and '=' in line:
+                    val = line.split('=')[1].strip().strip('"').strip("'")
+                    if val:
+                        info["date"] = val
+        except Exception:
+            pass
+    if shutil.which("git") and (dir_path / ".git").exists():
+        result = subprocess.run(
+            ["git", "-C", str(dir_path), "log", "-1", "--format=%h|%ci"],
+            capture_output=True, text=True, encoding='utf-8', errors='replace'
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            parts = result.stdout.strip().split("|")
+            if len(parts) >= 2:
+                info["commit"] = parts[0]
+                info["date"] = parts[1].split()[0]
+    return info
+
+
+def _format_version_info(info: dict) -> str:
+    """Format version info for display"""
+    parts = []
+    if info.get("version"):
+        parts.append(f"v{info['version']}")
+    if info.get("commit"):
+        parts.append(info["commit"])
+    if info.get("date"):
+        parts.append(info["date"])
+    return " ".join(parts) if parts else "unknown"
+
+
+def _get_remote_version_info() -> dict | None:
+    """Get latest version info from GitHub API"""
+    import urllib.request
+    import ssl
+
+    api_url = "https://api.github.com/repos/bfly123/claude_code_bridge/commits/main"
+    try:
+        ctx = ssl.create_default_context()
+        req = urllib.request.Request(api_url, headers={"User-Agent": "ccb"})
+        with urllib.request.urlopen(req, context=ctx, timeout=5) as resp:
+            data = json.loads(resp.read().decode('utf-8'))
+            commit = data.get("sha", "")[:7]
+            date_str = data.get("commit", {}).get("committer", {}).get("date", "")
+            date = date_str[:10] if date_str else None
+            return {"commit": commit, "date": date}
+    except Exception:
+        pass
+
+    if shutil.which("curl"):
+        result = subprocess.run(
+            ["curl", "-fsSL", api_url],
+            capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=10
+        )
+        if result.returncode == 0:
+            try:
+                data = json.loads(result.stdout)
+                commit = data.get("sha", "")[:7]
+                date_str = data.get("commit", {}).get("committer", {}).get("date", "")
+                date = date_str[:10] if date_str else None
+                return {"commit": commit, "date": date}
+            except Exception:
+                pass
+    return None
+
+
+def cmd_version(args):
+    """Show version info and check for updates"""
+    script_root = Path(__file__).resolve().parent
+    default_install_dir = Path.home() / ".local/share/codex-dual"
+    install_dir = Path(os.environ.get("CODEX_INSTALL_PREFIX") or default_install_dir).expanduser()
+    if (script_root / "install.sh").exists():
+        install_dir = script_root
+
+    local_info = _get_version_info(install_dir)
+    local_str = _format_version_info(local_info)
+
+    print(f"ccb (Claude Code Bridge) {local_str}")
+    print(f"Install path: {install_dir}")
+
+    print("\nChecking for updates...")
+    remote_info = _get_remote_version_info()
+
+    if remote_info is None:
+        print("⚠️  Unable to check for updates (network error)")
+    elif local_info.get("commit") and remote_info.get("commit"):
+        if local_info["commit"] == remote_info["commit"]:
+            print(f"✅ Up to date")
+        else:
+            remote_str = f"{remote_info['commit']} {remote_info.get('date', '')}"
+            print(f"📦 Update available: {remote_str}")
+            print(f"   Run: ccb update")
+    else:
+        print("⚠️  Unable to compare versions")
+
+    return 0
+
+
 def cmd_update(args):
     """Update ccb to latest version"""
-    import shutil
     import urllib.request
     import tarfile
     import tempfile
-
-    def _get_version_info(dir_path: Path) -> dict:
-        """Get commit hash, date and version from install directory"""
-        info = {"commit": None, "date": None, "version": None}
-        # Get version, commit, date from ccb file (works without git)
-        ccb_file = dir_path / "ccb"
-        if ccb_file.exists():
-            try:
-                content = ccb_file.read_text(encoding='utf-8', errors='replace')
-                for line in content.split('\n')[:60]:
-                    line = line.strip()
-                    if line.startswith('VERSION') and '=' in line:
-                        # VERSION = "2.2"
-                        info["version"] = line.split('=')[1].strip().strip('"').strip("'")
-                    elif line.startswith('GIT_COMMIT') and '=' in line:
-                        # GIT_COMMIT = "abc1234"
-                        val = line.split('=')[1].strip().strip('"').strip("'")
-                        if val:
-                            info["commit"] = val
-                    elif line.startswith('GIT_DATE') and '=' in line:
-                        # GIT_DATE = "2025-12-21"
-                        val = line.split('=')[1].strip().strip('"').strip("'")
-                        if val:
-                            info["date"] = val
-            except Exception:
-                pass
-        # Override with live git info if available
-        if shutil.which("git") and (dir_path / ".git").exists():
-            result = subprocess.run(
-                ["git", "-C", str(dir_path), "log", "-1", "--format=%h|%ci"],
-                capture_output=True, text=True, encoding='utf-8', errors='replace'
-            )
-            if result.returncode == 0 and result.stdout.strip():
-                parts = result.stdout.strip().split("|")
-                if len(parts) >= 2:
-                    info["commit"] = parts[0]
-                    info["date"] = parts[1].split()[0]  # YYYY-MM-DD
-        return info
-
-    def _format_version_info(info: dict) -> str:
-        """Format version info for display"""
-        parts = []
-        if info.get("version"):
-            parts.append(f"v{info['version']}")
-        if info.get("commit"):
-            parts.append(info["commit"])
-        if info.get("date"):
-            parts.append(info["date"])
-        return " ".join(parts) if parts else "unknown"
 
     # Prefer the directory where this script resides (installed copy), then fall back to env/default.
     script_root = Path(__file__).resolve().parent
@@ -1491,12 +1554,17 @@ def main():
     restore_parser.add_argument("providers", nargs="*", default=[], help="Backends to restore (codex/gemini)")
 
     # update subcommand
-    update_parser = subparsers.add_parser("update", help="Update to latest version")
+    subparsers.add_parser("update", help="Update to latest version")
+
+    # version subcommand
+    subparsers.add_parser("version", help="Show version and check for updates")
 
     argv = sys.argv[1:]
-    # Backward/shortcut compatibility: allow `ccb -r` to behave like `ccb up -r` (default provider).
+    # Backward/shortcut compatibility
     if argv and argv[0] in {"-r", "--resume", "--restore"}:
         argv = ["up"] + argv
+    elif argv and argv[0] in {"-v", "--version"}:
+        argv = ["version"]
     args = parser.parse_args(argv)
 
     if not args.command:
@@ -1513,6 +1581,8 @@ def main():
         return cmd_restore(args)
     elif args.command == "update":
         return cmd_update(args)
+    elif args.command == "version":
+        return cmd_version(args)
     else:
         parser.print_help()
         return 1

--- a/ccb
+++ b/ccb
@@ -24,6 +24,9 @@ from pathlib import Path
 script_dir = Path(__file__).resolve().parent
 sys.path.insert(0, str(script_dir / "lib"))
 from terminal import TmuxBackend, WeztermBackend, Iterm2Backend, detect_terminal, is_wsl, get_shell_type
+from compat import setup_windows_encoding
+
+setup_windows_encoding()
 
 VERSION = "2.1"
 
@@ -32,7 +35,7 @@ def _get_git_info() -> str:
     try:
         result = subprocess.run(
             ["git", "-C", str(script_dir), "log", "-1", "--format=%h %ci"],
-            capture_output=True, text=True, timeout=2
+            capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=2
         )
         if result.returncode == 0:
             return result.stdout.strip()
@@ -385,6 +388,8 @@ class AILauncher:
                 cwd=str(Path.cwd()),
                 capture_output=True,
                 text=True,
+                encoding='utf-8',
+                errors='replace',
             )
             if last_result.returncode == 0:
                 out = (last_result.stdout or "").strip()
@@ -629,6 +634,28 @@ exec tmux attach -t "$TMUX_SESSION"
         latest = max(uuid_sessions, key=lambda p: p.stat().st_mtime)
         return latest.stem, True
 
+    def _find_claude_cmd(self) -> str:
+        """Find Claude CLI executable"""
+        if sys.platform == "win32":
+            for cmd in ["claude.exe", "claude.cmd", "claude.bat", "claude"]:
+                path = shutil.which(cmd)
+                if path:
+                    return path
+            npm_paths = [
+                Path(os.environ.get("APPDATA", "")) / "npm" / "claude.cmd",
+                Path(os.environ.get("ProgramFiles", "")) / "nodejs" / "claude.cmd",
+            ]
+            for npm_path in npm_paths:
+                if npm_path.exists():
+                    return str(npm_path)
+        else:
+            path = shutil.which("claude")
+            if path:
+                return path
+        raise FileNotFoundError(
+            "❌ Claude CLI not found. Install: npm install -g @anthropic-ai/claude-code"
+        )
+
     def _start_claude(self) -> int:
         print("🚀 启动 Claude...")
 
@@ -659,7 +686,13 @@ exec tmux attach -t "$TMUX_SESSION"
             else:
                 env["GEMINI_TMUX_SESSION"] = self.tmux_sessions.get("gemini", "")
 
-        cmd = ["claude"]
+        try:
+            claude_cmd = self._find_claude_cmd()
+        except FileNotFoundError as e:
+            print(str(e))
+            return 1
+
+        cmd = [claude_cmd]
         if self.auto:
             cmd.append("--dangerously-skip-permissions")
         local_session_id: str | None = None
@@ -1009,7 +1042,7 @@ def cmd_update(args):
         print("📦 Updating via git pull...")
         result = subprocess.run(
             ["git", "-C", str(install_dir), "pull", "--ff-only"],
-            capture_output=True, text=True
+            capture_output=True, text=True, encoding='utf-8', errors='replace'
         )
         if result.returncode == 0:
             print(result.stdout.strip() if result.stdout.strip() else "Already up to date.")

--- a/ccb
+++ b/ccb
@@ -25,8 +25,13 @@ script_dir = Path(__file__).resolve().parent
 sys.path.insert(0, str(script_dir / "lib"))
 from terminal import TmuxBackend, WeztermBackend, Iterm2Backend, detect_terminal, is_wsl, get_shell_type
 from compat import setup_windows_encoding
+from ccb_config import get_backend_env
 
 setup_windows_encoding()
+
+backend_env = get_backend_env()
+if backend_env and not os.environ.get("CCB_BACKEND_ENV"):
+    os.environ["CCB_BACKEND_ENV"] = backend_env
 
 VERSION = "2.1"
 

--- a/ccb
+++ b/ccb
@@ -927,22 +927,9 @@ exec tmux attach -t "$TMUX_SESSION"
         cmd = [claude_cmd]
         if self.auto:
             cmd.append("--dangerously-skip-permissions")
-        local_session_id: str | None = None
         if self.resume:
-            local_session_id = self._read_local_claude_session_id()
-            # Only resume if Claude can actually find the session on disk.
-            if local_session_id and (Path.home() / ".claude" / "session-env" / local_session_id).exists():
-                cmd.extend(["--resume", local_session_id])
-                print(f"🔁 {t('resuming_claude', session_id=local_session_id[:8])}")
-            else:
-                local_session_id = None
-                print(f"ℹ️ {t('no_claude_session')}")
-
-        # Always start Claude with an explicit session id when not resuming, so the id is local and resettable.
-        if not local_session_id:
-            new_id = str(uuid.uuid4())
-            cmd.extend(["--session-id", new_id])
-            self._write_local_claude_session(new_id, active=True)
+            cmd.append("--continue")
+            print(f"🔁 {t('resuming_claude', session_id='')}")
 
         print(f"📋 Session ID: {self.session_id}")
         print(f"📁 Runtime dir: {self.runtime_dir}")

--- a/ccb
+++ b/ccb
@@ -1260,6 +1260,47 @@ def cmd_update(args):
     import tarfile
     import tempfile
 
+    def _get_version_info(dir_path: Path) -> dict:
+        """Get commit hash, date and version from install directory"""
+        info = {"commit": None, "date": None, "version": None}
+        if not shutil.which("git") or not (dir_path / ".git").exists():
+            return info
+        # Get commit hash and date
+        result = subprocess.run(
+            ["git", "-C", str(dir_path), "log", "-1", "--format=%h|%ci"],
+            capture_output=True, text=True, encoding='utf-8', errors='replace'
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            parts = result.stdout.strip().split("|")
+            if len(parts) >= 2:
+                info["commit"] = parts[0]
+                info["date"] = parts[1].split()[0]  # YYYY-MM-DD
+        # Get version from ccb file
+        ccb_file = dir_path / "ccb"
+        if ccb_file.exists():
+            try:
+                content = ccb_file.read_text(encoding='utf-8', errors='replace')
+                for line in content.split('\n')[:50]:
+                    if line.startswith('VERSION'):
+                        # VERSION = "2.2"
+                        version = line.split('=')[1].strip().strip('"').strip("'")
+                        info["version"] = version
+                        break
+            except Exception:
+                pass
+        return info
+
+    def _format_version_info(info: dict) -> str:
+        """Format version info for display"""
+        parts = []
+        if info.get("version"):
+            parts.append(f"v{info['version']}")
+        if info.get("commit"):
+            parts.append(info["commit"])
+        if info.get("date"):
+            parts.append(info["date"])
+        return " ".join(parts) if parts else "unknown"
+
     # Prefer the directory where this script resides (installed copy), then fall back to env/default.
     script_root = Path(__file__).resolve().parent
     default_install_dir = Path.home() / ".local/share/codex-dual"
@@ -1267,6 +1308,9 @@ def cmd_update(args):
     if (script_root / "install.sh").exists():
         install_dir = script_root
     repo_url = "https://github.com/bfly123/claude_code_bridge"
+
+    # Get current version info before update
+    old_info = _get_version_info(install_dir)
 
     print("🔄 Checking for updates...")
 
@@ -1281,7 +1325,14 @@ def cmd_update(args):
             print(result.stdout.strip() if result.stdout.strip() else "Already up to date.")
             print("🔧 Reinstalling...")
             subprocess.run([str(install_dir / "install.sh"), "install"])
-            print("✅ Update complete!")
+            # Show upgrade info
+            new_info = _get_version_info(install_dir)
+            old_str = _format_version_info(old_info)
+            new_str = _format_version_info(new_info)
+            if old_info.get("commit") != new_info.get("commit"):
+                print(f"✅ Updated: {old_str} → {new_str}")
+            else:
+                print(f"✅ Already up to date: {new_str}")
             return 0
         else:
             print(f"⚠️ Git pull failed: {result.stderr.strip()}")
@@ -1387,8 +1438,14 @@ def cmd_update(args):
         env["CODEX_INSTALL_PREFIX"] = str(install_dir)
         subprocess.run([str(extracted_dir / "install.sh"), "install"], check=True, env=env)
 
-        print("✅ Update complete!")
-        print("💡 Recommended: Install WezTerm as terminal frontend (better split/scroll experience), see README.")
+        # Show upgrade info
+        new_info = _get_version_info(install_dir)
+        old_str = _format_version_info(old_info)
+        new_str = _format_version_info(new_info)
+        if old_info.get("commit") != new_info.get("commit") or old_info.get("version") != new_info.get("version"):
+            print(f"✅ Updated: {old_str} → {new_str}")
+        else:
+            print(f"✅ Already up to date: {new_str}")
         return 0
 
     except Exception as e:

--- a/ccb
+++ b/ccb
@@ -928,8 +928,12 @@ exec tmux attach -t "$TMUX_SESSION"
         if self.auto:
             cmd.append("--dangerously-skip-permissions")
         if self.resume:
-            cmd.append("--continue")
-            print(f"🔁 {t('resuming_claude', session_id='')}")
+            _, has_history = self._get_latest_claude_session_id()
+            if has_history:
+                cmd.append("--continue")
+                print(f"🔁 {t('resuming_claude', session_id='')}")
+            else:
+                print(f"ℹ️ {t('no_claude_session')}")
 
         print(f"📋 Session ID: {self.session_id}")
         print(f"📁 Runtime dir: {self.runtime_dir}")

--- a/ccb
+++ b/ccb
@@ -19,6 +19,7 @@ import platform
 import tempfile
 import re
 import shutil
+import posixpath
 from pathlib import Path
 
 script_dir = Path(__file__).resolve().parent
@@ -36,6 +37,92 @@ if backend_env and not os.environ.get("CCB_BACKEND_ENV"):
     os.environ["CCB_BACKEND_ENV"] = backend_env
 
 VERSION = "2.2"
+
+_WIN_DRIVE_RE = re.compile(r"^[A-Za-z]:([/\\\\]|$)")
+_MNT_DRIVE_RE = re.compile(r"^/mnt/([A-Za-z])/(.*)$")
+_MSYS_DRIVE_RE = re.compile(r"^/([A-Za-z])/(.*)$")
+
+
+def _looks_like_windows_path(value: str) -> bool:
+    s = value.strip()
+    if not s:
+        return False
+    if _WIN_DRIVE_RE.match(s):
+        return True
+    if s.startswith("\\\\") or s.startswith("//"):
+        return True
+    return False
+
+
+def _normalize_path_for_match(value: str) -> str:
+    """
+    Normalize a path-like string for loose matching across Windows/WSL/MSYS variations.
+    This is used only for selecting a session for *current* cwd, so favor robustness.
+    """
+    s = (value or "").strip()
+    if not s:
+        return ""
+
+    s = s.replace("\\", "/")
+
+    # Map WSL drive mount to Windows-style drive path for comparison.
+    m = _MNT_DRIVE_RE.match(s)
+    if m:
+        drive = m.group(1).lower()
+        rest = m.group(2)
+        s = f"{drive}:/{rest}"
+    else:
+        # Map MSYS /c/... to c:/... (Git-Bash/MSYS2 environments on Windows).
+        m = _MSYS_DRIVE_RE.match(s)
+        if m and ("MSYSTEM" in os.environ or os.name == "nt"):
+            drive = m.group(1).lower()
+            rest = m.group(2)
+            s = f"{drive}:/{rest}"
+
+    # Collapse redundant separators and dot segments using POSIX semantics (we forced "/").
+    # Preserve UNC double-slash prefix.
+    if s.startswith("//"):
+        prefix = "//"
+        rest = s[2:]
+        rest = posixpath.normpath(rest)
+        s = prefix + rest.lstrip("/")
+    else:
+        s = posixpath.normpath(s)
+
+    # Normalize Windows drive letter casing (c:/..., not C:/...).
+    if _WIN_DRIVE_RE.match(s):
+        s = s[0].lower() + s[1:]
+
+    # Drop trailing slash (but keep "/" and "c:/").
+    if len(s) > 1 and s.endswith("/"):
+        s = s.rstrip("/")
+        if _WIN_DRIVE_RE.match(s) and not s.endswith("/"):
+            # Ensure drive root keeps trailing slash form "c:/".
+            if len(s) == 2:
+                s = s + "/"
+
+    # On Windows-like paths, compare case-insensitively to avoid drive letter/case issues.
+    if _looks_like_windows_path(s):
+        s = s.casefold()
+
+    return s
+
+
+def _work_dir_match_keys(work_dir: Path) -> set[str]:
+    keys: set[str] = set()
+    candidates: list[str] = []
+    for raw in (os.environ.get("PWD"), str(work_dir)):
+        if raw:
+            candidates.append(raw)
+    try:
+        candidates.append(str(work_dir.resolve()))
+    except Exception:
+        pass
+    for candidate in candidates:
+        normalized = _normalize_path_for_match(candidate)
+        if normalized:
+            keys.add(normalized)
+    return keys
 
 
 def _get_git_info() -> str:
@@ -298,16 +385,24 @@ class AILauncher:
         data = self._read_json_file(self._claude_session_file())
         sid = data.get("claude_session_id") or data.get("session_id")
         if isinstance(sid, str) and sid.strip():
+            # Guard against path-format mismatch (Windows case/slash differences, MSYS paths, etc.).
+            recorded = data.get("work_dir")
+            if isinstance(recorded, str) and recorded.strip():
+                current_keys = _work_dir_match_keys(Path.cwd())
+                if current_keys and _normalize_path_for_match(recorded) not in current_keys:
+                    return None
             return sid.strip()
         return None
 
     def _write_local_claude_session(self, session_id: str, active: bool = True) -> None:
         path = self._claude_session_file()
         data = self._read_json_file(path)
+        work_dir = Path.cwd()
         data.update(
             {
                 "claude_session_id": session_id,
-                "work_dir": str(Path.cwd()),
+                "work_dir": str(work_dir),
+                "work_dir_norm": _normalize_path_for_match(str(work_dir)),
                 "active": bool(active),
                 "started_at": data.get("started_at") or time.strftime("%Y-%m-%d %H:%M:%S"),
                 "updated_at": time.strftime("%Y-%m-%d %H:%M:%S"),
@@ -327,6 +422,47 @@ class AILauncher:
             cached = data.get("codex_session_id")
             if isinstance(cached, str) and cached:
                 return cached, True
+
+        # Fallback: scan Codex session logs for the latest session bound to this cwd.
+        # This handles cases where `.codex-session` exists but never got updated with `codex_session_id`
+        # (e.g., user closed the backend before sending any message through the bridge).
+        root = Path(os.environ.get("CODEX_SESSION_ROOT") or (Path.home() / ".codex" / "sessions")).expanduser()
+        if not root.exists():
+            return None, False
+        work_keys = _work_dir_match_keys(Path.cwd())
+        if not work_keys:
+            return None, False
+        try:
+            logs = sorted(
+                (p for p in root.glob("**/*.jsonl") if p.is_file()),
+                key=lambda p: p.stat().st_mtime,
+                reverse=True,
+            )
+        except Exception:
+            logs = []
+        for log_path in logs[:400]:
+            try:
+                with log_path.open("r", encoding="utf-8", errors="ignore") as handle:
+                    first = handle.readline().strip()
+            except OSError:
+                continue
+            if not first:
+                continue
+            try:
+                entry = json.loads(first)
+            except Exception:
+                continue
+            if not isinstance(entry, dict) or entry.get("type") != "session_meta":
+                continue
+            payload = entry.get("payload") if isinstance(entry.get("payload"), dict) else {}
+            cwd = payload.get("cwd")
+            if not isinstance(cwd, str) or not cwd.strip():
+                continue
+            if _normalize_path_for_match(cwd) not in work_keys:
+                continue
+            sid = payload.get("id")
+            if isinstance(sid, str) and sid:
+                return sid, True
         return None, False
 
     def _build_codex_start_cmd(self) -> str:
@@ -554,6 +690,7 @@ exec tmux attach -t "$TMUX_SESSION"
         if session_file.exists():
             data = self._read_json_file(session_file)
 
+        work_dir = Path.cwd()
         data.update({
             "session_id": self.session_id,
             "runtime_dir": str(runtime),
@@ -563,7 +700,8 @@ exec tmux attach -t "$TMUX_SESSION"
             "tmux_session": tmux_session,
             "pane_id": pane_id,
             "tmux_log": str(runtime / "bridge_output.log"),
-            "work_dir": str(Path.cwd()),
+            "work_dir": str(work_dir),
+            "work_dir_norm": _normalize_path_for_match(str(work_dir)),
             "active": True,
             "started_at": time.strftime("%Y-%m-%d %H:%M:%S"),
         })
@@ -986,11 +1124,7 @@ def cmd_restore(args):
                     else:
                         # Fallback: scan ~/.codex/sessions for latest session bound to this cwd.
                         root = Path(os.environ.get("CODEX_SESSION_ROOT") or (Path.home() / ".codex" / "sessions")).expanduser()
-                        work_dirs = set([os.environ.get("PWD", ""), str(Path.cwd())])
-                        try:
-                            work_dirs.add(str(Path.cwd().resolve()))
-                        except Exception:
-                            pass
+                        work_dirs = _work_dir_match_keys(Path.cwd())
                         try:
                             logs = sorted(
                                 (p for p in root.glob("**/*.jsonl") if p.is_file()),
@@ -1015,7 +1149,7 @@ def cmd_restore(args):
                                 continue
                             payload = entry.get("payload") if isinstance(entry.get("payload"), dict) else {}
                             cwd = payload.get("cwd")
-                            if isinstance(cwd, str) and cwd in work_dirs:
+                            if isinstance(cwd, str) and cwd.strip() and _normalize_path_for_match(cwd) in work_dirs:
                                 has_history = True
                                 sid = payload.get("id")
                                 if isinstance(sid, str) and sid:

--- a/ccb
+++ b/ccb
@@ -35,7 +35,7 @@ backend_env = get_backend_env()
 if backend_env and not os.environ.get("CCB_BACKEND_ENV"):
     os.environ["CCB_BACKEND_ENV"] = backend_env
 
-VERSION = "2.1"
+VERSION = "2.2"
 
 
 def _get_git_info() -> str:

--- a/ccb
+++ b/ccb
@@ -63,6 +63,29 @@ def _normalize_path_for_match(value: str) -> str:
     if not s:
         return ""
 
+    # Expand "~" early (common in shell-originated values). If expansion fails, keep original.
+    if s.startswith("~"):
+        try:
+            s = os.path.expanduser(s)
+        except Exception:
+            pass
+
+    # If the path is relative, absolutize it against current cwd for matching purposes only.
+    # This reduces false negatives when upstream tools record a relative cwd.
+    # NOTE: treat Windows-like absolute paths as absolute even on non-Windows hosts.
+    try:
+        preview = s.replace("\\", "/")
+        is_abs = (
+            preview.startswith("/")
+            or preview.startswith("//")
+            or bool(_WIN_DRIVE_RE.match(preview))
+            or preview.startswith("\\\\")
+        )
+        if not is_abs:
+            s = str((Path.cwd() / Path(s)).absolute())
+    except Exception:
+        pass
+
     s = s.replace("\\", "/")
 
     # Map WSL drive mount to Windows-style drive path for comparison.
@@ -503,23 +526,40 @@ class AILauncher:
         Returns (project_hash, has_any_history_for_cwd).
         Gemini CLI stores sessions under ~/.gemini/tmp/<sha256(cwd)>/chats/.
         """
-        # Calculate hash the same way Gemini CLI does (sha256 of absolute path)
         import hashlib
-        try:
-            normalized = str(Path.cwd().expanduser().absolute())
-        except Exception:
-            normalized = str(Path.cwd())
-        project_hash = hashlib.sha256(normalized.encode()).hexdigest()
 
-        # Check if actual session files exist
         gemini_root = Path(os.environ.get("GEMINI_ROOT") or (Path.home() / ".gemini" / "tmp")).expanduser()
-        chats_dir = gemini_root / project_hash / "chats"
-        if not chats_dir.exists():
-            return None, False
-        session_files = list(chats_dir.glob("session-*.json"))
-        if not session_files:
-            return None, False
-        return project_hash, True
+
+        candidates: list[str] = []
+        try:
+            candidates.append(str(Path.cwd().absolute()))
+        except Exception:
+            pass
+        try:
+            candidates.append(str(Path.cwd().resolve()))
+        except Exception:
+            pass
+        env_pwd = (os.environ.get("PWD") or "").strip()
+        if env_pwd:
+            try:
+                candidates.append(os.path.abspath(os.path.expanduser(env_pwd)))
+            except Exception:
+                candidates.append(env_pwd)
+
+        seen: set[str] = set()
+        for candidate in candidates:
+            if not candidate or candidate in seen:
+                continue
+            seen.add(candidate)
+            project_hash = hashlib.sha256(candidate.encode()).hexdigest()
+            chats_dir = gemini_root / project_hash / "chats"
+            if not chats_dir.exists():
+                continue
+            session_files = list(chats_dir.glob("session-*.json"))
+            if session_files:
+                return project_hash, True
+
+        return None, False
 
     def _build_gemini_start_cmd(self) -> str:
         cmd = "gemini --yolo" if self.auto else "gemini"

--- a/ccb
+++ b/ccb
@@ -435,19 +435,11 @@ if ! tmux has-session -t "$TMUX_SESSION" 2>/dev/null; then
 fi
 tmux pipe-pane -o -t "$TMUX_SESSION" "cat >> '$TMUX_LOG_FILE'"
 
-echo "=== Wrapper Start ===" > "$RUNTIME_DIR/debug.log"
-date >> "$RUNTIME_DIR/debug.log"
-pwd >> "$RUNTIME_DIR/debug.log"
-env >> "$RUNTIME_DIR/debug.log"
-echo "Python: $PYTHON_BIN" >> "$RUNTIME_DIR/debug.log"
-echo "Script: $BRIDGE_SCRIPT" >> "$RUNTIME_DIR/debug.log"
-
-nohup "$PYTHON_BIN" "$BRIDGE_SCRIPT" --runtime-dir "$RUNTIME_DIR" --session-id "$SESSION_ID" >>"$RUNTIME_DIR/bridge.log" 2>&1 &
+"$PYTHON_BIN" "$BRIDGE_SCRIPT" --runtime-dir "$RUNTIME_DIR" --session-id "$SESSION_ID" >>"$RUNTIME_DIR/bridge.log" 2>&1 &
 BRIDGE_PID=$!
-echo "Bridge PID: $BRIDGE_PID" >> "$RUNTIME_DIR/debug.log"
 echo $BRIDGE_PID > "$RUNTIME_DIR/bridge.pid"
-disown $BRIDGE_PID
 
+trap 'kill -TERM "$BRIDGE_PID" 2>/dev/null' EXIT
 exec tmux attach -t "$TMUX_SESSION"
 '''
         script_file = runtime / "wrapper.sh"

--- a/ccb
+++ b/ccb
@@ -277,14 +277,17 @@ class AILauncher:
         try:
             if not path.exists():
                 return {}
-            data = json.loads(path.read_text())
+            # Session files are written as UTF-8; on Windows PowerShell 5.1 the default encoding
+            # may not be UTF-8, so always decode explicitly and tolerate UTF-8 BOM.
+            raw = path.read_text(encoding="utf-8-sig")
+            data = json.loads(raw)
             return data if isinstance(data, dict) else {}
         except Exception:
             return {}
 
     def _write_json_file(self, path: Path, data: dict) -> None:
         try:
-            path.write_text(json.dumps(data, ensure_ascii=False, indent=2))
+            path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
         except Exception:
             pass
 
@@ -320,13 +323,10 @@ class AILauncher:
         # Only trust local project state; deleting local dotfiles should reset resume behavior.
         project_session = Path.cwd() / ".codex-session"
         if project_session.exists():
-            try:
-                data = json.loads(project_session.read_text())
-                cached = data.get("codex_session_id")
-                if isinstance(cached, str) and cached:
-                    return cached, True
-            except Exception:
-                pass
+            data = self._read_json_file(project_session)
+            cached = data.get("codex_session_id")
+            if isinstance(cached, str) and cached:
+                return cached, True
         return None, False
 
     def _build_codex_start_cmd(self) -> str:
@@ -552,10 +552,7 @@ exec tmux attach -t "$TMUX_SESSION"
 
         data = {}
         if session_file.exists():
-            try:
-                data = json.loads(session_file.read_text())
-            except Exception:
-                pass
+            data = self._read_json_file(session_file)
 
         data.update({
             "session_id": self.session_id,
@@ -790,10 +787,12 @@ exec tmux attach -t "$TMUX_SESSION"
         for session_file in [Path.cwd() / ".codex-session", Path.cwd() / ".gemini-session", Path.cwd() / ".claude-session"]:
             if session_file.exists():
                 try:
-                    data = json.loads(session_file.read_text())
+                    data = self._read_json_file(session_file)
+                    if not data:
+                        continue
                     data["active"] = False
                     data["ended_at"] = time.strftime("%Y-%m-%d %H:%M:%S")
-                    session_file.write_text(json.dumps(data, ensure_ascii=False, indent=2))
+                    safe_write_session(session_file, json.dumps(data, ensure_ascii=False, indent=2))
                 except Exception:
                     pass
 
@@ -874,7 +873,7 @@ def cmd_status(args):
             continue
 
         try:
-            data = json.loads(session_file.read_text())
+            data = json.loads(session_file.read_text(encoding="utf-8-sig"))
             terminal = data.get("terminal", "tmux")
             pane_id = data.get("pane_id") if terminal in ("wezterm", "iterm2") else data.get("tmux_session", "")
             active = data.get("active", False)
@@ -921,7 +920,7 @@ def cmd_kill(args):
             continue
 
         try:
-            data = json.loads(session_file.read_text())
+            data = json.loads(session_file.read_text(encoding="utf-8-sig"))
             terminal = data.get("terminal", "tmux")
             pane_id = data.get("pane_id") if terminal in ("wezterm", "iterm2") else data.get("tmux_session", "")
 
@@ -937,7 +936,7 @@ def cmd_kill(args):
 
             data["active"] = False
             data["ended_at"] = time.strftime("%Y-%m-%d %H:%M:%S")
-            session_file.write_text(json.dumps(data, ensure_ascii=False, indent=2))
+            safe_write_session(session_file, json.dumps(data, ensure_ascii=False, indent=2))
 
             print(f"✅ {provider.capitalize()} terminated")
         except Exception as e:
@@ -956,7 +955,7 @@ def cmd_restore(args):
             continue
 
         try:
-            data = json.loads(session_file.read_text())
+            data = json.loads(session_file.read_text(encoding="utf-8-sig"))
             terminal = data.get("terminal", "tmux")
             pane_id = data.get("pane_id") if terminal in ("wezterm", "iterm2") else data.get("tmux_session", "")
             active = data.get("active", False)
@@ -1210,7 +1209,7 @@ def main():
     # up subcommand
     up_parser = subparsers.add_parser("up", help="Start AI backends")
     up_parser.add_argument("providers", nargs="*", choices=["codex", "gemini"], help="Backends to start")
-    up_parser.add_argument("-r", "--resume", action="store_true", help="Resume context")
+    up_parser.add_argument("-r", "--resume", "--restore", action="store_true", help="Resume context")
     up_parser.add_argument("-a", "--auto", action="store_true", help="Full auto permission mode")
     up_parser.add_argument("--no-claude", action="store_true", help="Don't start Claude main window")
 
@@ -1229,7 +1228,11 @@ def main():
     # update subcommand
     update_parser = subparsers.add_parser("update", help="Update to latest version")
 
-    args = parser.parse_args()
+    argv = sys.argv[1:]
+    # Backward/shortcut compatibility: allow `ccb -r` to behave like `ccb up -r` (default provider).
+    if argv and argv[0] in {"-r", "--resume", "--restore"}:
+        argv = ["up"] + argv
+    args = parser.parse_args(argv)
 
     if not args.command:
         parser.print_help()

--- a/ccb
+++ b/ccb
@@ -37,8 +37,8 @@ if backend_env and not os.environ.get("CCB_BACKEND_ENV"):
     os.environ["CCB_BACKEND_ENV"] = backend_env
 
 VERSION = "2.2"
-GIT_COMMIT = ""  # Updated by install.sh
-GIT_DATE = ""    # Updated by install.sh
+GIT_COMMIT = ""
+GIT_DATE = ""
 
 _WIN_DRIVE_RE = re.compile(r"^[A-Za-z]:([/\\\\]|$)")
 _MNT_DRIVE_RE = re.compile(r"^/mnt/([A-Za-z])/(.*)$")

--- a/ccb
+++ b/ccb
@@ -1263,19 +1263,7 @@ def cmd_update(args):
     def _get_version_info(dir_path: Path) -> dict:
         """Get commit hash, date and version from install directory"""
         info = {"commit": None, "date": None, "version": None}
-        if not shutil.which("git") or not (dir_path / ".git").exists():
-            return info
-        # Get commit hash and date
-        result = subprocess.run(
-            ["git", "-C", str(dir_path), "log", "-1", "--format=%h|%ci"],
-            capture_output=True, text=True, encoding='utf-8', errors='replace'
-        )
-        if result.returncode == 0 and result.stdout.strip():
-            parts = result.stdout.strip().split("|")
-            if len(parts) >= 2:
-                info["commit"] = parts[0]
-                info["date"] = parts[1].split()[0]  # YYYY-MM-DD
-        # Get version from ccb file
+        # Get version from ccb file first (works without git)
         ccb_file = dir_path / "ccb"
         if ccb_file.exists():
             try:
@@ -1288,6 +1276,17 @@ def cmd_update(args):
                         break
             except Exception:
                 pass
+        # Get commit hash and date if git available
+        if shutil.which("git") and (dir_path / ".git").exists():
+            result = subprocess.run(
+                ["git", "-C", str(dir_path), "log", "-1", "--format=%h|%ci"],
+                capture_output=True, text=True, encoding='utf-8', errors='replace'
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                parts = result.stdout.strip().split("|")
+                if len(parts) >= 2:
+                    info["commit"] = parts[0]
+                    info["date"] = parts[1].split()[0]  # YYYY-MM-DD
         return info
 
     def _format_version_info(info: dict) -> str:

--- a/ccb
+++ b/ccb
@@ -37,6 +37,8 @@ if backend_env and not os.environ.get("CCB_BACKEND_ENV"):
     os.environ["CCB_BACKEND_ENV"] = backend_env
 
 VERSION = "2.2"
+GIT_COMMIT = ""  # Updated by install.sh
+GIT_DATE = ""    # Updated by install.sh
 
 _WIN_DRIVE_RE = re.compile(r"^[A-Za-z]:([/\\\\]|$)")
 _MNT_DRIVE_RE = re.compile(r"^/mnt/([A-Za-z])/(.*)$")
@@ -1263,20 +1265,29 @@ def cmd_update(args):
     def _get_version_info(dir_path: Path) -> dict:
         """Get commit hash, date and version from install directory"""
         info = {"commit": None, "date": None, "version": None}
-        # Get version from ccb file first (works without git)
+        # Get version, commit, date from ccb file (works without git)
         ccb_file = dir_path / "ccb"
         if ccb_file.exists():
             try:
                 content = ccb_file.read_text(encoding='utf-8', errors='replace')
-                for line in content.split('\n')[:50]:
-                    if line.startswith('VERSION'):
+                for line in content.split('\n')[:60]:
+                    line = line.strip()
+                    if line.startswith('VERSION') and '=' in line:
                         # VERSION = "2.2"
-                        version = line.split('=')[1].strip().strip('"').strip("'")
-                        info["version"] = version
-                        break
+                        info["version"] = line.split('=')[1].strip().strip('"').strip("'")
+                    elif line.startswith('GIT_COMMIT') and '=' in line:
+                        # GIT_COMMIT = "abc1234"
+                        val = line.split('=')[1].strip().strip('"').strip("'")
+                        if val:
+                            info["commit"] = val
+                    elif line.startswith('GIT_DATE') and '=' in line:
+                        # GIT_DATE = "2025-12-21"
+                        val = line.split('=')[1].strip().strip('"').strip("'")
+                        if val:
+                            info["date"] = val
             except Exception:
                 pass
-        # Get commit hash and date if git available
+        # Override with live git info if available
         if shutil.which("git") and (dir_path / ".git").exists():
             result = subprocess.run(
                 ["git", "-C", str(dir_path), "log", "-1", "--format=%h|%ci"],

--- a/commands/cask-w.md
+++ b/commands/cask-w.md
@@ -1,25 +1,21 @@
 Forward commands to Codex session and wait for reply via `cask-w` command (supports tmux / WezTerm, forward only, does not execute in current Claude process).
 
 Execution:
-- Run in background `Bash(cask-w "<content>", run_in_background=true)`
-- Continue conversation immediately after sending, no blocking wait
-- Use `TaskOutput(task_id, block=true)` to get result when needed
+- Run `Bash(cask-w "<content>")`
+- After sending, STOP immediately and wait for user input
+- Do NOT continue with other tasks
 
 Parameters:
 - `<content>` required, will be forwarded to Codex session
-- Returns task_id for later result retrieval
 
 Workflow:
-1. Send to Codex in background
-2. Return task_id immediately
-3. Claude continues with other tasks
-4. Use TaskOutput to get reply when needed
+1. Send to Codex and wait for reply
+2. Display result to user
+3. STOP and wait for user's next instruction
 
 Examples:
-- `Bash(cask-w "1+2", run_in_background=true)` -> returns task_id
-- `TaskOutput(task_id, block=true)` -> get Codex reply
+- `Bash(cask-w "1+2")` -> wait for reply, then STOP
 
 Hints:
-- Can continue conversation after sending, no need to wait
 - Use `/cpend` to view latest reply
-- Use `TaskOutput` to get specific task result
+- Use `cask` for fire-and-forget (no wait)

--- a/commands/cask-w.md
+++ b/commands/cask-w.md
@@ -1,25 +1,25 @@
-通过 `cask-w` 命令将指令转发到 Codex 会话并等待回复（支持 tmux / WezTerm，仅转发，不在当前 Claude 进程执行）。
+Forward commands to Codex session and wait for reply via `cask-w` command (supports tmux / WezTerm, forward only, does not execute in current Claude process).
 
-执行方式:
-- 后台运行 `Bash(cask-w "<转发内容>", run_in_background=true)`
-- 发送后立即继续对话，不阻塞等待
-- 需要结果时使用 `TaskOutput(task_id, block=true)` 获取
+Execution:
+- Run in background `Bash(cask-w "<content>", run_in_background=true)`
+- Continue conversation immediately after sending, no blocking wait
+- Use `TaskOutput(task_id, block=true)` to get result when needed
 
-参数说明:
-- `<转发内容>` 必填，会被转发到 Codex 会话
-- 返回 task_id，可用于后续获取结果
+Parameters:
+- `<content>` required, will be forwarded to Codex session
+- Returns task_id for later result retrieval
 
-交互流程:
-1. 后台发送到 Codex
-2. 立即返回 task_id
-3. Claude 继续处理其他任务
-4. 需要时通过 TaskOutput 获取回复
+Workflow:
+1. Send to Codex in background
+2. Return task_id immediately
+3. Claude continues with other tasks
+4. Use TaskOutput to get reply when needed
 
-示例:
-- `Bash(cask-w "1+2", run_in_background=true)` -> 返回 task_id
-- `TaskOutput(task_id, block=true)` -> 获取 Codex 回复
+Examples:
+- `Bash(cask-w "1+2", run_in_background=true)` -> returns task_id
+- `TaskOutput(task_id, block=true)` -> get Codex reply
 
-提示:
-- 发送后可继续对话，无需等待
-- 使用 `/cpend` 查看最新回复
-- 使用 `TaskOutput` 获取特定任务结果
+Hints:
+- Can continue conversation after sending, no need to wait
+- Use `/cpend` to view latest reply
+- Use `TaskOutput` to get specific task result

--- a/commands/cask-w.md
+++ b/commands/cask-w.md
@@ -1,27 +1,23 @@
-Forward commands to Codex session and wait for reply via `cask-w` command (supports tmux / WezTerm, forward only, does not execute in current Claude process).
+Forward commands to Codex session and wait for reply via `cask-w` command (supports tmux / WezTerm).
 
 Execution:
 1. Run `Bash(cask-w "<content>", run_in_background=true)` to start background task
 2. Tell user the task_id and that Codex is processing
-3. STOP immediately and wait for user input (do NOT call TaskOutput)
+3. Wait for bash-notification (task completed)
+4. When notification arrives, immediately `cat` the output file to show result
 
 Parameters:
 - `<content>` required, will be forwarded to Codex session
 
 Workflow:
 1. Start cask-w in background -> get task_id
-2. Inform user: "Codex processing in background (task: xxx), use /cpend to check reply"
-3. STOP and continue conversation - do NOT block waiting
-
-When user wants result:
-- User can say "check codex" or use `/cpend` to view reply
-- Or use `TaskOutput(task_id, block=false)` to check status
+2. Inform user: "Codex processing (task: xxx)"
+3. When bash-notification arrives -> `cat <output-file>` to show result
 
 Examples:
-- `Bash(cask-w "analyze code", run_in_background=true)` -> inform user, STOP
-- User: "check codex" -> `cpend` or `TaskOutput(task_id)`
+- `Bash(cask-w "analyze code", run_in_background=true)`
+- bash-notification arrives -> `cat /tmp/.../tasks/xxx.output`
 
 Hints:
-- Do NOT use `TaskOutput(block=true)` - it blocks conversation
-- Use `/cpend` to view latest reply anytime
 - Use `cask` for fire-and-forget (no wait)
+- Use `/cpend` to view latest reply anytime

--- a/commands/cask-w.md
+++ b/commands/cask-w.md
@@ -1,21 +1,27 @@
 Forward commands to Codex session and wait for reply via `cask-w` command (supports tmux / WezTerm, forward only, does not execute in current Claude process).
 
 Execution:
-- Run `Bash(cask-w "<content>")`
-- After sending, STOP immediately and wait for user input
-- Do NOT continue with other tasks
+1. Run `Bash(cask-w "<content>", run_in_background=true)` to start background task
+2. Tell user the task_id and that Codex is processing
+3. STOP immediately and wait for user input (do NOT call TaskOutput)
 
 Parameters:
 - `<content>` required, will be forwarded to Codex session
 
 Workflow:
-1. Send to Codex and wait for reply
-2. Display result to user
-3. STOP and wait for user's next instruction
+1. Start cask-w in background -> get task_id
+2. Inform user: "Codex processing in background (task: xxx), use /cpend to check reply"
+3. STOP and continue conversation - do NOT block waiting
+
+When user wants result:
+- User can say "check codex" or use `/cpend` to view reply
+- Or use `TaskOutput(task_id, block=false)` to check status
 
 Examples:
-- `Bash(cask-w "1+2")` -> wait for reply, then STOP
+- `Bash(cask-w "analyze code", run_in_background=true)` -> inform user, STOP
+- User: "check codex" -> `cpend` or `TaskOutput(task_id)`
 
 Hints:
-- Use `/cpend` to view latest reply
+- Do NOT use `TaskOutput(block=true)` - it blocks conversation
+- Use `/cpend` to view latest reply anytime
 - Use `cask` for fire-and-forget (no wait)

--- a/commands/cask-w.md
+++ b/commands/cask-w.md
@@ -1,24 +1,25 @@
 通过 `cask-w` 命令将指令转发到 Codex 会话并等待回复（支持 tmux / WezTerm，仅转发，不在当前 Claude 进程执行）。
 
 执行方式:
-- 沉默运行 `Bash(cask-w "<转发内容>")`，执行完毕后不做其他分析、推理或额外操作
-- 在终端中也可执行 `cask-w <转发内容>`，效果等同
+- 后台运行 `Bash(cask-w "<转发内容>", run_in_background=true)`
+- 发送后立即继续对话，不阻塞等待
+- 需要结果时使用 `TaskOutput(task_id, block=true)` 获取
 
 参数说明:
-- `<转发内容>` 必填，会被转发到 Codex 会话（例如 `pwd`、`ls` 等命令）
-- ⚠️ 注意：cask-w 转发后会等待 Codex 回复（默认无超时，`Ctrl-C` 可中断）
+- `<转发内容>` 必填，会被转发到 Codex 会话
+- 返回 task_id，可用于后续获取结果
 
 交互流程:
-1. 转发命令到 Codex tmux 会话
-2. 捕获当前日志状态
-3. 等待新的回复消息
-4. 打印回复内容后返回
+1. 后台发送到 Codex
+2. 立即返回 task_id
+3. Claude 继续处理其他任务
+4. 需要时通过 TaskOutput 获取回复
 
 示例:
-- `Bash(cask-w "pwd")`
-- `Bash(cask-w "echo test")`
+- `Bash(cask-w "1+2", run_in_background=true)` -> 返回 task_id
+- `TaskOutput(task_id, block=true)` -> 获取 Codex 回复
 
 提示:
-- cask-w 会阻塞等待 Codex 回复，适合需要立即看到结果的场景
-- 如不需要等待，使用 `/cask` 即可
-- cask-w 返回后表示已获取回复，无需继续执行任何操作
+- 发送后可继续对话，无需等待
+- 使用 `/cpend` 查看最新回复
+- 使用 `TaskOutput` 获取特定任务结果

--- a/commands/cask.md
+++ b/commands/cask.md
@@ -1,18 +1,18 @@
-通过 `cask` 命令将指令转发到 Codex 会话（支持 tmux / WezTerm，仅转发，不在当前 Claude 进程执行）。
+Forward commands to Codex session via `cask` command (supports tmux / WezTerm, forward only, does not execute in current Claude process).
 
-执行方式:
-- 沉默运行 `Bash(cask "<转发内容>")`，执行完毕后不做其他分析、推理或额外操作
-- 在终端中也可执行 `cask <转发内容>`，效果等同
+Execution:
+- Run silently `Bash(cask "<content>")`, no additional analysis or operations after execution
+- Can also run `cask <content>` in terminal with same effect
 
-参数说明:
-- `<转发内容>` 必填，会被转发到 Codex 会话（例如 `pwd`、`ls` 等命令）
-- ⚠️ 注意：cask 仅负责转发，不在本 Claude 进程执行，返回后立即结束
+Parameters:
+- `<content>` required, will be forwarded to Codex session (e.g. `pwd`, `ls` commands)
+- Note: cask only forwards, does not execute in Claude process, returns immediately after
 
-示例:
+Examples:
 - `Bash(cask "pwd")`
 - `Bash(cask "ls -la")`
 
-提示:
-- cask 发送命令后立即返回，不等待结果
-- 如需等待 Codex 回复，请使用 `/cask-w`
-- cask 返回后表示转发完成，无需继续执行任何操作
+Hints:
+- cask returns immediately after sending, does not wait for result
+- Use `/cask-w` if you need to wait for Codex reply
+- After cask returns, forwarding is complete, no further action needed

--- a/commands/cpend.md
+++ b/commands/cpend.md
@@ -1,19 +1,19 @@
-使用 `cpend` 从 Codex 官方日志中抓取最新回复，适合异步模式或超时后的补充查询。
+Use `cpend` to fetch latest reply from Codex official logs, suitable for async mode or follow-up queries after timeout.
 
-执行方式:
-- Claude 端使用 `Bash(cpend)`，命令执行过程保持静默
-- 本地终端可直接运行 `cpend`
+Execution:
+- Use `Bash(cpend)` on Claude side, keep command execution silent
+- Run `cpend` directly in local terminal
 
-功能特点:
-1. 解析 `.codex-session` 记录的日志路径，定位本次会话的最新 JSONL 文件
-2. 读取尾部消息并返回 Codex 最近一次输出
-3. 若无新内容，将提示“暂无 Codex 回复”
+Features:
+1. Parses log path recorded in `.codex-session`, locates latest JSONL file for current session
+2. Reads tail messages and returns Codex's most recent output
+3. If no new content, will prompt "No Codex reply yet"
 
-常见场景:
-- `cask` 异步提交多条任务后集中查看结果
-- `cask-w` 因超时退出后手动确认 Codex 是否已回应
-- 需要核对 Codex 回复与原始问题是否匹配
+Common scenarios:
+- View results after submitting multiple tasks via `cask` async
+- Manually confirm if Codex has responded after `cask-w` timeout exit
+- Need to verify if Codex reply matches original question
 
-提示:
-- 日志文件通常位于 `~/.codex/sessions/.../rollout-<session>.jsonl`
-- 如果命令返回空，请先确认 Codex 会话仍在运行（可用 `/cping` 检查）
+Hints:
+- Log file usually located at `~/.codex/sessions/.../rollout-<session>.jsonl`
+- If command returns empty, first confirm Codex session is still running (use `/cping` to check)

--- a/commands/cping.md
+++ b/commands/cping.md
@@ -1,19 +1,19 @@
-使用 `cping` 检查当前 Codex 会话是否健康，快速定位通信问题。
+Use `cping` to check if current Codex session is healthy, quickly locate communication issues.
 
-执行方式:
-- Claude 端运行 `Bash(cping)`，无需输出命令执行过程
-- 本地终端直接执行 `cping`
+Execution:
+- Run `Bash(cping)` on Claude side, no need to output command execution process
+- Run `cping` directly in local terminal
 
-检测内容:
-1. `.codex-session` 是否标记为活跃，运行目录是否存在
-2. tmux 模式：FIFO 管道是否仍可访问
-3. tmux 模式：Codex 侧进程是否存活（根据 `codex.pid` 验证）
-4. WezTerm 模式：pane 是否仍存在（根据 `wezterm cli list` 检测）
+Detection items:
+1. Is `.codex-session` marked as active, does runtime directory exist
+2. tmux mode: Is FIFO pipe still accessible
+3. tmux mode: Is Codex side process alive (verified by `codex.pid`)
+4. WezTerm mode: Does pane still exist (detected via `wezterm cli list`)
 
-输出说明:
-- 成功：`✅ Codex连接正常 (...)`
-- 失败：列出缺失的组件或异常信息，便于进一步排查
+Output:
+- Success: `Codex connection OK (...)`
+- Failure: Lists missing components or error info for further troubleshooting
 
-提示:
-- 若检测失败，可尝试重新运行 `ccb up codex` 或查看桥接日志
-- 在多次超时或无回复时，先执行 `cping` 再决定是否重启会话
+Hints:
+- If detection fails, try re-running `ccb up codex` or check bridge logs
+- On multiple timeouts or no response, run `cping` first before deciding to restart session

--- a/commands/gask-w.md
+++ b/commands/gask-w.md
@@ -1,25 +1,25 @@
-通过 `gask-w` 命令将指令转发到 Gemini 会话，并同步等待回复（支持 tmux / WezTerm）。
+Forward commands to Gemini session and wait for reply via `gask-w` command (supports tmux / WezTerm).
 
-执行方式:
-- 后台运行 `Bash(gask-w "<转发内容>", run_in_background=true)`
-- 发送后立即继续对话，不阻塞等待
-- 需要结果时使用 `TaskOutput(task_id, block=true)` 获取
+Execution:
+- Run in background `Bash(gask-w "<content>", run_in_background=true)`
+- Continue conversation immediately after sending, no blocking wait
+- Use `TaskOutput(task_id, block=true)` to get result when needed
 
-参数说明:
-- `<转发内容>` 必填，会被转发到 Gemini 会话
-- 返回 task_id，可用于后续获取结果
+Parameters:
+- `<content>` required, will be forwarded to Gemini session
+- Returns task_id for later result retrieval
 
-交互流程:
-1. 后台发送到 Gemini
-2. 立即返回 task_id
-3. Claude 继续处理其他任务
-4. 需要时通过 TaskOutput 获取回复
+Workflow:
+1. Send to Gemini in background
+2. Return task_id immediately
+3. Claude continues with other tasks
+4. Use TaskOutput to get reply when needed
 
-示例:
-- `Bash(gask-w "解释一下这段代码", run_in_background=true)` -> 返回 task_id
-- `TaskOutput(task_id, block=true)` -> 获取 Gemini 回复
+Examples:
+- `Bash(gask-w "explain this code", run_in_background=true)` -> returns task_id
+- `TaskOutput(task_id, block=true)` -> get Gemini reply
 
-提示:
-- 发送后可继续对话，无需等待
-- 使用 `/gpend` 查看最新回复
-- 使用 `TaskOutput` 获取特定任务结果
+Hints:
+- Can continue conversation after sending, no need to wait
+- Use `/gpend` to view latest reply
+- Use `TaskOutput` to get specific task result

--- a/commands/gask-w.md
+++ b/commands/gask-w.md
@@ -1,25 +1,21 @@
 Forward commands to Gemini session and wait for reply via `gask-w` command (supports tmux / WezTerm).
 
 Execution:
-- Run in background `Bash(gask-w "<content>", run_in_background=true)`
-- Continue conversation immediately after sending, no blocking wait
-- Use `TaskOutput(task_id, block=true)` to get result when needed
+- Run `Bash(gask-w "<content>")`
+- After sending, STOP immediately and wait for user input
+- Do NOT continue with other tasks
 
 Parameters:
 - `<content>` required, will be forwarded to Gemini session
-- Returns task_id for later result retrieval
 
 Workflow:
-1. Send to Gemini in background
-2. Return task_id immediately
-3. Claude continues with other tasks
-4. Use TaskOutput to get reply when needed
+1. Send to Gemini and wait for reply
+2. Display result to user
+3. STOP and wait for user's next instruction
 
 Examples:
-- `Bash(gask-w "explain this code", run_in_background=true)` -> returns task_id
-- `TaskOutput(task_id, block=true)` -> get Gemini reply
+- `Bash(gask-w "explain this code")` -> wait for reply, then STOP
 
 Hints:
-- Can continue conversation after sending, no need to wait
 - Use `/gpend` to view latest reply
-- Use `TaskOutput` to get specific task result
+- Use `gask` for fire-and-forget (no wait)

--- a/commands/gask-w.md
+++ b/commands/gask-w.md
@@ -1,21 +1,27 @@
 Forward commands to Gemini session and wait for reply via `gask-w` command (supports tmux / WezTerm).
 
 Execution:
-- Run `Bash(gask-w "<content>")`
-- After sending, STOP immediately and wait for user input
-- Do NOT continue with other tasks
+1. Run `Bash(gask-w "<content>", run_in_background=true)` to start background task
+2. Tell user the task_id and that Gemini is processing
+3. STOP immediately and wait for user input (do NOT call TaskOutput)
 
 Parameters:
 - `<content>` required, will be forwarded to Gemini session
 
 Workflow:
-1. Send to Gemini and wait for reply
-2. Display result to user
-3. STOP and wait for user's next instruction
+1. Start gask-w in background -> get task_id
+2. Inform user: "Gemini processing in background (task: xxx), use /gpend to check reply"
+3. STOP and continue conversation - do NOT block waiting
+
+When user wants result:
+- User can say "check gemini" or use `/gpend` to view reply
+- Or use `TaskOutput(task_id, block=false)` to check status
 
 Examples:
-- `Bash(gask-w "explain this code")` -> wait for reply, then STOP
+- `Bash(gask-w "explain this", run_in_background=true)` -> inform user, STOP
+- User: "check gemini" -> `gpend` or `TaskOutput(task_id)`
 
 Hints:
-- Use `/gpend` to view latest reply
+- Do NOT use `TaskOutput(block=true)` - it blocks conversation
+- Use `/gpend` to view latest reply anytime
 - Use `gask` for fire-and-forget (no wait)

--- a/commands/gask-w.md
+++ b/commands/gask-w.md
@@ -1,18 +1,25 @@
 通过 `gask-w` 命令将指令转发到 Gemini 会话，并同步等待回复（支持 tmux / WezTerm）。
 
 执行方式:
-- 沉默运行 `Bash(gask-w "<转发内容>")`，执行完毕后不做其他分析、推理或额外操作
-- 在终端中也可执行 `gask-w <转发内容>`，效果等同
+- 后台运行 `Bash(gask-w "<转发内容>", run_in_background=true)`
+- 发送后立即继续对话，不阻塞等待
+- 需要结果时使用 `TaskOutput(task_id, block=true)` 获取
 
 参数说明:
 - `<转发内容>` 必填，会被转发到 Gemini 会话
-- ⚠️ 注意：gask-w 会等待 Gemini 回复后再返回
+- 返回 task_id，可用于后续获取结果
+
+交互流程:
+1. 后台发送到 Gemini
+2. 立即返回 task_id
+3. Claude 继续处理其他任务
+4. 需要时通过 TaskOutput 获取回复
 
 示例:
-- `Bash(gask-w "解释一下这段代码")`
-- `Bash(gask-w "这个方案有什么建议？")`
+- `Bash(gask-w "解释一下这段代码", run_in_background=true)` -> 返回 task_id
+- `TaskOutput(task_id, block=true)` -> 获取 Gemini 回复
 
 提示:
-- gask-w 会阻塞等待 Gemini 回复
-- 默认无超时，`Ctrl-C` 可中断（如需非阻塞，使用 `/gask`）
-- 适合需要获取 Gemini 反馈的场景
+- 发送后可继续对话，无需等待
+- 使用 `/gpend` 查看最新回复
+- 使用 `TaskOutput` 获取特定任务结果

--- a/commands/gask-w.md
+++ b/commands/gask-w.md
@@ -10,7 +10,7 @@ Parameters:
 
 Workflow:
 1. Start gask-w in background -> get task_id
-2. Inform user: "Gemini processing in background (task: xxx), use /gpend to check reply"
+2. Inform user: "Gemini processing in background (task: xxx)"
 3. STOP and continue conversation - do NOT block waiting
 
 When user wants result:

--- a/commands/gask-w.md
+++ b/commands/gask-w.md
@@ -3,25 +3,21 @@ Forward commands to Gemini session and wait for reply via `gask-w` command (supp
 Execution:
 1. Run `Bash(gask-w "<content>", run_in_background=true)` to start background task
 2. Tell user the task_id and that Gemini is processing
-3. STOP immediately and wait for user input (do NOT call TaskOutput)
+3. Wait for bash-notification (task completed)
+4. When notification arrives, immediately `cat` the output file to show result
 
 Parameters:
 - `<content>` required, will be forwarded to Gemini session
 
 Workflow:
 1. Start gask-w in background -> get task_id
-2. Inform user: "Gemini processing in background (task: xxx)"
-3. STOP and continue conversation - do NOT block waiting
-
-When user wants result:
-- User can say "check gemini" or use `/gpend` to view reply
-- Or use `TaskOutput(task_id, block=false)` to check status
+2. Inform user: "Gemini processing (task: xxx)"
+3. When bash-notification arrives -> `cat <output-file>` to show result
 
 Examples:
-- `Bash(gask-w "explain this", run_in_background=true)` -> inform user, STOP
-- User: "check gemini" -> `gpend` or `TaskOutput(task_id)`
+- `Bash(gask-w "explain this", run_in_background=true)`
+- bash-notification arrives -> `cat /tmp/.../tasks/xxx.output`
 
 Hints:
-- Do NOT use `TaskOutput(block=true)` - it blocks conversation
-- Use `/gpend` to view latest reply anytime
 - Use `gask` for fire-and-forget (no wait)
+- Use `/gpend` to view latest reply anytime

--- a/commands/gask.md
+++ b/commands/gask.md
@@ -1,18 +1,18 @@
-通过 `gask` 命令将指令转发到 Gemini 会话（支持 tmux / WezTerm，仅转发，不在当前 Claude 进程执行）。
+Forward commands to Gemini session via `gask` command (supports tmux / WezTerm, forward only, does not execute in current Claude process).
 
-执行方式:
-- 沉默运行 `Bash(gask "<转发内容>")`，执行完毕后不做其他分析、推理或额外操作
-- 在终端中也可执行 `gask <转发内容>`，效果等同
+Execution:
+- Run silently `Bash(gask "<content>")`, no additional analysis or operations after execution
+- Can also run `gask <content>` in terminal with same effect
 
-参数说明:
-- `<转发内容>` 必填，会被转发到 Gemini 会话
-- ⚠️ 注意：gask 仅负责转发，不在本 Claude 进程执行，返回后立即结束
+Parameters:
+- `<content>` required, will be forwarded to Gemini session
+- Note: gask only forwards, does not execute in Claude process, returns immediately after
 
-示例:
-- `Bash(gask "解释一下这段代码")`
-- `Bash(gask "帮我优化这个函数")`
+Examples:
+- `Bash(gask "explain this code")`
+- `Bash(gask "help me optimize this function")`
 
-提示:
-- gask 发送命令后立即返回，不等待结果
-- 如需等待 Gemini 回复，请使用 `/gask-w`
-- gask 返回后表示转发完成，无需继续执行任何操作
+Hints:
+- gask returns immediately after sending, does not wait for result
+- Use `/gask-w` if you need to wait for Gemini reply
+- After gask returns, forwarding is complete, no further action needed

--- a/commands/gpend.md
+++ b/commands/gpend.md
@@ -1,9 +1,9 @@
-通过 `gpend` 命令查看 Gemini 最新回复。
+View latest Gemini reply via `gpend` command.
 
-执行方式:
-- 沉默运行 `Bash(gpend)`，执行完毕后不做其他分析、推理或额外操作
-- 在终端中也可执行 `gpend`，效果等同
+Execution:
+- Run silently `Bash(gpend)`, no additional analysis or operations after execution
+- Can also run `gpend` in terminal with same effect
 
-提示:
-- 用于查看 gask 异步发送后的回复
-- 或 gask-w 超时后继续获取回复
+Hints:
+- Used to view reply after gask async send
+- Or continue getting reply after gask-w timeout

--- a/commands/gping.md
+++ b/commands/gping.md
@@ -1,9 +1,9 @@
-通过 `gping` 命令测试与 Gemini 的连通性。
+Test connectivity with Gemini via `gping` command.
 
-执行方式:
-- 沉默运行 `Bash(gping)`，执行完毕后不做其他分析、推理或额外操作
-- 在终端中也可执行 `gping`，效果等同
+Execution:
+- Run silently `Bash(gping)`, no additional analysis or operations after execution
+- Can also run `gping` in terminal with same effect
 
-提示:
-- 返回 Gemini 会话状态
-- 用于检查 Gemini 是否正常运行
+Hints:
+- Returns Gemini session status
+- Used to check if Gemini is running normally

--- a/install.ps1
+++ b/install.ps1
@@ -45,24 +45,24 @@ function Require-Python310 {
     $major = [int]$parts[1]
     $minor = [int]$parts[2]
   } catch {
-    Write-Host "❌ Failed to query Python version using: $PythonCmd"
+    Write-Host "[ERROR] Failed to query Python version using: $PythonCmd"
     exit 1
   }
 
   if (($major -ne 3) -or ($minor -lt 10)) {
-    Write-Host "❌ Python version too old: $version"
+    Write-Host "[ERROR] Python version too old: $version"
     Write-Host "   ccb requires Python 3.10+"
     Write-Host "   Download: https://www.python.org/downloads/"
     exit 1
   }
-  Write-Host "✓ Python $version"
+  Write-Host "[OK] Python $version"
 }
 
 function Confirm-BackendEnv {
   if ($Yes -or $env:CCB_INSTALL_ASSUME_YES -eq "1") { return }
 
   if (-not [Environment]::UserInteractive) {
-    Write-Host "❌ Non-interactive environment detected, aborting to prevent Windows/WSL mismatch."
+    Write-Host "[ERROR] Non-interactive environment detected, aborting to prevent Windows/WSL mismatch."
     Write-Host "   If codex/gemini will run in native Windows:"
     Write-Host "   Re-run: powershell -ExecutionPolicy Bypass -File .\install.ps1 install -Yes"
     exit 1
@@ -70,7 +70,7 @@ function Confirm-BackendEnv {
 
   Write-Host ""
   Write-Host "================================================================"
-  Write-Host "⚠️  You are installing ccb in native Windows environment"
+  Write-Host "[WARNING] You are installing ccb in native Windows environment"
   Write-Host "================================================================"
   Write-Host "ccb/cask-w must run in the same environment as codex/gemini."
   Write-Host ""

--- a/install.ps1
+++ b/install.ps1
@@ -62,25 +62,25 @@ function Confirm-BackendEnv {
   if ($Yes -or $env:CCB_INSTALL_ASSUME_YES -eq "1") { return }
 
   if (-not [Environment]::UserInteractive) {
-    Write-Host "❌ 非交互环境下默认中止，避免 Windows/WSL 环境错配。"
-    Write-Host "   若确认 codex/gemini 将在 Windows 原生运行："
-    Write-Host "   重新运行: powershell -ExecutionPolicy Bypass -File .\install.ps1 install -Yes"
+    Write-Host "❌ Non-interactive environment detected, aborting to prevent Windows/WSL mismatch."
+    Write-Host "   If codex/gemini will run in native Windows:"
+    Write-Host "   Re-run: powershell -ExecutionPolicy Bypass -File .\install.ps1 install -Yes"
     exit 1
   }
 
   Write-Host ""
   Write-Host "================================================================"
-  Write-Host "⚠️  你正在 Windows 原生环境安装 ccb"
+  Write-Host "⚠️  You are installing ccb in native Windows environment"
   Write-Host "================================================================"
-  Write-Host "ccb/cask-w 必须与 codex/gemini 在同一环境运行。"
+  Write-Host "ccb/cask-w must run in the same environment as codex/gemini."
   Write-Host ""
-  Write-Host "请确认：你将把 codex/gemini 安装并运行在 Windows 原生（而不是 WSL 内）。"
-  Write-Host "如果你计划在 WSL 内运行 codex/gemini，请退出并在 WSL 中运行:"
+  Write-Host "Please confirm: You will install and run codex/gemini in native Windows (not WSL)."
+  Write-Host "If you plan to run codex/gemini in WSL, exit and run in WSL:"
   Write-Host "   ./install.sh install"
   Write-Host "================================================================"
-  $reply = Read-Host "确认继续在 Windows 中安装？(y/N)"
+  $reply = Read-Host "Continue installation in Windows? (y/N)"
   if ($reply.Trim().ToLower() -notin @("y", "yes")) {
-    Write-Host "已取消安装"
+    Write-Host "Installation cancelled"
     exit 1
   }
 }

--- a/install.ps1
+++ b/install.ps1
@@ -9,6 +9,39 @@ param(
 $ErrorActionPreference = "Stop"
 $repoRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
 
+# i18n support
+function Get-CCBLang {
+  $lang = $env:CCB_LANG
+  if ($lang -in @("zh", "cn", "chinese")) { return "zh" }
+  if ($lang -in @("en", "english")) { return "en" }
+  # Auto-detect from system
+  try {
+    $culture = (Get-Culture).Name
+    if ($culture -like "zh*") { return "zh" }
+  } catch {}
+  return "en"
+}
+
+$script:CCBLang = Get-CCBLang
+
+function Get-Msg {
+  param([string]$Key, [string]$Arg1 = "", [string]$Arg2 = "")
+  $msgs = @{
+    "install_complete" = @{ en = "Installation complete"; zh = "安装完成" }
+    "uninstall_complete" = @{ en = "Uninstall complete"; zh = "卸载完成" }
+    "python_old" = @{ en = "Python version too old: $Arg1"; zh = "Python 版本过旧: $Arg1" }
+    "requires_python" = @{ en = "ccb requires Python 3.10+"; zh = "ccb 需要 Python 3.10+" }
+    "confirm_windows" = @{ en = "Continue installation in Windows? (y/N)"; zh = "确认继续在 Windows 中安装？(y/N)" }
+    "cancelled" = @{ en = "Installation cancelled"; zh = "安装已取消" }
+    "windows_warning" = @{ en = "You are installing ccb in native Windows environment"; zh = "你正在 Windows 原生环境安装 ccb" }
+    "same_env" = @{ en = "ccb/cask-w must run in the same environment as codex/gemini."; zh = "ccb/cask-w 必须与 codex/gemini 在同一环境运行。" }
+  }
+  if ($msgs.ContainsKey($Key)) {
+    return $msgs[$Key][$script:CCBLang]
+  }
+  return $Key
+}
+
 function Show-Usage {
   Write-Host "Usage:"
   Write-Host "  .\install.ps1 install    # Install or update"

--- a/install.ps1
+++ b/install.ps1
@@ -38,19 +38,15 @@ function Require-Python310 {
   }
 
   try {
-    $version = & $exe @args -c "import sys; print('{}.{}.{}'.format(sys.version_info[0], sys.version_info[1], sys.version_info[2]))"
+    $vinfo = & $exe @args -c "import sys; v=sys.version_info; print(f'{v.major}.{v.minor}.{v.micro} {v.major} {v.minor}')"
+    $parts = $vinfo.Trim() -split " "
+    $version = $parts[0]
+    $major = [int]$parts[1]
+    $minor = [int]$parts[2]
   } catch {
-    Write-Host "Failed to query Python version using: $PythonCmd"
+    Write-Host "❌ Failed to query Python version using: $PythonCmd"
     exit 1
   }
-
-  $verParts = ($version -split "\\.") | Where-Object { $_ }
-  if ($verParts.Length -lt 2) {
-    Write-Host "❌ Unable to parse Python version: $version"
-    exit 1
-  }
-  $major = [int]$verParts[0]
-  $minor = [int]$verParts[1]
 
   if (($major -ne 3) -or ($minor -lt 10)) {
     Write-Host "❌ Python version too old: $version"

--- a/install.ps1
+++ b/install.ps1
@@ -2,7 +2,8 @@ param(
   [Parameter(Position = 0)]
   [ValidateSet("install", "uninstall", "help")]
   [string]$Command = "help",
-  [string]$InstallPrefix = "$env:LOCALAPPDATA\codex-dual"
+  [string]$InstallPrefix = "$env:LOCALAPPDATA\codex-dual",
+  [switch]$Yes
 )
 
 $ErrorActionPreference = "Stop"
@@ -57,7 +58,36 @@ function Require-Python310 {
   Write-Host "✓ Python $version"
 }
 
+function Confirm-BackendEnv {
+  if ($Yes -or $env:CCB_INSTALL_ASSUME_YES -eq "1") { return }
+
+  if (-not [Environment]::UserInteractive) {
+    Write-Host "❌ 非交互环境下默认中止，避免 Windows/WSL 环境错配。"
+    Write-Host "   若确认 codex/gemini 将在 Windows 原生运行："
+    Write-Host "   重新运行: powershell -ExecutionPolicy Bypass -File .\install.ps1 install -Yes"
+    exit 1
+  }
+
+  Write-Host ""
+  Write-Host "================================================================"
+  Write-Host "⚠️  你正在 Windows 原生环境安装 ccb"
+  Write-Host "================================================================"
+  Write-Host "ccb/cask-w 必须与 codex/gemini 在同一环境运行。"
+  Write-Host ""
+  Write-Host "请确认：你将把 codex/gemini 安装并运行在 Windows 原生（而不是 WSL 内）。"
+  Write-Host "如果你计划在 WSL 内运行 codex/gemini，请退出并在 WSL 中运行:"
+  Write-Host "   ./install.sh install"
+  Write-Host "================================================================"
+  $reply = Read-Host "确认继续在 Windows 中安装？(y/N)"
+  if ($reply.Trim().ToLower() -notin @("y", "yes")) {
+    Write-Host "已取消安装"
+    exit 1
+  }
+}
+
 function Install-Native {
+  Confirm-BackendEnv
+
   $binDir = Join-Path $InstallPrefix "bin"
   $pythonCmd = Find-Python
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,10 +1,22 @@
-param(
+﻿param(
   [Parameter(Position = 0)]
   [ValidateSet("install", "uninstall", "help")]
   [string]$Command = "help",
   [string]$InstallPrefix = "$env:LOCALAPPDATA\codex-dual",
   [switch]$Yes
 )
+
+# --- UTF-8 / BOM compatibility (Windows PowerShell 5.1) ---
+# Keep this near the top so Chinese/emoji output is rendered correctly.
+try {
+  $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+} catch {
+  $utf8NoBom = [System.Text.Encoding]::UTF8
+}
+try { $OutputEncoding = $utf8NoBom } catch {}
+try { [Console]::OutputEncoding = $utf8NoBom } catch {}
+try { [Console]::InputEncoding = $utf8NoBom } catch {}
+try { chcp 65001 | Out-Null } catch {}
 
 $ErrorActionPreference = "Stop"
 $repoRoot = Split-Path -Parent $MyInvocation.MyCommand.Path

--- a/install.sh
+++ b/install.sh
@@ -584,8 +584,8 @@ with open('$claude_md', 'w', encoding='utf-8') as f:
 Codex is another AI assistant running in a separate terminal session (WezTerm, iTerm2 or tmux). When user intent involves asking/consulting/collaborating with Codex:
 
 Fast path (minimize latency):
-- If the user message starts with any of: `调取codex`, `@codex`, `codex:`, `codex：`, `问codex`, `让codex` then immediately run:
-  - `cask-w "<rest of the message after the prefix>"` (no extra analysis, no pre-checks like cping)
+- If the user message starts with any of: `@codex`, `codex:`, `ask codex`, `let codex` then immediately run:
+  - `Bash(cask-w "<message>", run_in_background=true)` (background send, continue immediately)
 - If user message is only the prefix (no content), ask a 1-line clarification for what to send.
 
 Trigger conditions (any match):
@@ -594,23 +594,28 @@ Trigger conditions (any match):
 - User asks about codex's status or previous reply
 
 Command selection:
-- Default ask/collaborate → `cask-w "<question>"` (sync, waits for reply)
-- Send without waiting → `cask "<question>"` (async, returns immediately)
-- Check connectivity → `cping`
-- View previous reply → `cpend`
+- Default ask/collaborate -> `Bash(cask-w "<question>", run_in_background=true)`
+  - Sends in background, returns task_id immediately
+  - Continue with other work, do not wait
+  - Use `TaskOutput(task_id, block=true)` when result is needed
+- Send without waiting -> `cask "<question>"` (async, returns immediately)
+- Check connectivity -> `cping`
+- View previous reply -> `cpend`
+- Get background result -> `TaskOutput(task_id="xxx", block=true)`
 
 Examples:
-- "what does codex think" → cask-w
-- "ask codex to review this" → cask-w
-- "is codex alive" → cping
-- "don't wait for reply" → cask
+- "what does codex think" -> Bash(cask-w, run_in_background=true), then continue
+- "ask codex to review this" -> Bash(cask-w, run_in_background=true), then continue
+- "is codex alive" -> cping
+- "don't wait for reply" -> cask
+- "get codex result" -> TaskOutput(task_id) or cpend
 
 ## Gemini Collaboration Rules
 Gemini is another AI assistant running in a separate terminal session (WezTerm, iTerm2 or tmux). When user intent involves asking/consulting/collaborating with Gemini:
 
 Fast path (minimize latency):
-- If the user message starts with any of: `调取gemini`, `@gemini`, `gemini:`, `gemini：`, `问gemini`, `让gemini` then immediately run:
-  - `gask-w "<rest of the message after the prefix>"` (no extra analysis, no pre-checks like gping)
+- If the user message starts with any of: `@gemini`, `gemini:`, `ask gemini`, `let gemini` then immediately run:
+  - `Bash(gask-w "<message>", run_in_background=true)` (background send, continue immediately)
 - If user message is only the prefix (no content), ask a 1-line clarification for what to send.
 
 Trigger conditions (any match):
@@ -619,16 +624,21 @@ Trigger conditions (any match):
 - User asks about gemini's status or previous reply
 
 Command selection:
-- Default ask/collaborate → `gask-w "<question>"` (sync, waits for reply)
-- Send without waiting → `gask "<question>"` (async, returns immediately)
-- Check connectivity → `gping`
-- View previous reply → `gpend`
+- Default ask/collaborate -> `Bash(gask-w "<question>", run_in_background=true)`
+  - Sends in background, returns task_id immediately
+  - Continue with other work, do not wait
+  - Use `TaskOutput(task_id, block=true)` when result is needed
+- Send without waiting -> `gask "<question>"` (async, returns immediately)
+- Check connectivity -> `gping`
+- View previous reply -> `gpend`
+- Get background result -> `TaskOutput(task_id="xxx", block=true)`
 
 Examples:
-- "what does gemini think" → gask-w
-- "ask gemini to review this" → gask-w
-- "is gemini alive" → gping
-- "don't wait for reply" → gask
+- "what does gemini think" -> Bash(gask-w, run_in_background=true), then continue
+- "ask gemini to review this" -> Bash(gask-w, run_in_background=true), then continue
+- "is gemini alive" -> gping
+- "don't wait for reply" -> gask
+- "get gemini result" -> TaskOutput(task_id) or gpend
 AI_RULES
 
   echo "Updated AI collaboration rules in $claude_md"

--- a/install.sh
+++ b/install.sh
@@ -662,9 +662,9 @@ install_claude_md_config() {
   mkdir -p "$HOME/.claude"
 
   # Use temp file to avoid Bash 3.2 heredoc parsing bug with single quotes
-  local ccb_tmpfile
-  ccb_tmpfile="$(mktemp)"
-  trap 'rm -f "$ccb_tmpfile"' RETURN
+  local ccb_tmpfile=""
+  ccb_tmpfile="$(mktemp)" || { echo "Failed to create temp file"; return 1; }
+  trap 'rm -f "${ccb_tmpfile:-}"' RETURN
   cat > "$ccb_tmpfile" << 'AI_RULES'
 <!-- CCB_CONFIG_START -->
 ## Codex Collaboration Rules

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,81 @@ INSTALL_PREFIX="${CODEX_INSTALL_PREFIX:-$HOME/.local/share/codex-dual}"
 BIN_DIR="${CODEX_BIN_DIR:-$HOME/.local/bin}"
 readonly REPO_ROOT INSTALL_PREFIX BIN_DIR
 
+# i18n support
+detect_lang() {
+  local lang="${CCB_LANG:-auto}"
+  case "$lang" in
+    zh|cn|chinese) echo "zh" ;;
+    en|english) echo "en" ;;
+    *)
+      local sys_lang="${LANG:-${LC_ALL:-${LC_MESSAGES:-}}}"
+      if [[ "$sys_lang" == zh* ]] || [[ "$sys_lang" == *chinese* ]]; then
+        echo "zh"
+      else
+        echo "en"
+      fi
+      ;;
+  esac
+}
+
+CCB_LANG_DETECTED="$(detect_lang)"
+
+# Message function
+msg() {
+  local key="$1"
+  shift
+  local en_msg zh_msg
+  case "$key" in
+    install_complete)
+      en_msg="Installation complete"
+      zh_msg="安装完成" ;;
+    uninstall_complete)
+      en_msg="Uninstall complete"
+      zh_msg="卸载完成" ;;
+    python_version_old)
+      en_msg="Python version too old: $1"
+      zh_msg="Python 版本过旧: $1" ;;
+    requires_python)
+      en_msg="Requires Python 3.10+"
+      zh_msg="需要 Python 3.10+" ;;
+    missing_dep)
+      en_msg="Missing dependency: $1"
+      zh_msg="缺少依赖: $1" ;;
+    detected_env)
+      en_msg="Detected $1 environment"
+      zh_msg="检测到 $1 环境" ;;
+    wsl1_not_supported)
+      en_msg="WSL 1 does not support FIFO pipes, please upgrade to WSL 2"
+      zh_msg="WSL 1 不支持 FIFO 管道，请升级到 WSL 2" ;;
+    confirm_wsl)
+      en_msg="Confirm continue installing in WSL? (y/N)"
+      zh_msg="确认继续在 WSL 中安装？(y/N)" ;;
+    cancelled)
+      en_msg="Installation cancelled"
+      zh_msg="安装已取消" ;;
+    wsl_warning)
+      en_msg="Detected WSL environment"
+      zh_msg="检测到 WSL 环境" ;;
+    same_env_required)
+      en_msg="ccb/cask-w must run in the same environment as codex/gemini."
+      zh_msg="ccb/cask-w 必须与 codex/gemini 在同一环境运行。" ;;
+    confirm_wsl_native)
+      en_msg="Please confirm: you will install and run codex/gemini in WSL (not Windows native)."
+      zh_msg="请确认：你将在 WSL 中安装并运行 codex/gemini（不是 Windows 原生）。" ;;
+    wezterm_recommended)
+      en_msg="Recommend installing WezTerm as terminal frontend"
+      zh_msg="推荐安装 WezTerm 作为终端前端" ;;
+    *)
+      en_msg="$key"
+      zh_msg="$key" ;;
+  esac
+  if [[ "$CCB_LANG_DETECTED" == "zh" ]]; then
+    echo "$zh_msg"
+  else
+    echo "$en_msg"
+  fi
+}
+
 SCRIPTS_TO_LINK=(
   bin/cask
   bin/cask-w

--- a/install.sh
+++ b/install.sh
@@ -636,9 +636,11 @@ install_claude_md_config() {
 ## Codex Collaboration Rules
 Codex is another AI assistant running in a separate terminal session (WezTerm, iTerm2 or tmux). When user intent involves asking/consulting/collaborating with Codex:
 
+**CRITICAL: After sending cask-w, DO NOT perform any additional actions. Stop and wait for user input.**
+
 Fast path (minimize latency):
 - If the user message starts with any of: `@codex`, `codex:`, `ask codex`, `let codex`, `/cask-w` then immediately run:
-  - `Bash(cask-w "<message>", run_in_background=true)` (background send, continue immediately)
+  - `Bash(cask-w "<message>")` then STOP and wait for user
 - If user message is only the prefix (no content), ask a 1-line clarification for what to send.
 
 Trigger conditions (any match):
@@ -647,28 +649,29 @@ Trigger conditions (any match):
 - User asks about codex's status or previous reply
 
 Command selection:
-- Default ask/collaborate -> `Bash(cask-w "<question>", run_in_background=true)`
-  - Sends in background, returns task_id immediately
-  - Continue with other work, do not wait
-  - Use `TaskOutput(task_id, block=true)` when result is needed
-- Send without waiting -> `cask "<question>"` (async, returns immediately)
+- Default ask/collaborate -> `Bash(cask-w "<question>")`
+  - After sending, STOP immediately and wait for user input
+  - Do NOT continue with other work
+- Send without waiting -> `cask "<question>"` (fire and forget)
 - Check connectivity -> `cping`
 - View previous reply -> `cpend`
-- Get background result -> `TaskOutput(task_id="xxx", block=true)`
 
 Examples:
-- "what does codex think" -> Bash(cask-w, run_in_background=true), then continue
-- "ask codex to review this" -> Bash(cask-w, run_in_background=true), then continue
+- "what does codex think" -> `Bash(cask-w "...")`, then STOP
+- "ask codex to review this" -> `Bash(cask-w "...")`, then STOP
+- "codex, help me with X" -> `Bash(cask-w "...")`, then STOP
 - "is codex alive" -> cping
 - "don't wait for reply" -> cask
-- "get codex result" -> TaskOutput(task_id) or cpend
+- "view codex reply" -> cpend
 
 ## Gemini Collaboration Rules
 Gemini is another AI assistant running in a separate terminal session (WezTerm, iTerm2 or tmux). When user intent involves asking/consulting/collaborating with Gemini:
 
+**CRITICAL: After sending gask-w, DO NOT perform any additional actions. Stop and wait for user input.**
+
 Fast path (minimize latency):
 - If the user message starts with any of: `@gemini`, `gemini:`, `ask gemini`, `let gemini`, `/gask-w` then immediately run:
-  - `Bash(gask-w "<message>", run_in_background=true)` (background send, continue immediately)
+  - `Bash(gask-w "<message>")` then STOP and wait for user
 - If user message is only the prefix (no content), ask a 1-line clarification for what to send.
 
 Trigger conditions (any match):
@@ -677,21 +680,20 @@ Trigger conditions (any match):
 - User asks about gemini's status or previous reply
 
 Command selection:
-- Default ask/collaborate -> `Bash(gask-w "<question>", run_in_background=true)`
-  - Sends in background, returns task_id immediately
-  - Continue with other work, do not wait
-  - Use `TaskOutput(task_id, block=true)` when result is needed
-- Send without waiting -> `gask "<question>"` (async, returns immediately)
+- Default ask/collaborate -> `Bash(gask-w "<question>")`
+  - After sending, STOP immediately and wait for user input
+  - Do NOT continue with other work
+- Send without waiting -> `gask "<question>"` (fire and forget)
 - Check connectivity -> `gping`
 - View previous reply -> `gpend`
-- Get background result -> `TaskOutput(task_id="xxx", block=true)`
 
 Examples:
-- "what does gemini think" -> Bash(gask-w, run_in_background=true), then continue
-- "ask gemini to review this" -> Bash(gask-w, run_in_background=true), then continue
+- "what does gemini think" -> `Bash(gask-w "...")`, then STOP
+- "ask gemini to review this" -> `Bash(gask-w "...")`, then STOP
+- "gemini, help me with X" -> `Bash(gask-w "...")`, then STOP
 - "is gemini alive" -> gping
 - "don't wait for reply" -> gask
-- "get gemini result" -> TaskOutput(task_id) or gpend
+- "view gemini reply" -> gpend
 <!-- CCB_CONFIG_END -->
 AI_RULES
 )

--- a/install.sh
+++ b/install.sh
@@ -661,8 +661,11 @@ install_claude_md_config() {
   local claude_md="$HOME/.claude/CLAUDE.md"
   mkdir -p "$HOME/.claude"
 
-  local ccb_content
-  ccb_content=$(cat << 'AI_RULES'
+  # Use temp file to avoid Bash 3.2 heredoc parsing bug with single quotes
+  local ccb_tmpfile
+  ccb_tmpfile="$(mktemp)"
+  trap 'rm -f "$ccb_tmpfile"' RETURN
+  cat > "$ccb_tmpfile" << 'AI_RULES'
 <!-- CCB_CONFIG_START -->
 ## Codex Collaboration Rules
 Codex is another AI assistant running in a separate terminal session (WezTerm, iTerm2 or tmux). When user intent involves asking/consulting/collaborating with Codex:
@@ -721,7 +724,8 @@ Examples:
 - "view gemini reply" -> gpend
 <!-- CCB_CONFIG_END -->
 AI_RULES
-)
+  local ccb_content
+  ccb_content="$(cat "$ccb_tmpfile")"
 
   if [[ -f "$claude_md" ]]; then
     if grep -q "$CCB_START_MARKER" "$claude_md" 2>/dev/null; then

--- a/install.sh
+++ b/install.sh
@@ -667,11 +667,9 @@ install_claude_md_config() {
 ## Codex Collaboration Rules
 Codex is another AI assistant running in a separate terminal session (WezTerm, iTerm2 or tmux). When user intent involves asking/consulting/collaborating with Codex:
 
-**CRITICAL: After sending cask-w, DO NOT perform any additional actions. Stop and wait for user input.**
-
 Fast path (minimize latency):
 - If the user message starts with any of: `@codex`, `codex:`, `ask codex`, `let codex`, `/cask-w` then immediately run:
-  - `Bash(cask-w "<message>")` then STOP and wait for user
+  - `Bash(cask-w "<message>", run_in_background=true)` then STOP and wait for bash-notification
 - If user message is only the prefix (no content), ask a 1-line clarification for what to send.
 
 Trigger conditions (any match):
@@ -680,17 +678,16 @@ Trigger conditions (any match):
 - User asks about codex's status or previous reply
 
 Command selection:
-- Default ask/collaborate -> `Bash(cask-w "<question>")`
-  - After sending, STOP immediately and wait for user input
-  - Do NOT continue with other work
+- Default ask/collaborate -> `Bash(cask-w "<question>", run_in_background=true)`
+  - When bash-notification arrives (task completed), immediately cat the output file to show result
+  - Do NOT continue with other work until result is shown
 - Send without waiting -> `cask "<question>"` (fire and forget)
 - Check connectivity -> `cping`
 - View previous reply -> `cpend`
 
 Examples:
-- "what does codex think" -> `Bash(cask-w "...")`, then STOP
-- "ask codex to review this" -> `Bash(cask-w "...")`, then STOP
-- "codex, help me with X" -> `Bash(cask-w "...")`, then STOP
+- "what does codex think" -> `Bash(cask-w "...", run_in_background=true)`, wait for notification, cat output
+- "ask codex to review this" -> `Bash(cask-w "...", run_in_background=true)`, wait for notification, cat output
 - "is codex alive" -> cping
 - "don't wait for reply" -> cask
 - "view codex reply" -> cpend
@@ -698,11 +695,9 @@ Examples:
 ## Gemini Collaboration Rules
 Gemini is another AI assistant running in a separate terminal session (WezTerm, iTerm2 or tmux). When user intent involves asking/consulting/collaborating with Gemini:
 
-**CRITICAL: After sending gask-w, DO NOT perform any additional actions. Stop and wait for user input.**
-
 Fast path (minimize latency):
 - If the user message starts with any of: `@gemini`, `gemini:`, `ask gemini`, `let gemini`, `/gask-w` then immediately run:
-  - `Bash(gask-w "<message>")` then STOP and wait for user
+  - `Bash(gask-w "<message>", run_in_background=true)` then STOP and wait for bash-notification
 - If user message is only the prefix (no content), ask a 1-line clarification for what to send.
 
 Trigger conditions (any match):
@@ -711,17 +706,16 @@ Trigger conditions (any match):
 - User asks about gemini's status or previous reply
 
 Command selection:
-- Default ask/collaborate -> `Bash(gask-w "<question>")`
-  - After sending, STOP immediately and wait for user input
-  - Do NOT continue with other work
+- Default ask/collaborate -> `Bash(gask-w "<question>", run_in_background=true)`
+  - When bash-notification arrives (task completed), immediately cat the output file to show result
+  - Do NOT continue with other work until result is shown
 - Send without waiting -> `gask "<question>"` (fire and forget)
 - Check connectivity -> `gping`
 - View previous reply -> `gpend`
 
 Examples:
-- "what does gemini think" -> `Bash(gask-w "...")`, then STOP
-- "ask gemini to review this" -> `Bash(gask-w "...")`, then STOP
-- "gemini, help me with X" -> `Bash(gask-w "...")`, then STOP
+- "what does gemini think" -> `Bash(gask-w "...", run_in_background=true)`, wait for notification, cat output
+- "ask gemini to review this" -> `Bash(gask-w "...", run_in_background=true)`, wait for notification, cat output
 - "is gemini alive" -> gping
 - "don't wait for reply" -> gask
 - "view gemini reply" -> gpend

--- a/install.sh
+++ b/install.sh
@@ -637,7 +637,7 @@ install_claude_md_config() {
 Codex is another AI assistant running in a separate terminal session (WezTerm, iTerm2 or tmux). When user intent involves asking/consulting/collaborating with Codex:
 
 Fast path (minimize latency):
-- If the user message starts with any of: `@codex`, `codex:`, `ask codex`, `let codex` then immediately run:
+- If the user message starts with any of: `@codex`, `codex:`, `ask codex`, `let codex`, `/cask-w` then immediately run:
   - `Bash(cask-w "<message>", run_in_background=true)` (background send, continue immediately)
 - If user message is only the prefix (no content), ask a 1-line clarification for what to send.
 
@@ -667,7 +667,7 @@ Examples:
 Gemini is another AI assistant running in a separate terminal session (WezTerm, iTerm2 or tmux). When user intent involves asking/consulting/collaborating with Gemini:
 
 Fast path (minimize latency):
-- If the user message starts with any of: `@gemini`, `gemini:`, `ask gemini`, `let gemini` then immediately run:
+- If the user message starts with any of: `@gemini`, `gemini:`, `ask gemini`, `let gemini`, `/gask-w` then immediately run:
   - `Bash(gask-w "<message>", run_in_background=true)` (background send, continue immediately)
 - If user message is only the prefix (no content), ask a 1-line clarification for what to send.
 

--- a/install.sh
+++ b/install.sh
@@ -136,6 +136,40 @@ check_wsl_compatibility() {
   fi
 }
 
+confirm_backend_env_wsl() {
+  if ! is_wsl; then
+    return
+  fi
+
+  if [[ "${CCB_INSTALL_ASSUME_YES:-}" == "1" ]]; then
+    return
+  fi
+
+  if [[ ! -t 0 ]]; then
+    echo "❌ 当前在 WSL 中安装，但检测到非交互终端；为避免环境错配，已中止。"
+    echo "   如果你确认 codex/gemini 将安装并运行在 WSL："
+    echo "   重新运行: CCB_INSTALL_ASSUME_YES=1 ./install.sh install"
+    exit 1
+  fi
+
+  echo
+  echo "================================================================"
+  echo "⚠️  检测到 WSL 环境"
+  echo "================================================================"
+  echo "ccb/cask-w 必须与 codex/gemini 在同一环境运行。"
+  echo
+  echo "请确认：你将把 codex/gemini 安装并运行在 WSL（而不是 Windows 原生）。"
+  echo "如果你计划在 Windows 原生运行 codex/gemini，请退出并在 Windows 侧运行:"
+  echo "   powershell -ExecutionPolicy Bypass -File .\\install.ps1 install"
+  echo "================================================================"
+  echo
+  read -r -p "确认继续在 WSL 中安装？(y/N): " reply
+  case "$reply" in
+    y|Y|yes|YES) ;;
+    *) echo "已取消安装"; exit 1 ;;
+  esac
+}
+
 print_tmux_install_hint() {
   local platform
   platform="$(detect_platform)"
@@ -668,6 +702,7 @@ with open('$settings_file', 'w') as f:
 
 install_requirements() {
   check_wsl_compatibility
+  confirm_backend_env_wsl
   require_command python3 python3
   require_python_version
   require_terminal_backend

--- a/install.sh
+++ b/install.sh
@@ -893,13 +893,20 @@ uninstall_all() {
   done
   echo "已移除 bin 链接: $BIN_DIR"
 
-  # 3. 移除 Claude 命令文件
-  local claude_dir
-  claude_dir="$(detect_claude_dir)"
-  for doc in "${CLAUDE_MARKDOWN[@]}"; do
-    rm -f "$claude_dir/$doc"
+  # 3. 移除 Claude 命令文件（清理所有可能的位置）
+  local cmd_dirs=(
+    "$HOME/.claude/commands"
+    "$HOME/.config/claude/commands"
+    "$HOME/.local/share/claude/commands"
+  )
+  for dir in "${cmd_dirs[@]}"; do
+    if [[ -d "$dir" ]]; then
+      for doc in "${CLAUDE_MARKDOWN[@]}"; do
+        rm -f "$dir/$doc"
+      done
+      echo "已清理命令目录: $dir"
+    fi
   done
-  echo "已移除 Claude 命令: $claude_dir"
 
   # 4. 移除 CLAUDE.md 中的协作规则
   uninstall_claude_md_config

--- a/install.sh
+++ b/install.sh
@@ -524,6 +524,18 @@ copy_project() {
   mkdir -p "$(dirname "$INSTALL_PREFIX")"
   mv "$staging" "$INSTALL_PREFIX"
   trap - EXIT
+
+  # Update GIT_COMMIT and GIT_DATE in ccb file
+  if command -v git >/dev/null 2>&1 && [[ -d "$REPO_ROOT/.git" ]]; then
+    local git_commit git_date
+    git_commit=$(git -C "$REPO_ROOT" log -1 --format='%h' 2>/dev/null || echo "")
+    git_date=$(git -C "$REPO_ROOT" log -1 --format='%cs' 2>/dev/null || echo "")
+    if [[ -n "$git_commit" && -f "$INSTALL_PREFIX/ccb" ]]; then
+      sed -i.bak "s/^GIT_COMMIT = .*/GIT_COMMIT = \"$git_commit\"/" "$INSTALL_PREFIX/ccb"
+      sed -i.bak "s/^GIT_DATE = .*/GIT_DATE = \"$git_date\"/" "$INSTALL_PREFIX/ccb"
+      rm -f "$INSTALL_PREFIX/ccb.bak"
+    fi
+  fi
 }
 
 install_bin_links() {

--- a/lib/ccb_config.py
+++ b/lib/ccb_config.py
@@ -1,0 +1,83 @@
+"""CCB configuration for Windows/WSL backend environment"""
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def get_backend_env() -> str | None:
+    """Get BackendEnv from env var or .ccb-config.json"""
+    v = (os.environ.get("CCB_BACKEND_ENV") or "").strip().lower()
+    if v in {"wsl", "windows"}:
+        return v
+    path = Path.cwd() / ".ccb-config.json"
+    if path.exists():
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            v = (data.get("BackendEnv") or "").strip().lower()
+            if v in {"wsl", "windows"}:
+                return v
+        except Exception:
+            pass
+    return "windows" if sys.platform == "win32" else None
+
+
+def _wsl_probe_distro_and_home() -> tuple[str, str]:
+    """Probe default WSL distro and home directory"""
+    try:
+        r = subprocess.run(
+            ["wsl.exe", "-e", "sh", "-lc", "echo $WSL_DISTRO_NAME; echo $HOME"],
+            capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=10
+        )
+        if r.returncode == 0:
+            lines = r.stdout.strip().split("\n")
+            if len(lines) >= 2:
+                return lines[0].strip(), lines[1].strip()
+    except Exception:
+        pass
+    try:
+        r = subprocess.run(
+            ["wsl.exe", "-l", "-q"],
+            capture_output=True, text=True, encoding="utf-16-le", errors="replace", timeout=5
+        )
+        if r.returncode == 0:
+            for line in r.stdout.strip().split("\n"):
+                distro = line.strip().strip("\x00")
+                if distro:
+                    break
+            else:
+                distro = "Ubuntu"
+        else:
+            distro = "Ubuntu"
+    except Exception:
+        distro = "Ubuntu"
+    try:
+        r = subprocess.run(
+            ["wsl.exe", "-d", distro, "-e", "sh", "-lc", "echo $HOME"],
+            capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=5
+        )
+        home = r.stdout.strip() if r.returncode == 0 else "/root"
+    except Exception:
+        home = "/root"
+    return distro, home
+
+
+def apply_backend_env() -> None:
+    """Apply BackendEnv=wsl settings (set session root paths for Windows to access WSL)"""
+    if sys.platform != "win32" or get_backend_env() != "wsl":
+        return
+    if os.environ.get("CODEX_SESSION_ROOT") and os.environ.get("GEMINI_ROOT"):
+        return
+    distro, home = _wsl_probe_distro_and_home()
+    for base in (fr"\\wsl.localhost\{distro}", fr"\\wsl$\{distro}"):
+        prefix = base + home.replace("/", "\\")
+        codex_path = prefix + r"\.codex\sessions"
+        gemini_path = prefix + r"\.gemini\tmp"
+        if Path(codex_path).exists() or Path(gemini_path).exists():
+            os.environ.setdefault("CODEX_SESSION_ROOT", codex_path)
+            os.environ.setdefault("GEMINI_ROOT", gemini_path)
+            return
+    prefix = fr"\\wsl.localhost\{distro}" + home.replace("/", "\\")
+    os.environ.setdefault("CODEX_SESSION_ROOT", prefix + r"\.codex\sessions")
+    os.environ.setdefault("GEMINI_ROOT", prefix + r"\.gemini\tmp")

--- a/lib/codex_comm.py
+++ b/lib/codex_comm.py
@@ -543,7 +543,13 @@ class CodexCommunicator:
                 with tmp_file.open("w", encoding="utf-8") as handle:
                     json.dump(data, handle, ensure_ascii=False, indent=2)
                 os.replace(tmp_file, project_file)
-            except Exception:
+            except PermissionError as e:
+                print(f"⚠️  无法更新 {project_file.name}: {e}", file=sys.stderr)
+                print(f"💡 尝试: sudo chown $USER:$USER {project_file}", file=sys.stderr)
+                if tmp_file.exists():
+                    tmp_file.unlink(missing_ok=True)
+            except Exception as e:
+                print(f"⚠️  更新 {project_file.name} 失败: {e}", file=sys.stderr)
                 if tmp_file.exists():
                     tmp_file.unlink(missing_ok=True)
 

--- a/lib/codex_comm.py
+++ b/lib/codex_comm.py
@@ -17,6 +17,7 @@ from typing import Optional, Tuple, Dict, Any
 
 from terminal import get_backend_for_session, get_pane_id_from_session
 from ccb_config import apply_backend_env
+from i18n import t
 
 apply_backend_env()
 
@@ -412,11 +413,11 @@ class CodexCommunicator:
             if not healthy:
                 raise RuntimeError(f"❌ Session error: {status}")
 
-            print("🔔 Sending question to Codex...")
+            print(f"🔔 {t('sending_to', provider='Codex')}")
             marker, state = self._send_message(question)
             wait_timeout = self.timeout if timeout is None else int(timeout)
             if wait_timeout == 0:
-                print("⏳ Waiting for Codex reply (no timeout, Ctrl-C to interrupt)...")
+                print(f"⏳ {t('waiting_for_reply', provider='Codex')}")
                 start_time = time.time()
                 last_hint = 0
                 while True:
@@ -427,7 +428,7 @@ class CodexCommunicator:
                         log_hint = self.log_reader.current_log_path()
                     self._remember_codex_session(log_hint)
                     if message:
-                        print("🤖 Codex reply:")
+                        print(f"🤖 {t('reply_from', provider='Codex')}")
                         print(message)
                         return message
                     elapsed = int(time.time() - start_time)
@@ -442,11 +443,11 @@ class CodexCommunicator:
                 log_hint = self.log_reader.current_log_path()
             self._remember_codex_session(log_hint)
             if message:
-                print("🤖 Codex reply:")
+                print(f"🤖 {t('reply_from', provider='Codex')}")
                 print(message)
                 return message
 
-            print("⏰ Codex did not reply in time. Use /cpend later to get the latest answer")
+            print(f"⏰ {t('timeout_no_reply', provider='Codex')}")
             return None
         except Exception as exc:
             print(f"❌ Sync ask failed: {exc}")
@@ -460,7 +461,7 @@ class CodexCommunicator:
             self._remember_codex_session(self.log_reader.current_log_path())
         if not message:
             if display:
-                print("No Codex reply available")
+                print(t('no_reply_available', provider='Codex'))
             return None
         if display:
             print(message)

--- a/lib/codex_comm.py
+++ b/lib/codex_comm.py
@@ -413,11 +413,11 @@ class CodexCommunicator:
             if not healthy:
                 raise RuntimeError(f"❌ Session error: {status}")
 
-            print(f"🔔 {t('sending_to', provider='Codex')}")
+            print(f"🔔 {t('sending_to', provider='Codex')}", flush=True)
             marker, state = self._send_message(question)
             wait_timeout = self.timeout if timeout is None else int(timeout)
             if wait_timeout == 0:
-                print(f"⏳ {t('waiting_for_reply', provider='Codex')}")
+                print(f"⏳ {t('waiting_for_reply', provider='Codex')}", flush=True)
                 start_time = time.time()
                 last_hint = 0
                 while True:

--- a/lib/codex_comm.py
+++ b/lib/codex_comm.py
@@ -199,7 +199,7 @@ class CodexLogReader:
                         offset = 0
                     if not block:
                         return None, {"log_path": current_path, "offset": offset}
-                    time.sleep(0.05)
+                    time.sleep(self._poll_interval)
                     last_rescan = time.time()
                     continue
                 last_rescan = time.time()
@@ -338,6 +338,19 @@ class CodexCommunicator:
                 os.kill(codex_pid, 0)
             except OSError:
                 return False, f"Codex进程(PID:{codex_pid})已退出"
+
+            bridge_pid_file = self.runtime_dir / "bridge.pid"
+            if not bridge_pid_file.exists():
+                return False, "Bridge进程PID文件不存在"
+            try:
+                with bridge_pid_file.open("r", encoding="utf-8") as handle:
+                    bridge_pid = int(handle.read().strip())
+            except Exception:
+                return False, "Bridge进程PID读取失败"
+            try:
+                os.kill(bridge_pid, 0)
+            except OSError:
+                return False, f"Bridge进程(PID:{bridge_pid})已退出"
 
             if not self.input_fifo.exists():
                 return False, "通信管道不存在"

--- a/lib/codex_comm.py
+++ b/lib/codex_comm.py
@@ -16,6 +16,9 @@ from pathlib import Path
 from typing import Optional, Tuple, Dict, Any
 
 from terminal import get_backend_for_session, get_pane_id_from_session
+from ccb_config import apply_backend_env
+
+apply_backend_env()
 
 SESSION_ROOT = Path(os.environ.get("CODEX_SESSION_ROOT") or (Path.home() / ".codex" / "sessions")).expanduser()
 SESSION_ID_PATTERN = re.compile(

--- a/lib/codex_comm.py
+++ b/lib/codex_comm.py
@@ -239,11 +239,10 @@ class CodexLogReader:
                 if latest and latest != log_path:
                     current_path = latest
                     self._preferred_log = latest
-                    # When switching to a new log file, start from EOF to avoid replaying old content.
-                    try:
-                        offset = latest.stat().st_size
-                    except OSError:
-                        offset = 0
+                    # When switching to a new log file (session rotation / new session),
+                    # start from the beginning to avoid missing a reply that was already written
+                    # before we noticed the new file.
+                    offset = 0
                     if not block:
                         return None, {"log_path": current_path, "offset": offset}
                     time.sleep(self._poll_interval)

--- a/lib/codex_comm.py
+++ b/lib/codex_comm.py
@@ -350,7 +350,7 @@ class CodexCommunicator:
             return None
 
         try:
-            with open(project_session, "r", encoding="utf-8") as f:
+            with open(project_session, "r", encoding="utf-8-sig") as f:
                 data = json.load(f)
 
             if not isinstance(data, dict):
@@ -573,7 +573,7 @@ class CodexCommunicator:
         if not project_file.exists():
             return
         try:
-            with project_file.open("r", encoding="utf-8") as handle:
+            with project_file.open("r", encoding="utf-8-sig") as handle:
                 data = json.load(handle)
         except Exception:
             return

--- a/lib/codex_comm.py
+++ b/lib/codex_comm.py
@@ -64,8 +64,6 @@ class CodexLogReader:
             latest_mtime = -1.0
             for p in (p for p in self.root.glob("**/*.jsonl") if p.is_file()):
                 try:
-                    if self._session_id_filter and self._session_id_filter not in p.name:
-                        continue
                     mtime = p.stat().st_mtime
                 except OSError:
                     continue

--- a/lib/codex_dual_bridge.py
+++ b/lib/codex_dual_bridge.py
@@ -46,17 +46,6 @@ class DualBridge:
 
         terminal_type = os.environ.get("CODEX_TERMINAL", "tmux")
         pane_id = os.environ.get("CODEX_WEZTERM_PANE") if terminal_type == "wezterm" else os.environ.get("CODEX_TMUX_SESSION")
-        
-        # If pane_id not in env, try to read from .codex-session file
-        if not pane_id and terminal_type == "tmux":
-            session_file = Path.cwd() / ".codex-session"
-            if session_file.exists():
-                try:
-                    data = json.loads(session_file.read_text())
-                    pane_id = data.get("tmux_session")
-                except Exception:
-                    pass
-        
         if not pane_id:
             raise RuntimeError(f"缺少 {'CODEX_WEZTERM_PANE' if terminal_type == 'wezterm' else 'CODEX_TMUX_SESSION'} 环境变量")
 

--- a/lib/compat.py
+++ b/lib/compat.py
@@ -1,0 +1,9 @@
+"""Windows compatibility utilities"""
+import sys
+
+def setup_windows_encoding():
+    """Configure UTF-8 encoding for Windows console"""
+    if sys.platform == "win32":
+        import io
+        sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8', errors='replace')
+        sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf-8', errors='replace')

--- a/lib/gemini_comm.py
+++ b/lib/gemini_comm.py
@@ -554,7 +554,16 @@ class GeminiCommunicator:
             with tmp_file.open("w", encoding="utf-8") as handle:
                 json.dump(data, handle, ensure_ascii=False, indent=2)
             os.replace(tmp_file, project_file)
-        except Exception:
+        except PermissionError as e:
+            print(f"⚠️  无法更新 {project_file.name}: {e}", file=sys.stderr)
+            print(f"💡 尝试: sudo chown $USER:$USER {project_file}", file=sys.stderr)
+            try:
+                if tmp_file.exists():
+                    tmp_file.unlink(missing_ok=True)
+            except Exception:
+                pass
+        except Exception as e:
+            print(f"⚠️  更新 {project_file.name} 失败: {e}", file=sys.stderr)
             try:
                 if tmp_file.exists():
                     tmp_file.unlink(missing_ok=True)

--- a/lib/gemini_comm.py
+++ b/lib/gemini_comm.py
@@ -455,14 +455,14 @@ class GeminiCommunicator:
             if not healthy:
                 raise RuntimeError(f"❌ Session error: {status}")
 
-            print(f"🔔 {t('sending_to', provider='Gemini')}")
+            print(f"🔔 {t('sending_to', provider='Gemini')}", flush=True)
             self._send_via_terminal(question)
             # Capture state after sending to reduce "question → send" latency.
             state = self.log_reader.capture_state()
 
             wait_timeout = self.timeout if timeout is None else int(timeout)
             if wait_timeout == 0:
-                print(f"⏳ {t('waiting_for_reply', provider='Gemini')}")
+                print(f"⏳ {t('waiting_for_reply', provider='Gemini')}", flush=True)
                 start_time = time.time()
                 last_hint = 0
                 while True:

--- a/lib/gemini_comm.py
+++ b/lib/gemini_comm.py
@@ -15,6 +15,7 @@ from typing import Optional, Tuple, Dict, Any
 
 from terminal import get_backend_for_session, get_pane_id_from_session
 from ccb_config import apply_backend_env
+from i18n import t
 
 apply_backend_env()
 
@@ -454,14 +455,14 @@ class GeminiCommunicator:
             if not healthy:
                 raise RuntimeError(f"❌ Session error: {status}")
 
-            print("🔔 Sending question to Gemini...")
+            print(f"🔔 {t('sending_to', provider='Gemini')}")
             self._send_via_terminal(question)
             # Capture state after sending to reduce "question → send" latency.
             state = self.log_reader.capture_state()
 
             wait_timeout = self.timeout if timeout is None else int(timeout)
             if wait_timeout == 0:
-                print("⏳ Waiting for Gemini reply (no timeout, Ctrl-C to interrupt)...")
+                print(f"⏳ {t('waiting_for_reply', provider='Gemini')}")
                 start_time = time.time()
                 last_hint = 0
                 while True:
@@ -471,7 +472,7 @@ class GeminiCommunicator:
                     if isinstance(session_path, Path):
                         self._remember_gemini_session(session_path)
                     if message:
-                        print("🤖 Gemini reply:")
+                        print(f"🤖 {t('reply_from', provider='Gemini')}")
                         print(message)
                         return message
                     elapsed = int(time.time() - start_time)
@@ -485,11 +486,11 @@ class GeminiCommunicator:
             if isinstance(session_path, Path):
                 self._remember_gemini_session(session_path)
             if message:
-                print("🤖 Gemini reply:")
+                print(f"🤖 {t('reply_from', provider='Gemini')}")
                 print(message)
                 return message
 
-            print("⏰ Gemini did not reply in time, run gpend later to get the answer")
+            print(f"⏰ {t('timeout_no_reply', provider='Gemini')}")
             return None
         except Exception as exc:
             print(f"❌ Sync ask failed: {exc}")
@@ -502,7 +503,7 @@ class GeminiCommunicator:
         message = self.log_reader.latest_message()
         if not message:
             if display:
-                print("No Gemini reply yet")
+                print(t('no_reply_available', provider='Gemini'))
             return None
         if display:
             print(message)

--- a/lib/gemini_comm.py
+++ b/lib/gemini_comm.py
@@ -14,6 +14,9 @@ from pathlib import Path
 from typing import Optional, Tuple, Dict, Any
 
 from terminal import get_backend_for_session, get_pane_id_from_session
+from ccb_config import apply_backend_env
+
+apply_backend_env()
 
 GEMINI_ROOT = Path(os.environ.get("GEMINI_ROOT") or (Path.home() / ".gemini" / "tmp")).expanduser()
 

--- a/lib/i18n.py
+++ b/lib/i18n.py
@@ -1,0 +1,245 @@
+"""
+i18n - Internationalization support for CCB
+
+Language detection priority:
+1. CCB_LANG environment variable (zh/en/auto)
+2. System locale (LANG/LC_ALL/LC_MESSAGES)
+3. Default to English
+"""
+
+import os
+import locale
+
+_current_lang = None
+
+MESSAGES = {
+    "en": {
+        # Terminal detection
+        "no_terminal_backend": "No terminal backend detected (WezTerm or tmux)",
+        "solutions": "Solutions:",
+        "install_wezterm": "Install WezTerm (recommended): https://wezfurlong.org/wezterm/",
+        "or_install_tmux": "Or install tmux",
+        "or_set_ccb_terminal": "Or set CCB_TERMINAL=wezterm and configure CODEX_WEZTERM_BIN",
+        "tmux_not_installed": "tmux not installed and WezTerm unavailable",
+        "install_wezterm_or_tmux": "Solution: Install WezTerm (recommended) or tmux",
+
+        # Startup messages
+        "starting_backend": "Starting {provider} backend ({terminal})...",
+        "started_backend": "{provider} started ({terminal}: {pane_id})",
+        "unknown_provider": "Unknown provider: {provider}",
+        "resuming_session": "Resuming {provider} session: {session_id}...",
+        "no_history_fresh": "No {provider} history found, starting fresh",
+        "warmup": "Warmup: {script}",
+        "warmup_failed": "Warmup failed: {provider}",
+
+        # Claude
+        "starting_claude": "Starting Claude...",
+        "resuming_claude": "Resuming Claude session: {session_id}...",
+        "no_claude_session": "No local Claude session found, starting fresh",
+        "session_id": "Session ID: {session_id}",
+        "runtime_dir": "Runtime dir: {runtime_dir}",
+        "active_backends": "Active backends: {backends}",
+        "available_commands": "Available commands:",
+        "codex_commands": "cask/cask-w/cping/cpend - Codex communication",
+        "gemini_commands": "gask/gask-w/gping/gpend - Gemini communication",
+        "executing": "Executing: {cmd}",
+        "user_interrupted": "User interrupted",
+        "cleaning_up": "Cleaning up session resources...",
+        "cleanup_complete": "Cleanup complete",
+
+        # Banner
+        "banner_title": "Claude Code Bridge {version}",
+        "banner_date": "{date}",
+        "banner_backends": "Backends: {backends}",
+
+        # No-claude mode
+        "backends_started_no_claude": "Backends started (--no-claude mode)",
+        "switch_to_pane": "Switch to pane:",
+        "kill_hint": "Kill: ccb kill {providers}",
+
+        # Status
+        "backend_status": "AI backend status:",
+
+        # Errors
+        "cannot_write_session": "Cannot write {filename}: {reason}",
+        "fix_hint": "Fix: {fix}",
+        "error": "Error",
+        "execution_failed": "Execution failed: {error}",
+        "import_failed": "Import failed: {error}",
+        "module_import_failed": "Module import failed: {error}",
+
+        # Connectivity
+        "connectivity_test_failed": "{provider} connectivity test failed: {error}",
+        "no_reply_available": "No {provider} reply available",
+
+        # Commands
+        "usage": "Usage: {cmd}",
+        "sending_to": "Sending question to {provider}...",
+        "waiting_for_reply": "Waiting for {provider} reply (no timeout, Ctrl-C to interrupt)...",
+        "reply_from": "{provider} reply:",
+        "timeout_no_reply": "Timeout: no reply from {provider}",
+        "session_not_found": "No active {provider} session found",
+
+        # Install messages
+        "install_complete": "Installation complete",
+        "uninstall_complete": "Uninstall complete",
+        "python_version_old": "Python version too old: {version}",
+        "requires_python": "Requires Python 3.10+",
+        "missing_dependency": "Missing dependency: {dep}",
+        "detected_env": "Detected {env} environment",
+        "wsl_not_supported": "WSL 1 does not support FIFO pipes, please upgrade to WSL 2",
+        "confirm_continue": "Confirm continue? (y/N)",
+        "cancelled": "Cancelled",
+    },
+    "zh": {
+        # Terminal detection
+        "no_terminal_backend": "未检测到终端后端 (WezTerm 或 tmux)",
+        "solutions": "解决方案：",
+        "install_wezterm": "安装 WezTerm (推荐): https://wezfurlong.org/wezterm/",
+        "or_install_tmux": "或安装 tmux",
+        "or_set_ccb_terminal": "或设置 CCB_TERMINAL=wezterm 并配置 CODEX_WEZTERM_BIN",
+        "tmux_not_installed": "tmux 未安装且 WezTerm 不可用",
+        "install_wezterm_or_tmux": "解决方案：安装 WezTerm (推荐) 或 tmux",
+
+        # Startup messages
+        "starting_backend": "正在启动 {provider} 后端 ({terminal})...",
+        "started_backend": "{provider} 已启动 ({terminal}: {pane_id})",
+        "unknown_provider": "未知提供者: {provider}",
+        "resuming_session": "正在恢复 {provider} 会话: {session_id}...",
+        "no_history_fresh": "未找到 {provider} 历史记录，全新启动",
+        "warmup": "预热: {script}",
+        "warmup_failed": "预热失败: {provider}",
+
+        # Claude
+        "starting_claude": "正在启动 Claude...",
+        "resuming_claude": "正在恢复 Claude 会话: {session_id}...",
+        "no_claude_session": "未找到本地 Claude 会话，全新启动",
+        "session_id": "会话 ID: {session_id}",
+        "runtime_dir": "运行目录: {runtime_dir}",
+        "active_backends": "活动后端: {backends}",
+        "available_commands": "可用命令：",
+        "codex_commands": "cask/cask-w/cping/cpend - Codex 通信",
+        "gemini_commands": "gask/gask-w/gping/gpend - Gemini 通信",
+        "executing": "执行: {cmd}",
+        "user_interrupted": "用户中断",
+        "cleaning_up": "正在清理会话资源...",
+        "cleanup_complete": "清理完成",
+
+        # Banner
+        "banner_title": "Claude Code Bridge {version}",
+        "banner_date": "{date}",
+        "banner_backends": "后端: {backends}",
+
+        # No-claude mode
+        "backends_started_no_claude": "后端已启动 (--no-claude 模式)",
+        "switch_to_pane": "切换到面板:",
+        "kill_hint": "终止: ccb kill {providers}",
+
+        # Status
+        "backend_status": "AI 后端状态:",
+
+        # Errors
+        "cannot_write_session": "无法写入 {filename}: {reason}",
+        "fix_hint": "修复: {fix}",
+        "error": "错误",
+        "execution_failed": "执行失败: {error}",
+        "import_failed": "导入失败: {error}",
+        "module_import_failed": "模块导入失败: {error}",
+
+        # Connectivity
+        "connectivity_test_failed": "{provider} 连通性测试失败: {error}",
+        "no_reply_available": "暂无 {provider} 回复",
+
+        # Commands
+        "usage": "用法: {cmd}",
+        "sending_to": "正在发送问题到 {provider}...",
+        "waiting_for_reply": "等待 {provider} 回复 (无超时，Ctrl-C 中断)...",
+        "reply_from": "{provider} 回复:",
+        "timeout_no_reply": "超时: 未收到 {provider} 回复",
+        "session_not_found": "未找到活动的 {provider} 会话",
+
+        # Install messages
+        "install_complete": "安装完成",
+        "uninstall_complete": "卸载完成",
+        "python_version_old": "Python 版本过旧: {version}",
+        "requires_python": "需要 Python 3.10+",
+        "missing_dependency": "缺少依赖: {dep}",
+        "detected_env": "检测到 {env} 环境",
+        "wsl_not_supported": "WSL 1 不支持 FIFO 管道，请升级到 WSL 2",
+        "confirm_continue": "确认继续？(y/N)",
+        "cancelled": "已取消",
+    },
+}
+
+
+def detect_language() -> str:
+    """Detect language from environment.
+
+    Priority:
+    1. CCB_LANG environment variable (zh/en/auto)
+    2. System locale
+    3. Default to English
+    """
+    ccb_lang = os.environ.get("CCB_LANG", "auto").lower()
+
+    if ccb_lang in ("zh", "cn", "chinese"):
+        return "zh"
+    if ccb_lang in ("en", "english"):
+        return "en"
+
+    # Auto-detect from system locale
+    try:
+        lang = os.environ.get("LANG", "") or os.environ.get("LC_ALL", "") or os.environ.get("LC_MESSAGES", "")
+        if not lang:
+            lang, _ = locale.getdefaultlocale()
+            lang = lang or ""
+
+        lang = lang.lower()
+        if lang.startswith("zh") or "chinese" in lang:
+            return "zh"
+    except Exception:
+        pass
+
+    return "en"
+
+
+def get_lang() -> str:
+    """Get current language setting."""
+    global _current_lang
+    if _current_lang is None:
+        _current_lang = detect_language()
+    return _current_lang
+
+
+def set_lang(lang: str) -> None:
+    """Set language explicitly."""
+    global _current_lang
+    if lang in ("zh", "en"):
+        _current_lang = lang
+
+
+def t(key: str, **kwargs) -> str:
+    """Get translated message by key.
+
+    Args:
+        key: Message key
+        **kwargs: Format arguments
+
+    Returns:
+        Translated and formatted message
+    """
+    lang = get_lang()
+    messages = MESSAGES.get(lang, MESSAGES["en"])
+
+    msg = messages.get(key)
+    if msg is None:
+        # Fallback to English
+        msg = MESSAGES["en"].get(key, key)
+
+    if kwargs:
+        try:
+            msg = msg.format(**kwargs)
+        except (KeyError, ValueError):
+            pass
+
+    return msg

--- a/lib/session_utils.py
+++ b/lib/session_utils.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""
+session_utils.py - Session 文件权限检查工具
+"""
+from __future__ import annotations
+import os
+import stat
+from pathlib import Path
+from typing import Tuple, Optional
+
+
+def check_session_writable(session_file: Path) -> Tuple[bool, Optional[str], Optional[str]]:
+    """
+    检查 session 文件是否可写
+
+    Returns:
+        (可写, 错误原因, 解决建议)
+    """
+    session_file = Path(session_file)
+    parent = session_file.parent
+
+    # 1. 检查父目录是否存在且可进入
+    if not parent.exists():
+        return False, f"目录不存在: {parent}", f"mkdir -p {parent}"
+
+    if not os.access(parent, os.X_OK):
+        return False, f"目录无法访问(缺少x权限): {parent}", f"chmod +x {parent}"
+
+    # 2. 检查父目录是否可写
+    if not os.access(parent, os.W_OK):
+        return False, f"目录不可写: {parent}", f"chmod u+w {parent}"
+
+    # 3. 如果文件不存在，目录可写就行
+    if not session_file.exists():
+        return True, None, None
+
+    # 4. 检查是否是普通文件
+    if session_file.is_symlink():
+        target = session_file.resolve()
+        return False, f"是符号链接指向 {target}", f"rm -f {session_file}"
+
+    if session_file.is_dir():
+        return False, "是目录而非文件", f"rmdir {session_file} 或 rm -rf {session_file}"
+
+    if not session_file.is_file():
+        return False, "不是普通文件", f"rm -f {session_file}"
+
+    # 5. 检查文件归属
+    try:
+        file_stat = session_file.stat()
+        file_uid = file_stat.st_uid
+        current_uid = os.getuid()
+
+        if file_uid != current_uid:
+            import pwd
+            try:
+                owner_name = pwd.getpwuid(file_uid).pw_name
+            except KeyError:
+                owner_name = str(file_uid)
+            current_name = pwd.getpwuid(current_uid).pw_name
+            return False, f"文件归属为 {owner_name} (当前用户: {current_name})", \
+                   f"sudo chown {current_name}:{current_name} {session_file}"
+    except Exception:
+        pass
+
+    # 6. 检查文件是否可写
+    if not os.access(session_file, os.W_OK):
+        mode = stat.filemode(session_file.stat().st_mode)
+        return False, f"文件不可写 (权限: {mode})", f"chmod u+w {session_file}"
+
+    return True, None, None
+
+
+def safe_write_session(session_file: Path, content: str) -> Tuple[bool, Optional[str]]:
+    """
+    安全写入 session 文件，失败时返回友好错误
+
+    Returns:
+        (成功, 错误信息)
+    """
+    session_file = Path(session_file)
+
+    # 预检查
+    writable, reason, fix = check_session_writable(session_file)
+    if not writable:
+        return False, f"❌ 无法写入 {session_file.name}: {reason}\n💡 解决方案: {fix}"
+
+    # 尝试原子写入
+    tmp_file = session_file.with_suffix(".tmp")
+    try:
+        tmp_file.write_text(content, encoding="utf-8")
+        os.replace(tmp_file, session_file)
+        return True, None
+    except PermissionError as e:
+        if tmp_file.exists():
+            try:
+                tmp_file.unlink()
+            except Exception:
+                pass
+        return False, f"❌ 无法写入 {session_file.name}: {e}\n💡 尝试: rm -f {session_file} 后重试"
+    except Exception as e:
+        if tmp_file.exists():
+            try:
+                tmp_file.unlink()
+            except Exception:
+                pass
+        return False, f"❌ 写入失败: {e}"
+
+
+def print_session_error(msg: str, to_stderr: bool = True) -> None:
+    """输出 session 相关错误"""
+    import sys
+    output = sys.stderr if to_stderr else sys.stdout
+    print(msg, file=output)

--- a/lib/terminal.py
+++ b/lib/terminal.py
@@ -364,8 +364,11 @@ class WeztermBackend(TerminalBackend):
                 args.extend(["--pane-id", parent_pane])
             shell, flag = _default_shell()
             args.extend(["--", shell, flag, cmd])
-        result = subprocess.run(args, capture_output=True, text=True, check=True)
-        return result.stdout.strip()
+        try:
+            result = subprocess.run(args, capture_output=True, text=True, check=True)
+            return result.stdout.strip()
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(f"WezTerm split-pane failed:\nCommand: {' '.join(args)}\nStderr: {e.stderr}") from e
 
 
 _backend_cache: Optional[TerminalBackend] = None

--- a/lib/terminal.py
+++ b/lib/terminal.py
@@ -207,7 +207,7 @@ class Iterm2Backend(TerminalBackend):
         try:
             result = subprocess.run(
                 [self._bin(), "session", "list", "--json"],
-                capture_output=True, text=True
+                capture_output=True, text=True, encoding='utf-8', errors='replace'
             )
             if result.returncode != 0:
                 return False
@@ -234,7 +234,7 @@ class Iterm2Backend(TerminalBackend):
         if parent_pane:
             args.extend(["--session", parent_pane])
 
-        result = subprocess.run(args, capture_output=True, text=True, check=True)
+        result = subprocess.run(args, capture_output=True, text=True, encoding='utf-8', errors='replace', check=True)
         # it2 output format: "Created new pane: <session_id>"
         output = result.stdout.strip()
         if ":" in output:
@@ -313,7 +313,7 @@ class WeztermBackend(TerminalBackend):
 
     def is_alive(self, pane_id: str) -> bool:
         try:
-            result = subprocess.run([*self._cli_base_args(), "list", "--format", "json"], capture_output=True, text=True)
+            result = subprocess.run([*self._cli_base_args(), "list", "--format", "json"], capture_output=True, text=True, encoding='utf-8', errors='replace')
             if result.returncode != 0:
                 return False
             panes = json.loads(result.stdout)
@@ -368,7 +368,7 @@ class WeztermBackend(TerminalBackend):
             shell, flag = _default_shell()
             args.extend(["--", shell, flag, cmd])
         try:
-            result = subprocess.run(args, capture_output=True, text=True, check=True)
+            result = subprocess.run(args, capture_output=True, text=True, encoding='utf-8', errors='replace', check=True)
             return result.stdout.strip()
         except subprocess.CalledProcessError as e:
             raise RuntimeError(f"WezTerm split-pane failed:\nCommand: {' '.join(args)}\nStderr: {e.stderr}") from e

--- a/lib/terminal.py
+++ b/lib/terminal.py
@@ -133,7 +133,7 @@ class TmuxBackend(TerminalBackend):
         encoded = (sanitized + "\n").encode("utf-8")
         subprocess.run(["tmux", "load-buffer", "-b", buffer_name, "-"], input=encoded, check=True)
         subprocess.run(["tmux", "paste-buffer", "-t", session, "-b", buffer_name, "-p"], check=True)
-        time.sleep(0.5)
+        time.sleep(0.02)
         subprocess.run(["tmux", "send-keys", "-t", session, "Enter"], check=True)
         subprocess.run(["tmux", "delete-buffer", "-b", buffer_name], stderr=subprocess.DEVNULL)
 


### PR DESCRIPTION
## 问题描述

在 Windows 中文环境下，WeztermBackend 和 Iterm2Backend 的 subprocess 调用会因为默认使用 GBK 编码而导致解码失败：

```
UnicodeDecodeError: 'gbk' codec can't decode byte
```

这会导致：
- `ccb status` 无法正常检查终端状态
- `is_alive()` 方法失败
- 创建终端窗格时出错

## 解决方案

为所有 subprocess.run 调用添加 `encoding='utf-8'` 和 `errors='replace'` 参数，确保在 Windows 环境下使用 UTF-8 编码。

## 影响的方法

- `WeztermBackend.is_alive()` - lib/terminal.py:316
- `WeztermBackend.create_pane()` - lib/terminal.py:371
- `Iterm2Backend.is_alive()` - lib/terminal.py:210
- `Iterm2Backend.create_pane()` - lib/terminal.py:237

## 测试环境

- ✅ Windows 11 with Chinese locale
- ✅ WezTerm backend
- ✅ 修复后 ccb status 和 session 管理正常工作

## 相关提交

这个修复补充了之前的 Windows 兼容性改进工作，与以下提交相关：
- c35c096 fix(cask-w,gask-w): move setup_windows_encoding to module level
- 6d9da2f fix(install.ps1): add UTF-8 BOM and encoding setup for PS5.1 compatibility
- f8cf9cc fix(windows): add Windows compatibility fixes