### PR TITLE
Fix: preserve ccb up flags when relaunching inside tmux

### DIFF
--- a/ccb
+++ b/ccb
@@ -770,7 +770,16 @@ class AILauncher:
         # `ai-<epoch>-<pid>` collides frequently (same day) and can incorrectly attach to an old session.
         session_name = f"ccb-{self.session_id}"
         providers_str = ",".join(self.providers)
-        ccb_cmd = f"{shlex.quote(str(self.script_dir / 'ccb'))} up {shlex.quote(providers_str)}"
+
+        # Preserve CLI flags when re-launching inside tmux; otherwise options like `ccb up ... -a`
+        # get lost when not already inside tmux.
+        ccb_args = [str(self.script_dir / "ccb"), "up"]
+        if self.resume:
+            ccb_args.append("-r")
+        if self.auto:
+            ccb_args.append("-a")
+        ccb_args.append(providers_str)
+        ccb_cmd = " ".join(shlex.quote(a) for a in ccb_args)
 
         # Check if session already exists
         check = subprocess.run(


### PR DESCRIPTION
## Background

CCB supports running Codex/Gemini/OpenCode in tmux/WezTerm panes.
When `ccb up` is invoked *outside* an existing tmux client, CCB auto-creates a new tmux session and re-runs `ccb up` inside that session.

This relaunch behavior is implemented by CCB itself (not oh-my-zsh).

## Problem

The tmux relaunch command previously forwarded only the providers list (e.g. `codex,gemini`).
CLI flags from the original invocation were dropped, so options like:

- `-a/--auto` (full auto permission mode)
- `-r/--resume`

would silently not take effect after the tmux session was created.

## Reproduction

1. From a non-tmux shell, run: `ccb up codex -a`
2. CCB creates a tmux session and re-runs `ccb up` inside it
3. Observed: the restarted command behaves as if `-a` was not passed

## Fix

When building the tmux session command in `AILauncher._launch_in_new_tmux_session`, forward the relevant flags based on launcher state:

- include `-a` when `self.auto` is true
- include `-r` when `self.resume` is true

Then quote argv safely with `shlex.quote`.

## Notes / Workaround

A common workaround is to ensure `ccb up ...` runs *inside* tmux.
Note that `tmux &` alone does not put your current shell inside tmux; you still need to attach or run the command as the tmux session command.

Example:

- `tmux new-session -A -s ccb 'ccb up codex -a'`

This PR makes the auto-relaunch path behave consistently so users can run `ccb up ...` directly from a non-tmux shell without losing flags.

## Tests

- `python -m compileall -q lib bin ccb`
- `pytest test/`
