### PR TITLE
fix(mail): unblock ccb mail setup import on config v3

### DIFF
--- a/lib/mail_tui/wizard.py
+++ b/lib/mail_tui/wizard.py
@@ -21,7 +21,7 @@ except ImportError:
     TEXTUAL_AVAILABLE = False
 
 from mail.config import (
-    MailConfig, AccountConfig, RoutingConfig, PollingConfig,
+    MailConfig, AccountConfig, PollingConfig,
     ImapConfig, SmtpConfig, PROVIDER_PRESETS, load_config, save_config,
 )
 from mail.credentials import store_password, has_password
@@ -95,7 +95,7 @@ def run_simple_wizard() -> bool:
     print("  2. Subject prefix ([claude] message)")
 
     route_choice = input("\nEnter choice [1-2]: ").strip()
-    routing_mode = "subject_prefix" if route_choice == "2" else "plus_alias"
+    _routing_mode = "subject_prefix" if route_choice == "2" else "plus_alias"
 
     # Step 5: Default provider
     print("\nSelect default AI provider:")
@@ -143,12 +143,16 @@ def run_simple_wizard() -> bool:
         )
 
     config.account.email = email
-    config.routing = RoutingConfig(
-        mode=routing_mode,
-        default_provider=default_provider,
-        allowed_senders=allowed_senders,
-        reply_to_address=reply_to,
-    )
+
+    # V3 config no longer has RoutingConfig.
+    # Keep setup inputs mapped to current fields:
+    # - default provider stays explicit
+    # - target_email acts as the authorized/reply address
+    config.default_provider = default_provider
+    if reply_to:
+        config.target_email = reply_to
+    elif allowed_senders:
+        config.target_email = allowed_senders[0]
 
     # Step 8: Test connection
     print("\nTesting connection...")
@@ -291,4 +295,3 @@ def run_wizard() -> bool:
             print(f"TUI error: {e}, falling back to simple wizard")
 
     return run_simple_wizard()
-

--- a/test/test_mail_setup_wizard_import.py
+++ b/test/test_mail_setup_wizard_import.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import importlib
+
+
+def test_mail_setup_wizard_module_imports() -> None:
+    module = importlib.import_module("mail_tui.wizard")
+    assert hasattr(module, "run_wizard")
+    assert hasattr(module, "run_simple_wizard")


### PR DESCRIPTION
## Summary
- remove stale `RoutingConfig` import from `mail_tui.wizard`
- map wizard setup outputs to v3 config fields (`default_provider`, `target_email`)
- add a regression test that imports `mail_tui.wizard` to prevent startup regressions

## Repro
- before: `ccb mail setup` failed with `cannot import name 'RoutingConfig' from mail.config`
- after: wizard starts and prompts for provider/email (no import failure)

## Test Plan
- `pytest -q test/test_mail_setup_wizard_import.py`
