### PR TITLE
fix(ccb-mounted): use ping-based detection for all platforms

### DIFF
--- a/bin/ccb-mounted
+++ b/bin/ccb-mounted
@@ -19,38 +19,19 @@ if [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "cygwin" ]]; then
   fi
 fi
 
-# Detect OS and get online daemons accordingly
-if [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "cygwin" ]] || [[ -n "${WINDIR:-}" ]]; then
-  # Windows: use ping command to check each provider directly
-  MOUNTED=""
-  for pair in $PROVIDERS; do
-    provider="${pair%%:*}"
-    # Check session file exists first
-    if [[ -f "$CWD/.ccb_config/.${provider}-session" ]] || [[ -f "$CWD/.${provider}-session" ]]; then
-      # Try the ping command to check if daemon is responsive
-      if "$SCRIPT_DIR/ping" "$provider" >/dev/null 2>&1; then
-        MOUNTED="$MOUNTED $provider"
-      fi
+# Check mounted providers using ping command
+# This works with both legacy per-provider daemons and the unified askd daemon
+MOUNTED=""
+for pair in $PROVIDERS; do
+  provider="${pair%%:*}"
+  # Check session file exists first
+  if [[ -f "$CWD/.ccb_config/.${provider}-session" ]] || [[ -f "$CWD/.${provider}-session" ]]; then
+    # Try the ping command to check if daemon is responsive
+    if "$SCRIPT_DIR/ping" "$provider" >/dev/null 2>&1; then
+      MOUNTED="$MOUNTED $provider"
     fi
-  done
-else
-  # Linux/macOS: use pgrep
-  ONLINE=$(pgrep -af "bin/[cglod]askd$" 2>/dev/null | grep -oE "[cglod]askd" | sort -u || true)
-
-  MOUNTED=""
-  for pair in $PROVIDERS; do
-    provider="${pair%%:*}"
-    daemon="${pair##*:}"
-
-    # Check session file exists
-    if [[ -f "$CWD/.ccb_config/.${provider}-session" ]] || [[ -f "$CWD/.${provider}-session" ]]; then
-      # Check daemon is online
-      if echo "$ONLINE" | grep -q "${daemon}d"; then
-        MOUNTED="$MOUNTED $provider"
-      fi
-    fi
-  done
-fi
+  fi
+done
 
 MOUNTED=$(echo $MOUNTED | xargs)  # trim
 


### PR DESCRIPTION
## Summary

- Replace pgrep-based daemon detection on Linux/macOS with ping command
- Fixes detection when using the unified askd daemon architecture
- Unifies behavior across all platforms (Windows already used this approach)

## Problem

The `ccb-mounted` script fails to detect mounted providers on Linux/macOS because it searches for legacy per-provider daemons using pgrep:

```bash
ONLINE=$(pgrep -af "bin/[cglod]askd$" ...)
```

This regex matches `caskd`, `gaskd`, `oaskd`, `laskd`, `daskd` - but the new architecture uses a single unified `askd` daemon.

## Solution

Use the `ping` command to check provider responsiveness (same approach already used for Windows). This method:
- Works with both legacy and unified daemon architectures
- Is more reliable than process name matching
- Provides consistent behavior across all platforms

## Test plan

- [x] Verified `ccb-mounted` returns empty array before fix
- [x] Verified `ccb-mounted` returns correct providers after fix
- [x] Tested on Linux with unified askd daemon