### PR TITLE
fix(installer): respect BIN_DIR for PATH and tmux scripts

### DIFF
--- a/config/tmux-ccb.conf
+++ b/config/tmux-ccb.conf
@@ -40,7 +40,10 @@ set -g renumber-windows on
 
 # NOTE:
 # CCB's status bar + pane title theming is enabled only while CCB is running.
-# See: `~/.local/bin/ccb-tmux-on.sh` / `~/.local/bin/ccb-tmux-off.sh`.
+# See: `@CCB_BIN_DIR@/ccb-tmux-on.sh` / `@CCB_BIN_DIR@/ccb-tmux-off.sh`.
+
+# CCB script directory (filled by installer)
+set -g @ccb_bin_dir "@CCB_BIN_DIR@"
 
 # -----------------------------------------------------------------------------
 # Copy Mode (vi-style) with System Clipboard
@@ -124,8 +127,8 @@ bind M set -g mouse off \; display "Mouse OFF"
 bind r source-file ~/.tmux.conf \; display "Config reloaded!"
 
 # Manually toggle CCB theme for current session (optional).
-bind-key C run-shell "~/.local/bin/ccb-tmux-on.sh"
-bind-key V run-shell "~/.local/bin/ccb-tmux-off.sh"
+bind-key C run-shell "#{@ccb_bin_dir}/ccb-tmux-on.sh"
+bind-key V run-shell "#{@ccb_bin_dir}/ccb-tmux-off.sh"
 
 # -----------------------------------------------------------------------------
 # Session Management

--- a/install.sh
+++ b/install.sh
@@ -655,10 +655,10 @@ ensure_path_configured() {
     *)    shell_rc="$HOME/.profile" ;;
   esac
 
-  local path_line="export PATH=\"\$HOME/.local/bin:\$PATH\""
+  local path_line="export PATH=\"${BIN_DIR}:\$PATH\""
 
   # Check if already configured in shell rc
-  if [[ -f "$shell_rc" ]] && grep -qF '.local/bin' "$shell_rc" 2>/dev/null; then
+  if [[ -f "$shell_rc" ]] && grep -qF "$BIN_DIR" "$shell_rc" 2>/dev/null; then
     echo "PATH already configured in $shell_rc (restart terminal to apply)"
     return
   fi
@@ -989,15 +989,16 @@ install_tmux_config() {
   local tmux_conf="$HOME/.tmux.conf"
   local ccb_tmux_conf="$REPO_ROOT/config/tmux-ccb.conf"
   local ccb_status_script="$REPO_ROOT/config/ccb-status.sh"
-  local status_install_path="$HOME/.local/bin/ccb-status.sh"
+  local status_install_path="$BIN_DIR/ccb-status.sh"
 
   if [[ ! -f "$ccb_tmux_conf" ]]; then
     return
   fi
 
+  mkdir -p "$BIN_DIR"
+
   # Install ccb-status.sh script
   if [[ -f "$ccb_status_script" ]]; then
-    mkdir -p "$HOME/.local/bin"
     cp "$ccb_status_script" "$status_install_path"
     chmod +x "$status_install_path"
     echo "Installed: $status_install_path"
@@ -1005,7 +1006,7 @@ install_tmux_config() {
 
   # Install ccb-border.sh script (dynamic pane border colors)
   local ccb_border_script="$REPO_ROOT/config/ccb-border.sh"
-  local border_install_path="$HOME/.local/bin/ccb-border.sh"
+  local border_install_path="$BIN_DIR/ccb-border.sh"
   if [[ -f "$ccb_border_script" ]]; then
     cp "$ccb_border_script" "$border_install_path"
     chmod +x "$border_install_path"
@@ -1016,14 +1017,14 @@ install_tmux_config() {
   local ccb_tmux_on_script="$REPO_ROOT/config/ccb-tmux-on.sh"
   local ccb_tmux_off_script="$REPO_ROOT/config/ccb-tmux-off.sh"
   if [[ -f "$ccb_tmux_on_script" ]]; then
-    cp "$ccb_tmux_on_script" "$HOME/.local/bin/ccb-tmux-on.sh"
-    chmod +x "$HOME/.local/bin/ccb-tmux-on.sh"
-    echo "Installed: $HOME/.local/bin/ccb-tmux-on.sh"
+    cp "$ccb_tmux_on_script" "$BIN_DIR/ccb-tmux-on.sh"
+    chmod +x "$BIN_DIR/ccb-tmux-on.sh"
+    echo "Installed: $BIN_DIR/ccb-tmux-on.sh"
   fi
   if [[ -f "$ccb_tmux_off_script" ]]; then
-    cp "$ccb_tmux_off_script" "$HOME/.local/bin/ccb-tmux-off.sh"
-    chmod +x "$HOME/.local/bin/ccb-tmux-off.sh"
-    echo "Installed: $HOME/.local/bin/ccb-tmux-off.sh"
+    cp "$ccb_tmux_off_script" "$BIN_DIR/ccb-tmux-off.sh"
+    chmod +x "$BIN_DIR/ccb-tmux-off.sh"
+    echo "Installed: $BIN_DIR/ccb-tmux-off.sh"
   fi
 
   # Check if already configured (new or legacy marker)
@@ -1059,10 +1060,22 @@ with open('$tmux_conf', 'w', encoding='utf-8') as f:
     fi
   fi
 
-  # Append CCB tmux config
+  # Append CCB tmux config (fill in BIN_DIR placeholders)
   {
     echo ""
-    cat "$ccb_tmux_conf"
+    if pick_any_python_bin; then
+      "$PYTHON_BIN" -c "
+import sys
+
+path = '$ccb_tmux_conf'
+bin_dir = '$BIN_DIR'
+with open(path, 'r', encoding='utf-8') as f:
+    content = f.read()
+sys.stdout.write(content.replace('@CCB_BIN_DIR@', bin_dir))
+" 2>/dev/null || cat "$ccb_tmux_conf"
+    else
+      cat "$ccb_tmux_conf"
+    fi
   } >> "$tmux_conf"
 
   echo "Updated tmux configuration: $tmux_conf"
@@ -1076,10 +1089,10 @@ with open('$tmux_conf', 'w', encoding='utf-8') as f:
 
 uninstall_tmux_config() {
   local tmux_conf="$HOME/.tmux.conf"
-  local status_script="$HOME/.local/bin/ccb-status.sh"
-  local border_script="$HOME/.local/bin/ccb-border.sh"
-  local tmux_on_script="$HOME/.local/bin/ccb-tmux-on.sh"
-  local tmux_off_script="$HOME/.local/bin/ccb-tmux-off.sh"
+  local status_script="$BIN_DIR/ccb-status.sh"
+  local border_script="$BIN_DIR/ccb-border.sh"
+  local tmux_on_script="$BIN_DIR/ccb-tmux-on.sh"
+  local tmux_off_script="$BIN_DIR/ccb-tmux-off.sh"
 
   # Remove ccb-status.sh script
   if [[ -f "$status_script" ]]; then


### PR DESCRIPTION
## Summary
When users set a custom `CODEX_BIN_DIR`, the installer and tmux integration previously still hardcoded `~/.local/bin` in a few places. This made the installed helper scripts and PATH configuration inconsistent with the configured bin directory.

This PR removes the remaining `~/.local/bin` coupling and makes tmux integration fully honor `CODEX_BIN_DIR` end-to-end.

## What changed
- Installer PATH setup now appends the configured `BIN_DIR` (derived from `CODEX_BIN_DIR`) instead of `~/.local/bin`.
- tmux helper scripts are installed/uninstalled into/from `BIN_DIR`.
- tmux config no longer hardcodes `~/.local/bin`; it uses an install-time placeholder replacement so key bindings point to the correct `BIN_DIR`.
- `ccb-tmux-on.sh` no longer assumes helper scripts live in `~/.local/bin`; it resolves helper paths relative to its own location.

## Why
Customizing `CODEX_BIN_DIR` should be a supported workflow (e.g., shared tool directories, non-default HOME layouts, container/WSL setups). Hardcoding `~/.local/bin` breaks that expectation and causes “installed but not found” behavior in tmux keybindings / status helpers.

## Backward compatibility
- Default behavior remains unchanged for users who keep the default `CODEX_BIN_DIR` (i.e., `~/.local/bin`).
- Users with an existing tmux block will have it refreshed by the installer update path.

## Testing
- Ran `bash -n install.sh` and `bash -n ccb-tmux-on.sh config/ccb-tmux-off.sh`.
- Manual sanity check: verified generated tmux config points to the configured `BIN_DIR`.

## How to verify (manual)
1. Run: `CODEX_BIN_DIR=/your/custom/bin CODEX_INSTALL_PREFIX=/your/prefix install.sh install`
2. Confirm the helper scripts exist in `/your/custom/bin` (e.g., `ccb-tmux-on.sh`, `ccb-border.sh`, `ccb-status.sh`).
3. Reload tmux config: `tmux source-file ~/.tmux.conf`
4. In tmux, use the provided keybindings to toggle CCB theming and confirm no references to `~/.local/bin` remain in the active workflow.

## Notes
Windows installer paths were reviewed; no analogous `~/.local/bin` assumption exists there, so no changes were required.