### PR TITLE
fix(askd_client): check CCB_RUN_DIR for daemon state files

### DIFF
--- a/lib/askd_client.py
+++ b/lib/askd_client.py
@@ -175,6 +175,18 @@ def try_daemon_request(
     read_state = getattr(daemon_module, "read_state")
 
     st = read_state(state_file=state_file)
+
+    # If state not found and CCB_RUN_DIR is set, try project-specific state file
+    # This fixes background mode where env vars may not be inherited
+    if not st:
+        run_dir = os.environ.get("CCB_RUN_DIR", "").strip()
+        if run_dir:
+            # State file name is derived from protocol_prefix (e.g., cask -> caskd.json)
+            state_filename = f"{spec.protocol_prefix}d.json"
+            project_state = Path(run_dir) / state_filename
+            if project_state.exists():
+                st = read_state(state_file=project_state)
+
     if not st:
         return None
     try:


### PR DESCRIPTION
## Summary

- Add fallback state file lookup in CCB_RUN_DIR
- Fixes background mode commands failing with "daemon required but not available"

## Problem

When using `cask`/`gask` commands with `run_in_background=true` (e.g., from Claude Code's Bash tool), the commands fail with "daemon required but not available" even though:
- Daemons are running (verified via `ps aux`)
- `ccb-mounted` shows providers as mounted
- `cping`/`gping` return success

### Root Cause

The daemon state files (`caskd.json`, `gaskd.json`) are stored in a project-specific directory determined by `$CCB_RUN_DIR`:

```
$CCB_RUN_DIR/caskd.json  # e.g., ~/.cache/ccb/projects/d00cb73071680884/caskd.json
```

When commands run in background mode, the `$CCB_RUN_DIR` environment variable is **not inherited** by the child process. The `cask`/`gask` scripts then look for state files in the default location (`~/.cache/ccb/`) instead of the project-specific directory.

## Solution

Add a fallback lookup in `try_daemon_request()`:
1. First try explicit state_file parameter
2. Then try CCB_*_STATE_FILE environment variable  
3. **NEW:** Try CCB_RUN_DIR/{protocol}d.json (e.g., caskd.json)
4. Return None if still not found

## Test plan

- [x] Verified background mode commands fail before fix
- [x] Verified background mode commands work after fix
- [x] Verified normal (foreground) mode still works