### PR TITLE
feat: 会话绑定强化与 cask 并发支持

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 __pycache__/
 *.pyc
+.venv/
+.pytest_cache/
+docs/
+tests/
 .codex-session
 .gemini-session
 .claude-session
@@ -9,3 +13,5 @@ __pycache__/
 tmp/
 compare_with_mcp/
 CLAUDE.md
+AGENTS.md
+openspec

--- a/bin/cask
+++ b/bin/cask
@@ -8,9 +8,11 @@ If --output is provided, the reply is written atomically to that file and stdout
 from __future__ import annotations
 import json
 import os
+import re
 import subprocess
 import sys
 import time
+import uuid
 from pathlib import Path
 from typing import Optional, Tuple
 
@@ -19,9 +21,8 @@ lib_dir = script_dir.parent / "lib"
 sys.path.insert(0, str(lib_dir))
 from compat import setup_windows_encoding
 setup_windows_encoding()
-from process_lock import ProviderLock
 
-COMPLETION_MARKER = (os.environ.get("CCB_EXECUTION_COMPLETE_MARKER") or "EXECUTION_COMPLETE").strip() or "EXECUTION_COMPLETE"
+COMPLETION_MARKER_BASE = (os.environ.get("CCB_EXECUTION_COMPLETE_MARKER") or "EXECUTION_COMPLETE").strip() or "EXECUTION_COMPLETE"
 
 SUPERVISOR_PROMPT = """## Executor Mode: codex+opencode
 You are the SUPERVISOR, NOT the executor.
@@ -52,40 +53,64 @@ def _get_executor_from_roles() -> Optional[str]:
     return None
 
 
-def _has_completion_marker(text: str) -> bool:
-    """Check if last line contains COMPLETION_MARKER (flexible match)."""
-    lines = text.rstrip().splitlines()
-    return bool(lines) and COMPLETION_MARKER in lines[-1]
+def _build_markers(request_id: str) -> tuple[str, str]:
+    start_marker = f"{COMPLETION_MARKER_BASE}:BEGIN:{request_id}"
+    end_marker = f"{COMPLETION_MARKER_BASE}:END:{request_id}"
+    return start_marker, end_marker
 
 
-def _strip_completion_marker(text: str) -> str:
-    """Remove the trailing marker line if it contains COMPLETION_MARKER."""
-    lines = text.rstrip().splitlines()
-    if lines and COMPLETION_MARKER in lines[-1]:
-        lines[-1] = lines[-1].replace(COMPLETION_MARKER, "").rstrip()
-        if not lines[-1]:
-            lines = lines[:-1]
-        return "\n".join(lines).rstrip()
-    return text.rstrip()
+def _marker_regex(marker: str) -> re.Pattern:
+    escaped = [re.escape(ch) for ch in marker]
+    pattern = r"\s*".join(escaped)
+    return re.compile(pattern, re.DOTALL)
 
 
-def _wait_for_complete_reply(log_reader, state: dict, timeout: float, quiet: bool):
-    """Wait until reply ends with COMPLETION_MARKER or timeout."""
+def _marker_in_text(text: str, marker: str) -> bool:
+    return bool(_marker_regex(marker).search(text))
+
+
+def _strip_markers(text: str, start_marker: str, end_marker: str) -> str:
+    """Remove marker lines (start/end) from the reply."""
+    for marker in (start_marker, end_marker):
+        text = _marker_regex(marker).sub("", text)
+    return text.strip()
+
+
+def _wait_for_complete_reply(log_reader, state: dict, timeout: float, quiet: bool,
+                             start_marker: str, end_marker: str):
+    """Wait until reply ends with end_marker or timeout."""
     from cli_output import EXIT_NO_REPLY, EXIT_OK
-
-    # Pre-check: try to read existing messages (may have arrived before we started)
-    existing_reply = None
-    try:
-        existing_reply, state = log_reader.wait_for_message(state, timeout=0.1)
-        if existing_reply and _has_completion_marker(existing_reply):
-            return _strip_completion_marker(existing_reply), EXIT_OK
-    except Exception:
-        pass
 
     deadline = time.time() + timeout
     chunks = []
-    if existing_reply:
-        chunks.append(existing_reply)
+    collecting = False
+
+    def _handle_reply(reply: str) -> Optional[str]:
+        nonlocal collecting, chunks
+        has_start = _marker_in_text(reply, start_marker)
+        has_end = _marker_in_text(reply, end_marker)
+        if not collecting:
+            if has_start or has_end:
+                collecting = True
+                chunks.append(reply)
+            else:
+                return None
+        else:
+            chunks.append(reply)
+        if has_end:
+            combined = "\n".join(chunks)
+            return _strip_markers(combined, start_marker, end_marker)
+        return None
+
+    # Pre-check: try to read existing messages (may have arrived before we started)
+    try:
+        existing_reply, state = log_reader.wait_for_message(state, timeout=0.1)
+        if existing_reply:
+            result = _handle_reply(existing_reply)
+            if result is not None:
+                return result, EXIT_OK
+    except Exception:
+        pass
 
     while True:
         remaining = deadline - time.time()
@@ -94,29 +119,30 @@ def _wait_for_complete_reply(log_reader, state: dict, timeout: float, quiet: boo
         reply, state = log_reader.wait_for_message(state, remaining)
         if reply is None:
             continue
-        chunks.append(reply)
-        if _has_completion_marker(reply):
-            combined = "\n".join(chunks)
-            return _strip_completion_marker(combined), EXIT_OK
+        result = _handle_reply(reply)
+        if result is not None:
+            return result, EXIT_OK
 
-    if chunks:
+    if chunks and collecting:
         if not quiet:
-            print("[WARN] Marker not detected, returning partial reply", file=sys.stderr)
+            print("[WARN] cask_marker_missing: marker not detected for this request, returning partial reply", file=sys.stderr)
         combined = "\n".join(chunks)
-        return _strip_completion_marker(combined), EXIT_NO_REPLY
+        return _strip_markers(combined, start_marker, end_marker), EXIT_NO_REPLY
     return None, EXIT_NO_REPLY
 
 
-def _with_completion_marker_request(message: str) -> str:
+def _with_completion_marker_request(message: str, start_marker: str, end_marker: str) -> str:
     if not message:
         return message
-    if COMPLETION_MARKER in message:
+    if start_marker in message or end_marker in message:
         return message
     return (
         f"{message}\n\n"
         "IMPORTANT:\n"
         "- You MUST reply with a final response (do not stay silent).\n"
-        f"- End your reply with this exact line (verbatim):\n{COMPLETION_MARKER}\n"
+        f"- Begin your reply with this exact line (verbatim):\n{start_marker}\n"
+        f"- End your reply with this exact line (verbatim):\n{end_marker}\n"
+        "- Reply in a single message if possible.\n"
     )
 
 def _usage() -> None:
@@ -215,35 +241,29 @@ def main(argv: list[str]) -> int:
         if not healthy:
             raise RuntimeError(f"[ERROR] Session error: {status}")
 
-        # Use per-provider lock to serialize request-response cycles (non-blocking)
-        lock = ProviderLock("codex")
-        if not lock.try_acquire():
-            print("[ERROR] Another cask request is in progress. Please wait and try again.", file=sys.stderr)
-            return EXIT_ERROR
+        # Reset log state to ignore any messages before request dispatch
+        comm.log_reader.capture_state()
 
-        try:
-            # Reset log state to ignore any messages before lock acquisition
-            comm.log_reader.capture_state()
+        # Check if supervisor mode is enabled via roles config
+        executor = _get_executor_from_roles()
+        if executor == "codex+opencode":
+            message = SUPERVISOR_PROMPT + message
 
-            # Check if supervisor mode is enabled via roles config
-            executor = _get_executor_from_roles()
-            if executor == "codex+opencode":
-                message = SUPERVISOR_PROMPT + message
+        request_id = uuid.uuid4().hex
+        start_marker, end_marker = _build_markers(request_id)
 
-            _, state = comm._send_message(_with_completion_marker_request(message))
-            reply, exit_code = _wait_for_complete_reply(comm.log_reader, state, timeout, quiet)
-            if reply is None:
-                if not quiet:
-                    print(f"[TIMEOUT] Timeout after {int(timeout)}s", file=sys.stderr)
-                return exit_code
+        _, state = comm._send_message(_with_completion_marker_request(message, start_marker, end_marker))
+        reply, exit_code = _wait_for_complete_reply(comm.log_reader, state, timeout, quiet, start_marker, end_marker)
+        if reply is None:
+            if not quiet:
+                print(f"[TIMEOUT] Timeout after {int(timeout)}s", file=sys.stderr)
+            return exit_code
 
-            if output_path:
-                pending_path = Path(str(output_path) + ".pending")
-                atomic_write_text(pending_path, reply + "\n")
-                pending_path.replace(output_path)
-                return exit_code
-        finally:
-            lock.release()
+        if output_path:
+            pending_path = Path(str(output_path) + ".pending")
+            atomic_write_text(pending_path, reply + "\n")
+            pending_path.replace(output_path)
+            return exit_code
 
         sys.stdout.write(reply)
         if not reply.endswith("\n"):

--- a/bin/cpend
+++ b/bin/cpend
@@ -18,7 +18,8 @@ from i18n import t
 
 try:
     from cli_output import EXIT_ERROR, EXIT_NO_REPLY, EXIT_OK
-    from codex_comm import CodexLogReader
+    from codex_comm import CodexLogReader, SESSION_ID_PATTERN
+    from pane_registry import load_registry_by_session_id, load_registry_by_claude_pane
 except ImportError as exc:
     print(f"Import failed: {exc}")
     sys.exit(1)
@@ -33,19 +34,59 @@ def _debug(message: str) -> None:
     print(f"[DEBUG] {message}", file=sys.stderr)
 
 
-def _load_session_log_path() -> Path | None:
+def _load_session_log_path() -> tuple[Path | None, str | None]:
     """Load codex_session_path from .codex-session if exists"""
     session_file = Path.cwd() / ".codex-session"
     if not session_file.exists():
-        return None
+        return None, None
     try:
         with session_file.open("r", encoding="utf-8-sig") as f:
             data = json.load(f)
         path_str = data.get("codex_session_path")
+        session_id = data.get("codex_session_id")
         if path_str:
-            return Path(path_str).expanduser()
+            return Path(path_str).expanduser(), session_id
     except Exception as exc:
         _debug(f"Failed to read .codex-session ({session_file}): {exc}")
+    return None, None
+
+
+def _load_registry_log_path() -> tuple[Path | None, dict | None]:
+    session_id = (os.environ.get("CODEX_SESSION_ID") or "").strip()
+    if session_id:
+        record = load_registry_by_session_id(session_id)
+        if record:
+            path_str = record.get("codex_session_path")
+            if path_str:
+                path = Path(path_str).expanduser()
+                _debug(f"Using registry by CODEX_SESSION_ID: {path}")
+                return path, record
+
+    pane_id = (os.environ.get("WEZTERM_PANE") or "").strip()
+    if pane_id:
+        record = load_registry_by_claude_pane(pane_id)
+        if record:
+            path_str = record.get("codex_session_path")
+            if path_str:
+                path = Path(path_str).expanduser()
+                _debug(f"Using registry by WEZTERM_PANE: {path}")
+                return path, record
+    return None, None
+
+
+def _derive_session_filter(log_path: Path | None, registry_record: dict | None, session_id: str | None) -> str | None:
+    if registry_record:
+        reg_id = registry_record.get("codex_session_id")
+        if isinstance(reg_id, str) and reg_id:
+            return reg_id
+    if session_id:
+        return session_id
+    if log_path:
+        for source in (log_path.stem, log_path.name):
+            match = SESSION_ID_PATTERN.search(source)
+            if match:
+                return match.group(0)
+        return log_path.name
     return None
 
 def _parse_n(argv: list[str]) -> int:
@@ -66,22 +107,15 @@ def main(argv: list[str]) -> int:
     try:
         n = _parse_n(argv)
 
-        # Try session-specific log path first, fallback to scanning latest
-        log_path = _load_session_log_path()
-        if log_path:
-            _debug(f"Using codex_session_path from .codex-session: {log_path}")
-        reader = CodexLogReader(log_path=log_path)
+        registry_log_path, registry_record = _load_registry_log_path()
+        session_log_path, session_id = _load_session_log_path()
 
-        # If specified log has no reply, try scanning for latest
-        if log_path and log_path.exists():
-            test_msg = reader.latest_message()
-            if not test_msg:
-                # Scan for latest log that might have replies
-                latest = reader._scan_latest()
-                if latest and latest != log_path:
-                    reader.set_preferred_log(latest)
-                    log_path = latest
-                    _debug(f"Preferred log had no reply; switching to latest: {log_path}")
+        log_path = registry_log_path or session_log_path
+        if not registry_log_path and log_path:
+            _debug(f"Using codex_session_path from .codex-session: {log_path}")
+
+        session_filter = _derive_session_filter(log_path, registry_record, session_id)
+        reader = CodexLogReader(log_path=log_path, session_id_filter=session_filter)
 
         if n > 1:
             conversations = reader.latest_conversations(n)

--- a/ccb
+++ b/ccb
@@ -28,6 +28,7 @@ from terminal import TmuxBackend, WeztermBackend, Iterm2Backend, detect_terminal
 from compat import setup_windows_encoding
 from ccb_config import get_backend_env
 from session_utils import safe_write_session, check_session_writable
+from pane_registry import upsert_registry
 from i18n import t
 
 setup_windows_encoding()
@@ -353,6 +354,7 @@ class AILauncher:
             output_fifo = runtime / "output.fifo"
             # WezTerm mode injects text via pane, no strong FIFO dependency; Windows/WSL may not support mkfifo
             self._write_codex_session(runtime, None, input_fifo, output_fifo, pane_id=pane_id, pane_title_marker=pane_title_marker)
+            self._write_cend_registry(os.environ.get("WEZTERM_PANE", ""), pane_id)
         elif provider == "gemini":
             self._write_gemini_session(runtime, None, pane_id=pane_id, pane_title_marker=pane_title_marker)
         else:
@@ -450,6 +452,21 @@ class AILauncher:
             path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
         except Exception:
             pass
+
+    def _clear_codex_log_binding(self, data: dict) -> dict:
+        try:
+            if not isinstance(data, dict):
+                return {}
+            cleared = dict(data)
+            for key in ("codex_session_path", "codex_session_id", "codex_start_cmd"):
+                if key in cleared:
+                    cleared.pop(key, None)
+            if cleared.get("active") is False:
+                cleared["active"] = True
+            return cleared
+        except Exception as exc:
+            print(f"⚠️ codex_session_clear_failed: {exc}", file=sys.stderr)
+            return data if isinstance(data, dict) else {}
 
     def _claude_session_file(self) -> Path:
         return Path.cwd() / ".claude-session"
@@ -875,6 +892,9 @@ exec tmux attach -t "$TMUX_SESSION"
         if session_file.exists():
             data = self._read_json_file(session_file)
 
+        if not self.resume:
+            data = self._clear_codex_log_binding(data)
+
         work_dir = Path.cwd()
         data.update({
             "session_id": self.session_id,
@@ -897,6 +917,20 @@ exec tmux attach -t "$TMUX_SESSION"
             print(err, file=sys.stderr)
             return False
         return True
+
+    def _write_cend_registry(self, claude_pane_id: str, codex_pane_id: str | None) -> bool:
+        if not claude_pane_id:
+            return False
+        record = {
+            "ccb_session_id": self.session_id,
+            "claude_pane_id": claude_pane_id,
+            "codex_pane_id": codex_pane_id,
+            "work_dir": str(Path.cwd()),
+        }
+        ok = upsert_registry(record)
+        if not ok:
+            print("⚠️ Failed to update cpend registry", file=sys.stderr)
+        return ok
 
     def _write_gemini_session(self, runtime, tmux_session, pane_id=None, pane_title_marker=None):
         session_file = Path.cwd() / ".gemini-session"

--- a/lib/pane_registry.py
+++ b/lib/pane_registry.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Optional, Dict, Any, Iterable
+
+from cli_output import atomic_write_text
+
+REGISTRY_PREFIX = "ccb-session-"
+REGISTRY_SUFFIX = ".json"
+REGISTRY_TTL_SECONDS = 7 * 24 * 60 * 60
+
+
+def _debug_enabled() -> bool:
+    return os.environ.get("CCB_DEBUG") in ("1", "true", "yes")
+
+
+def _debug(message: str) -> None:
+    if not _debug_enabled():
+        return
+    print(f"[DEBUG] {message}", file=sys.stderr)
+
+
+def _registry_dir() -> Path:
+    return Path.home() / ".ccb" / "run"
+
+
+def registry_path_for_session(session_id: str) -> Path:
+    return _registry_dir() / f"{REGISTRY_PREFIX}{session_id}{REGISTRY_SUFFIX}"
+
+
+def _iter_registry_files() -> Iterable[Path]:
+    registry_dir = _registry_dir()
+    if not registry_dir.exists():
+        return []
+    return sorted(registry_dir.glob(f"{REGISTRY_PREFIX}*{REGISTRY_SUFFIX}"))
+
+
+def _coerce_updated_at(value: Any, fallback_path: Optional[Path] = None) -> int:
+    if isinstance(value, (int, float)):
+        return int(value)
+    if isinstance(value, str):
+        trimmed = value.strip()
+        if trimmed.isdigit():
+            try:
+                return int(trimmed)
+            except ValueError:
+                pass
+    if fallback_path:
+        try:
+            return int(fallback_path.stat().st_mtime)
+        except OSError:
+            return 0
+    return 0
+
+
+def _is_stale(updated_at: int, now: Optional[int] = None) -> bool:
+    if updated_at <= 0:
+        return True
+    now_ts = int(time.time()) if now is None else int(now)
+    return (now_ts - updated_at) > REGISTRY_TTL_SECONDS
+
+
+def _load_registry_file(path: Path) -> Optional[Dict[str, Any]]:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+        if isinstance(data, dict):
+            return data
+    except Exception as exc:
+        _debug(f"Failed to read registry {path}: {exc}")
+    return None
+
+
+def load_registry_by_session_id(session_id: str) -> Optional[Dict[str, Any]]:
+    if not session_id:
+        return None
+    path = registry_path_for_session(session_id)
+    if not path.exists():
+        return None
+    data = _load_registry_file(path)
+    if not data:
+        return None
+    updated_at = _coerce_updated_at(data.get("updated_at"), path)
+    if _is_stale(updated_at):
+        _debug(f"Registry stale for session {session_id}: {path}")
+        return None
+    return data
+
+
+def load_registry_by_claude_pane(pane_id: str) -> Optional[Dict[str, Any]]:
+    if not pane_id:
+        return None
+    best: Optional[Dict[str, Any]] = None
+    best_ts = -1
+    for path in _iter_registry_files():
+        data = _load_registry_file(path)
+        if not data:
+            continue
+        if data.get("claude_pane_id") != pane_id:
+            continue
+        updated_at = _coerce_updated_at(data.get("updated_at"), path)
+        if _is_stale(updated_at):
+            _debug(f"Registry stale for pane {pane_id}: {path}")
+            continue
+        if updated_at > best_ts:
+            best = data
+            best_ts = updated_at
+    return best
+
+
+def upsert_registry(record: Dict[str, Any]) -> bool:
+    session_id = record.get("ccb_session_id")
+    if not session_id:
+        _debug("Registry update skipped: missing ccb_session_id")
+        return False
+    path = registry_path_for_session(str(session_id))
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    data: Dict[str, Any] = {}
+    if path.exists():
+        existing = _load_registry_file(path)
+        if isinstance(existing, dict):
+            data.update(existing)
+
+    for key, value in record.items():
+        if value is None:
+            continue
+        data[key] = value
+
+    data["updated_at"] = int(time.time())
+
+    try:
+        atomic_write_text(path, json.dumps(data, ensure_ascii=False, indent=2))
+        return True
+    except Exception as exc:
+        _debug(f"Failed to write registry {path}: {exc}")
+        return False


### PR DESCRIPTION
- 新增 pane_registry 模块，实现 session-first 绑定策略
- 修复新会话启动后仍读取旧日志的问题
- 允许 cask 并发请求，使用 per-request marker 防止串答

上次更新后出现：
1. 强制绑定单实例单codex串行，禁止并发。
2. claude code无法读取codex返回的内容，因为旧日志会被覆盖。

解决同目录多实例串会话问题，提升多模型协作稳定性（只适用于cc-codex)。

