### PR TITLE
fix: prevent cross-project session reading in cpend/gpend/cask/gask

### DIFF
--- a/lib/gemini_comm.py
+++ b/lib/gemini_comm.py
@@ -89,8 +89,7 @@ class GeminiLogReader:
         if sessions:
             return sessions[-1]
 
-        # fallback: projectHash may mismatch due to path normalization differences (Windows/WSL, symlinks, etc.)
-        return self._scan_latest_session_any_project()
+        return None
 
     def _latest_session(self) -> Optional[Path]:
         preferred = self._preferred_session


### PR DESCRIPTION
## Problem

When running `cpend`, `gpend`, `cask`, or `gask` commands in one project, they could incorrectly read conversation history from other projects. This caused confusion when working on multiple projects simultaneously.

### Root Cause

1. **CodexLogReader**: `_scan_latest()` scanned all sessions globally without filtering by project directory
2. **GeminiLogReader**: `_scan_latest_session()` had a fallback to `_scan_latest_session_any_project()` which bypassed project isolation
3. **bin/cpend**: Had fallback logic that would scan globally when the preferred log had no replies

## Solution

### CodexLogReader (`lib/codex_comm.py`)
- Added `work_dir` parameter to `__init__` (defaults to `Path.cwd()`)
- Added `_normalize_work_dir()` to normalize paths for comparison
- Added `_extract_cwd_from_log()` to extract `cwd` from session metadata
- Modified `_scan_latest()` to filter sessions by matching `cwd` with current `work_dir`

### GeminiLogReader (`lib/gemini_comm.py`)
- Removed fallback to `_scan_latest_session_any_project()` in `_scan_latest_session()`
- Now returns `None` instead of scanning across all projects

### bin/cpend
- Removed fallback logic that would scan globally when preferred log had no replies

## Testing

Verified that `cpend` now correctly returns only conversations from the current project directory, not from other projects.

## Files Changed

- `lib/codex_comm.py` (+32 lines)
- `lib/gemini_comm.py` (-1 line)
- `bin/cpend` (-11 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)