### PR TITLE
fix: 修复 WSL 环境下 WezTerm 启动时的 chdir 错误

### DIFF
--- a/lib/terminal.py
+++ b/lib/terminal.py
@@ -35,6 +35,54 @@ def is_wsl() -> bool:
         return False
 
 
+def _choose_wezterm_cli_cwd() -> str | None:
+    """
+    Pick a safe cwd for launching Windows `wezterm.exe` from inside WSL.
+
+    When a Windows binary is launched via WSL interop from a WSL cwd (e.g. /home/...),
+    Windows may treat the process cwd as a UNC path like \\\\wsl.localhost\\...,
+    which can confuse WezTerm's WSL relay and produce noisy `chdir(/wsl.localhost/...) failed 2`.
+    Using a Windows-mounted path like /mnt/c avoids that.
+    """
+    override = (os.environ.get("CCB_WEZTERM_CLI_CWD") or "").strip()
+    candidates = [override] if override else []
+    candidates.extend(["/mnt/c", "/mnt/d", "/mnt"])
+    for candidate in candidates:
+        if not candidate:
+            continue
+        try:
+            p = Path(candidate)
+            if p.is_dir():
+                return str(p)
+        except Exception:
+            continue
+    return None
+
+
+def _extract_wsl_path_from_unc_like_path(raw: str) -> str | None:
+    """
+    Convert UNC-like WSL paths into a WSL-internal absolute path.
+
+    Supports forms commonly seen in Git Bash/MSYS and Windows:
+      - /wsl.localhost/Ubuntu-24.04/home/user/...
+      - \\\\wsl.localhost\\Ubuntu-24.04\\home\\user\\...
+      - /wsl$/Ubuntu-24.04/home/user/...
+    Returns a POSIX absolute path like: /home/user/...
+    """
+    if not raw:
+        return None
+
+    m = re.match(r'^(?:[/\\]{1,2})(?:wsl\.localhost|wsl\$)[/\\]([^/\\]+)(.*)$', raw, re.IGNORECASE)
+    if not m:
+        return None
+    remainder = m.group(2).replace("\\", "/")
+    if not remainder:
+        return "/"
+    if not remainder.startswith("/"):
+        remainder = "/" + remainder
+    return remainder
+
+
 def _load_cached_wezterm_bin() -> str | None:
     """Load cached WezTerm path from installation"""
     config = Path.home() / ".config/ccb/env"
@@ -363,14 +411,16 @@ class WeztermBackend(TerminalBackend):
     def create_pane(self, cmd: str, cwd: str, direction: str = "right", percent: int = 50, parent_pane: Optional[str] = None) -> str:
         args = [*self._cli_base_args(), "split-pane"]
         force_wsl = os.environ.get("CCB_BACKEND_ENV", "").lower() == "wsl"
+        wsl_unc_cwd = _extract_wsl_path_from_unc_like_path(cwd)
+        # If the caller is in a WSL UNC path (e.g. Git Bash `/wsl.localhost/...`),
+        # default to launching via wsl.exe so the new pane lands in the real WSL path.
+        if is_windows() and wsl_unc_cwd and not force_wsl:
+            force_wsl = True
         use_wsl_launch = (is_wsl() and _is_windows_wezterm()) or (force_wsl and is_windows())
         if use_wsl_launch:
             in_wsl_pane = bool(os.environ.get("WSL_DISTRO_NAME") or os.environ.get("WSL_INTEROP"))
-            wsl_cwd = cwd
-            wsl_localhost_match = re.match(r'^[/\\]{1,2}wsl\.localhost[/\\][^/\\]+(.+)$', cwd, re.IGNORECASE)
-            if wsl_localhost_match:
-                wsl_cwd = wsl_localhost_match.group(1).replace('\\', '/')
-            elif "\\" in cwd or (len(cwd) > 2 and cwd[1] == ":"):
+            wsl_cwd = wsl_unc_cwd or cwd
+            if wsl_unc_cwd is None and ("\\" in cwd or (len(cwd) > 2 and cwd[1] == ":")):
                 try:
                     wslpath_cmd = ["wslpath", "-a", cwd] if is_wsl() else ["wsl.exe", "wslpath", "-a", cwd]
                     result = subprocess.run(wslpath_cmd, capture_output=True, text=True, check=True, encoding="utf-8", errors="replace")
@@ -384,7 +434,8 @@ class WeztermBackend(TerminalBackend):
             args.extend(["--percent", str(percent)])
             if parent_pane:
                 args.extend(["--pane-id", parent_pane])
-            startup_script = f"cd {shlex.quote(wsl_cwd)} && exec {cmd}"
+            # Do not `exec` here: `cmd` may be a compound shell snippet (e.g. keep-open wrappers).
+            startup_script = f"cd {shlex.quote(wsl_cwd)} && {cmd}"
             if in_wsl_pane:
                 args.extend(["--", "bash", "-l", "-i", "-c", startup_script])
             else:
@@ -401,7 +452,18 @@ class WeztermBackend(TerminalBackend):
             shell, flag = _default_shell()
             args.extend(["--", shell, flag, cmd])
         try:
-            result = subprocess.run(args, capture_output=True, text=True, check=True, encoding="utf-8", errors="replace")
+            run_cwd = None
+            if is_wsl() and _is_windows_wezterm():
+                run_cwd = _choose_wezterm_cli_cwd()
+            result = subprocess.run(
+                args,
+                capture_output=True,
+                text=True,
+                check=True,
+                encoding="utf-8",
+                errors="replace",
+                cwd=run_cwd,
+            )
             return result.stdout.strip()
         except subprocess.CalledProcessError as e:
             raise RuntimeError(f"WezTerm split-pane failed:\nCommand: {' '.join(args)}\nStderr: {e.stderr}") from e


### PR DESCRIPTION
问题描述：
在 WSL 环境下运行 `ccb up codex` 时，WezTerm 创建新窗格会输出错误：
`chdir(/wsl.localhost/Ubuntu-24.04/...) failed 2`
 虽然 Codex 最终能正常启动，但错误日志会对用户造成困扰。

根本原因：
当从 WSL 工作目录（如 /home/...）通过 WSL interop 调用 Windows wezterm.exe 时， Windows 会将当前目录错误地映射为 UNC 路径 \\wsl.localhost\...，
导致 WezTerm 的 WSL relay 在执行 chdir 时失败。

解决方案：
通过 _choose_wezterm_cli_cwd() 函数，在 WSL 环境下调用 Windows wezterm.exe 时， 将子进程工作目录设置为 Windows 挂载路径（如 /mnt/c），避免 relay 接触 UNC 路径。

主要改动：
- 新增 _choose_wezterm_cli_cwd() 函数：选择安全的 cwd（/mnt/c、/mnt/d 等）
- 新增 _extract_wsl_path_from_unc_like_path() 函数：解析 WSL UNC 路径
- 修改 WeztermBackend.create_pane()：在 subprocess.run() 中传递 cwd=run_cwd
- 修复 startup_script：移除 exec 以支持复合命令
- 支持 CCB_WEZTERM_CLI_CWD 环境变量自定义覆盖

测试环境：
WSL2 + Windows WezTerm
验证修复后无 `chdir failed 2` 错误
支持 `/wsl.localhost/...` 和 `\\wsl.localhost\...` 格式
支持 `/wsl$/...` 格式