### PR TITLE
修复终端检测逻辑

### DIFF
--- a/ccb
+++ b/ccb
@@ -730,12 +730,13 @@ class AILauncher:
         if forced in {"wezterm", "tmux"}:
             return forced
 
-        # When inside WezTerm pane, use wezterm
-        if os.environ.get("WEZTERM_PANE"):
-            return "wezterm"
-        # When inside tmux, use tmux
+        # When inside tmux, use tmux (check first - tmux is the "inner" environment
+        # when running inside WezTerm with tmux)
         if os.environ.get("TMUX") or os.environ.get("TMUX_PANE"):
             return "tmux"
+        # When inside WezTerm pane (without tmux), use wezterm
+        if os.environ.get("WEZTERM_PANE"):
+            return "wezterm"
 
         # Not inside any multiplexer:
         # Prefer split-capable terminals (WezTerm) when available,

--- a/lib/terminal.py
+++ b/lib/terminal.py
@@ -889,10 +889,11 @@ _backend_cache: Optional[TerminalBackend] = None
 
 def detect_terminal() -> Optional[str]:
     # Priority 1: detect *current* terminal session from env vars.
-    if os.environ.get("WEZTERM_PANE"):
-        return "wezterm"
+    # Check tmux first - it's the "inner" environment when running WezTerm with tmux.
     if os.environ.get("TMUX") or os.environ.get("TMUX_PANE"):
         return "tmux"
+    if os.environ.get("WEZTERM_PANE"):
+        return "wezterm"
 
     # WSL-specific: WezTerm on Windows does not always propagate WEZTERM_PANE into tmux server env
     # (or custom shells), but wezterm CLI may still be reachable via interop.


### PR DESCRIPTION
Bug 原因：
  当你在 WezTerm 中开启 tmux 后，两个环境变量同时存在：
  - WEZTERM_PANE (WezTerm 设置)
  - TMUX (tmux 设置)

  原代码先检查 WEZTERM_PANE，所以即使在 tmux 中也会返回 wezterm。

  修复内容：
  1. ccb:619-625 - 调换检测顺序，先检查 TMUX
  2. lib/terminal.py:890-896 - 同样调换检测顺序

  修复逻辑：tmux 是更"内层"的环境，当用户在 tmux 中操作时，应该使用 tmux 的 pane 管理功能，而不是外层 WezTerm 的。