### PR TITLE
fix(protocol): generate 32-hex request IDs

### DIFF
--- a/lib/ccb_protocol.py
+++ b/lib/ccb_protocol.py
@@ -10,10 +10,12 @@ DONE_PREFIX = "CCB_DONE:"
 
 DONE_LINE_RE_TEMPLATE = r"^\s*CCB_DONE:\s*{req_id}\s*$"
 
+_REQ_ID_RE_FRAGMENT = r"(?:[0-9a-f]{32}|\d{8}-\d{6}-\d{3}-\d+)"
 _TRAILING_DONE_TAG_RE = re.compile(
-    r"^\s*(?!CCB_DONE\s*:)[A-Z][A-Z0-9_]*_DONE(?:\s*:\s*\d{8}-\d{6}-\d{3}-\d+)?\s*$"
+    rf"^\s*(?!CCB_DONE\s*:)[A-Z][A-Z0-9_]*_DONE(?:\s*:\s*{_REQ_ID_RE_FRAGMENT})?\s*$",
+    re.IGNORECASE,
 )
-_ANY_CCB_DONE_LINE_RE = re.compile(r"^\s*CCB_DONE:\s*\d{8}-\d{6}-\d{3}-\d+\s*$")
+_ANY_CCB_DONE_LINE_RE = re.compile(rf"^\s*CCB_DONE:\s*{_REQ_ID_RE_FRAGMENT}\s*$", re.IGNORECASE)
 
 
 def _is_trailing_noise_line(line: str) -> bool:
@@ -41,13 +43,9 @@ def strip_trailing_markers(text: str) -> str:
 
 
 def make_req_id() -> str:
-    # Use readable datetime-PID format with millisecond precision
-    # Format: YYYYMMDD-HHMMSS-mmm-PID (e.g., 20260125-143000-123-12345)
-    import os
-    from datetime import datetime
-    now = datetime.now()
-    ms = now.microsecond // 1000
-    return f"{now.strftime('%Y%m%d-%H%M%S')}-{ms:03d}-{os.getpid()}"
+    # 32 hex chars (128-bit) for uniqueness and easy parsing.
+    # Keep lowercase to simplify regex matching.
+    return secrets.token_hex(16)
 
 
 def wrap_codex_prompt(message: str, req_id: str) -> str:


### PR DESCRIPTION
## Summary
Standardize CCB request IDs to 32 lowercase hex chars (128-bit) for uniqueness and consistent parsing.

## Details
- make_req_id now returns secrets.token_hex(16) (32 hex chars).
- Protocol regexes accept both the new 32-hex IDs and the legacy timestamp format for backward compatibility.

## Testing
- python -m pytest -q