### PR TITLE
fix: handle PermissionError in process health check for sandbox compatibility

### DIFF
--- a/lib/codex_comm.py
+++ b/lib/codex_comm.py
@@ -788,6 +788,15 @@ class CodexCommunicator:
                 codex_pid = int(f.read().strip())
             try:
                 os.kill(codex_pid, 0)
+            except PermissionError:
+                # 沙箱阻止了 os.kill，使用 ps 命令验证
+                import subprocess
+                try:
+                    result = subprocess.run(["ps", "-p", str(codex_pid)], capture_output=True, timeout=2)
+                    if result.returncode != 0:
+                        return False, f"Codex process (PID:{codex_pid}) has exited"
+                except Exception:
+                    pass  # 无法验证，假设存在
             except OSError:
                 return False, f"Codex process (PID:{codex_pid}) has exited"
 
@@ -801,6 +810,15 @@ class CodexCommunicator:
                 return False, "Failed to read bridge process PID"
             try:
                 os.kill(bridge_pid, 0)
+            except PermissionError:
+                # 沙箱阻止了 os.kill，使用 ps 命令验证
+                import subprocess
+                try:
+                    result = subprocess.run(["ps", "-p", str(bridge_pid)], capture_output=True, timeout=2)
+                    if result.returncode != 0:
+                        return False, f"Bridge process (PID:{bridge_pid}) has exited"
+                except Exception:
+                    pass  # 无法验证，假设存在
             except OSError:
                 return False, f"Bridge process (PID:{bridge_pid}) has exited"
 


### PR DESCRIPTION
## Summary
- Fix `cping`/`cask` incorrectly reporting "Codex process has exited" when running in Claude Code's sandbox environment
- Add fallback to `ps -p <pid>` when `os.kill(pid, 0)` is blocked by sandbox

## Problem
On macOS, Claude Code uses `sandbox-exec` which blocks `os.kill(pid, 0)` system calls. This causes `PermissionError` to be raised, which was previously caught as a generic `OSError`, leading to false "process exited" errors.

## Solution
Add explicit `PermissionError` handling that falls back to using `ps -p <pid>` subprocess call to verify process existence.

## Test plan
- [x] Tested `cping` in Claude Code sandbox on macOS - now returns "Session healthy"
- [x] Tested `cask` message sending - successfully communicates with Codex

🤖 Generated with [Claude Code](https://claude.ai/claude-code)