### PR TITLE
Fix: 避免Windows环境下subprocess调用产生CMD窗口闪烁

### DIFF
--- a/bin/cask
+++ b/bin/cask
@@ -22,6 +22,7 @@ sys.path.insert(0, str(lib_dir))
 from compat import setup_windows_encoding
 setup_windows_encoding()
 from process_lock import ProviderLock
+from terminal import _subprocess_kwargs
 
 COMPLETION_MARKER = (os.environ.get("CCB_EXECUTION_COMPLETE_MARKER") or "EXECUTION_COMPLETE").strip() or "EXECUTION_COMPLETE"
 
@@ -303,14 +304,8 @@ def _maybe_start_caskd() -> bool:
         argv = [python_exe, entry]
     try:
         kwargs = {"stdin": subprocess.DEVNULL, "stdout": subprocess.DEVNULL, "stderr": subprocess.DEVNULL, "close_fds": True}
-        if os.name == "nt":
-            # Use STARTUPINFO to hide the console window on Windows
-            startupinfo = subprocess.STARTUPINFO()
-            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-            startupinfo.wShowWindow = subprocess.SW_HIDE
-            kwargs["startupinfo"] = startupinfo
-            kwargs["creationflags"] = getattr(subprocess, "DETACHED_PROCESS", 0) | getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
-        else:
+        kwargs.update(_subprocess_kwargs())
+        if os.name != "nt":
             kwargs["start_new_session"] = True
         subprocess.Popen(argv, **kwargs)
         return True
@@ -359,14 +354,8 @@ def _popen_detached(argv: list[str]) -> None:
         "stderr": subprocess.DEVNULL,
         "close_fds": True,
     }
-    if os.name == "nt":
-        # Use STARTUPINFO to hide the console window on Windows
-        startupinfo = subprocess.STARTUPINFO()
-        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-        startupinfo.wShowWindow = subprocess.SW_HIDE
-        kwargs["startupinfo"] = startupinfo
-        kwargs["creationflags"] = getattr(subprocess, "DETACHED_PROCESS", 0) | getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
-    else:
+    kwargs.update(_subprocess_kwargs())
+    if os.name != "nt":
         kwargs["start_new_session"] = True
     subprocess.Popen(argv, **kwargs)
 

--- a/bin/gask
+++ b/bin/gask
@@ -22,6 +22,7 @@ sys.path.insert(0, str(lib_dir))
 from compat import setup_windows_encoding
 setup_windows_encoding()
 from process_lock import ProviderLock
+from terminal import _subprocess_kwargs
 
 from cli_output import EXIT_ERROR, EXIT_NO_REPLY, EXIT_OK, atomic_write_text
 
@@ -157,14 +158,8 @@ def _maybe_start_gaskd() -> bool:
         argv = [python_exe, entry]
     try:
         kwargs = {"stdin": subprocess.DEVNULL, "stdout": subprocess.DEVNULL, "stderr": subprocess.DEVNULL, "close_fds": True}
-        if os.name == "nt":
-            # Use STARTUPINFO to hide the console window on Windows
-            startupinfo = subprocess.STARTUPINFO()
-            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-            startupinfo.wShowWindow = subprocess.SW_HIDE
-            kwargs["startupinfo"] = startupinfo
-            kwargs["creationflags"] = getattr(subprocess, "DETACHED_PROCESS", 0) | getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
-        else:
+        kwargs.update(_subprocess_kwargs())
+        if os.name != "nt":
             kwargs["start_new_session"] = True
         subprocess.Popen(argv, **kwargs)
         return True

--- a/bin/oask
+++ b/bin/oask
@@ -24,6 +24,7 @@ from compat import setup_windows_encoding
 
 setup_windows_encoding()
 from process_lock import ProviderLock
+from terminal import _subprocess_kwargs
 
 def _env_bool(name: str, default: bool) -> bool:
     raw = os.environ.get(name)
@@ -202,14 +203,8 @@ def _maybe_start_oaskd() -> bool:
         argv = [python_exe, entry]
     try:
         kwargs = {"stdin": subprocess.DEVNULL, "stdout": subprocess.DEVNULL, "stderr": subprocess.DEVNULL, "close_fds": True}
-        if os.name == "nt":
-            # Use STARTUPINFO to hide the console window on Windows
-            startupinfo = subprocess.STARTUPINFO()
-            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-            startupinfo.wShowWindow = subprocess.SW_HIDE
-            kwargs["startupinfo"] = startupinfo
-            kwargs["creationflags"] = getattr(subprocess, "DETACHED_PROCESS", 0) | getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
-        else:
+        kwargs.update(_subprocess_kwargs())
+        if os.name != "nt":
             kwargs["start_new_session"] = True
         subprocess.Popen(argv, **kwargs)
         return True

--- a/ccb
+++ b/ccb
@@ -286,7 +286,10 @@ class AILauncher:
             "close_fds": True,
         }
         if os.name == "nt":
-            kwargs["creationflags"] = getattr(subprocess, "DETACHED_PROCESS", 0) | getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+            # 使用 CREATE_NO_WINDOW 而非 DETACHED_PROCESS
+            # CREATE_NO_WINDOW: 隐藏窗口但保留控制台附着，子进程可继承
+            # DETACHED_PROCESS: 完全脱离控制台，子进程必须创建新窗口
+            kwargs["creationflags"] = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0) | getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000)
         else:
             kwargs["start_new_session"] = True
 

--- a/lib/caskd_daemon.py
+++ b/lib/caskd_daemon.py
@@ -23,6 +23,7 @@ from caskd_protocol import (
     wrap_codex_prompt,
 )
 from caskd_session import CodexProjectSession, compute_session_key, find_project_session_file, load_project_session
+from terminal import is_windows
 from codex_comm import CodexLogReader, CodexCommunicator
 from process_lock import ProviderLock
 from session_utils import safe_write_session
@@ -215,7 +216,9 @@ class _SessionWorker(threading.Thread):
         saw_any_event = False
         tail_bytes = int(os.environ.get("CCB_CASKD_REBIND_TAIL_BYTES", str(1024 * 1024 * 2)) or (1024 * 1024 * 2))
         last_pane_check = time.time()
-        pane_check_interval = float(os.environ.get("CCB_CASKD_PANE_CHECK_INTERVAL", "2.0") or "2.0")
+        # Windows平台降低检查频率，减少CLI调用和窗口闪烁风险
+        default_interval = "5.0" if is_windows() else "2.0"
+        pane_check_interval = float(os.environ.get("CCB_CASKD_PANE_CHECK_INTERVAL", default_interval) or default_interval)
 
         while True:
             remaining = deadline - time.time()

--- a/lib/ccb_config.py
+++ b/lib/ccb_config.py
@@ -5,16 +5,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-
-def _get_subprocess_kwargs():
-    """Get subprocess kwargs with hidden window on Windows."""
-    kwargs = {}
-    if os.name == "nt":
-        startupinfo = subprocess.STARTUPINFO()
-        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-        startupinfo.wShowWindow = subprocess.SW_HIDE
-        kwargs["startupinfo"] = startupinfo
-    return kwargs
+from terminal import _subprocess_kwargs
 
 
 def get_backend_env() -> str | None:
@@ -40,7 +31,7 @@ def _wsl_probe_distro_and_home() -> tuple[str, str]:
         r = subprocess.run(
             ["wsl.exe", "-e", "sh", "-lc", "echo $WSL_DISTRO_NAME; echo $HOME"],
             capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=10,
-            **_get_subprocess_kwargs()
+            **_subprocess_kwargs()
         )
         if r.returncode == 0:
             lines = r.stdout.strip().split("\n")
@@ -52,7 +43,7 @@ def _wsl_probe_distro_and_home() -> tuple[str, str]:
         r = subprocess.run(
             ["wsl.exe", "-l", "-q"],
             capture_output=True, text=True, encoding="utf-16-le", errors="replace", timeout=5,
-            **_get_subprocess_kwargs()
+            **_subprocess_kwargs()
         )
         if r.returncode == 0:
             for line in r.stdout.strip().split("\n"):
@@ -69,7 +60,7 @@ def _wsl_probe_distro_and_home() -> tuple[str, str]:
         r = subprocess.run(
             ["wsl.exe", "-d", distro, "-e", "sh", "-lc", "echo $HOME"],
             capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=5,
-            **_get_subprocess_kwargs()
+            **_subprocess_kwargs()
         )
         home = r.stdout.strip() if r.returncode == 0 else "/root"
     except Exception:


### PR DESCRIPTION
采用 CREATE_NO_WINDOW 方式，统一使用 terminal._subprocess_kwargs() 实现

修改内容:
- lib/terminal.py: 使用 CREATE_NO_WINDOW 替代 STARTUPINFO 方式
- lib/ccb_config.py: 导入 terminal._subprocess_kwargs()
- bin/cask/gask/oask: 使用 _subprocess_kwargs() + pythonw.exe 支持

保留上游优点:
- pythonw.exe 支持（彻底避免控制台窗口）
- _run() 包装函数（代码统一性）

采用本地方式:
- CREATE_NO_WINDOW 标志（更简洁高效）
- 统一导入（避免重复定义）