### PR TITLE
fix(tmux): install CCB block into .tmux.conf.local for Oh My Tmux

### DIFF
--- a/config/tmux-ccb.conf
+++ b/config/tmux-ccb.conf
@@ -83,11 +83,16 @@ if-shell 'command -v pbcopy' {
     bind-key -T copy-mode-vi Enter send -X copy-pipe-and-cancel 'pbcopy'
     bind-key -T copy-mode-vi MouseDragEnd1Pane send -X copy-pipe-and-cancel 'pbcopy'
 }
-# WSL: Use PowerShell for clipboard (clip.exe doesn't support UTF-8)
-if-shell '[ -n "$WSL_DISTRO_NAME" ] && command -v powershell.exe' {
-    bind-key -T copy-mode-vi 'y' send -X copy-pipe "powershell.exe -NoProfile -Command 'Set-Clipboard -Value ([Console]::In.ReadToEnd())'"
-    bind-key -T copy-mode-vi Enter send -X copy-pipe-and-cancel "powershell.exe -NoProfile -Command 'Set-Clipboard -Value ([Console]::In.ReadToEnd())'"
-    bind-key -T copy-mode-vi MouseDragEnd1Pane send -X copy-pipe-and-cancel "powershell.exe -NoProfile -Command 'Set-Clipboard -Value ([Console]::In.ReadToEnd())'"
+# Prefer PowerShell clipboard providers when available (more reliable UTF-8 handling on WSL/Windows).
+if-shell 'command -v powershell.exe >/dev/null 2>&1' {
+    bind-key -T copy-mode-vi 'y' send -X copy-pipe "powershell.exe -NoProfile -Command '[Console]::InputEncoding=[System.Text.UTF8Encoding]::new(); Set-Clipboard -Value ([Console]::In.ReadToEnd())'"
+    bind-key -T copy-mode-vi Enter send -X copy-pipe-and-cancel "powershell.exe -NoProfile -Command '[Console]::InputEncoding=[System.Text.UTF8Encoding]::new(); Set-Clipboard -Value ([Console]::In.ReadToEnd())'"
+    bind-key -T copy-mode-vi MouseDragEnd1Pane send -X copy-pipe-and-cancel "powershell.exe -NoProfile -Command '[Console]::InputEncoding=[System.Text.UTF8Encoding]::new(); Set-Clipboard -Value ([Console]::In.ReadToEnd())'"
+}
+if-shell 'command -v pwsh >/dev/null 2>&1' {
+    bind-key -T copy-mode-vi 'y' send -X copy-pipe "pwsh -NoLogo -NoProfile -Command '[Console]::InputEncoding=[System.Text.UTF8Encoding]::new(); Set-Clipboard -Value ([Console]::In.ReadToEnd())'"
+    bind-key -T copy-mode-vi Enter send -X copy-pipe-and-cancel "pwsh -NoLogo -NoProfile -Command '[Console]::InputEncoding=[System.Text.UTF8Encoding]::new(); Set-Clipboard -Value ([Console]::In.ReadToEnd())'"
+    bind-key -T copy-mode-vi MouseDragEnd1Pane send -X copy-pipe-and-cancel "pwsh -NoLogo -NoProfile -Command '[Console]::InputEncoding=[System.Text.UTF8Encoding]::new(); Set-Clipboard -Value ([Console]::In.ReadToEnd())'"
 }
 
 # Paste from system clipboard (try providers in order; avoids X11/Wayland mis-detection).
@@ -95,6 +100,8 @@ if-shell '[ -n "$WSL_DISTRO_NAME" ] && command -v powershell.exe' {
 # Also bind `prefix + p` because many users expect it (and some configs remap `]`).
 bind-key ] run-shell "sh -lc '\
 out=\"\"; \
+if [ -z \"\$out\" ] && command -v pwsh >/dev/null 2>&1; then out=$(pwsh -NoLogo -NoProfile -Command '\''[Console]::OutputEncoding=[System.Text.UTF8Encoding]::new(); Get-Clipboard'\'' 2>/dev/null | tr -d \"\\r\" || true); fi; \
+if [ -z \"\$out\" ] && command -v powershell.exe >/dev/null 2>&1; then out=$(powershell.exe -NoProfile -Command '\''[Console]::OutputEncoding=[System.Text.UTF8Encoding]::new(); Get-Clipboard'\'' 2>/dev/null | tr -d \"\\r\" || true); fi; \
 if [ -z \"\$out\" ] && command -v wl-paste >/dev/null 2>&1; then out=$(wl-paste -n 2>/dev/null || true); fi; \
 if [ -z \"\$out\" ] && command -v wl-paste >/dev/null 2>&1; then out=$(wl-paste -n -p 2>/dev/null || true); fi; \
 if [ -z \"\$out\" ] && command -v xclip >/dev/null 2>&1; then out=$(xclip -selection clipboard -o 2>/dev/null || true); fi; \
@@ -102,11 +109,12 @@ if [ -z \"\$out\" ] && command -v xclip >/dev/null 2>&1; then out=$(xclip -selec
 if [ -z \"\$out\" ] && command -v xsel >/dev/null 2>&1; then out=$(xsel --clipboard --output 2>/dev/null || true); fi; \
 if [ -z \"\$out\" ] && command -v xsel >/dev/null 2>&1; then out=$(xsel --primary --output 2>/dev/null || true); fi; \
 if [ -z \"\$out\" ] && command -v pbpaste >/dev/null 2>&1; then out=$(pbpaste 2>/dev/null || true); fi; \
-if [ -z \"\$out\" ] && command -v powershell.exe >/dev/null 2>&1; then out=$(powershell.exe -NoProfile -Command Get-Clipboard 2>/dev/null | tr -d \"\\r\" || true); fi; \
 if [ -z \"\$out\" ]; then tmux display-message \"No clipboard content/helper found (install wl-clipboard or xclip/xsel)\"; exit 0; fi; \
 printf \"%s\" \"\$out\"' | tmux load-buffer - && tmux paste-buffer"
 bind-key p run-shell "sh -lc '\
 out=\"\"; \
+if [ -z \"\$out\" ] && command -v pwsh >/dev/null 2>&1; then out=$(pwsh -NoLogo -NoProfile -Command '\''[Console]::OutputEncoding=[System.Text.UTF8Encoding]::new(); Get-Clipboard'\'' 2>/dev/null | tr -d \"\\r\" || true); fi; \
+if [ -z \"\$out\" ] && command -v powershell.exe >/dev/null 2>&1; then out=$(powershell.exe -NoProfile -Command '\''[Console]::OutputEncoding=[System.Text.UTF8Encoding]::new(); Get-Clipboard'\'' 2>/dev/null | tr -d \"\\r\" || true); fi; \
 if [ -z \"\$out\" ] && command -v wl-paste >/dev/null 2>&1; then out=$(wl-paste -n 2>/dev/null || true); fi; \
 if [ -z \"\$out\" ] && command -v wl-paste >/dev/null 2>&1; then out=$(wl-paste -n -p 2>/dev/null || true); fi; \
 if [ -z \"\$out\" ] && command -v xclip >/dev/null 2>&1; then out=$(xclip -selection clipboard -o 2>/dev/null || true); fi; \
@@ -114,7 +122,6 @@ if [ -z \"\$out\" ] && command -v xclip >/dev/null 2>&1; then out=$(xclip -selec
 if [ -z \"\$out\" ] && command -v xsel >/dev/null 2>&1; then out=$(xsel --clipboard --output 2>/dev/null || true); fi; \
 if [ -z \"\$out\" ] && command -v xsel >/dev/null 2>&1; then out=$(xsel --primary --output 2>/dev/null || true); fi; \
 if [ -z \"\$out\" ] && command -v pbpaste >/dev/null 2>&1; then out=$(pbpaste 2>/dev/null || true); fi; \
-if [ -z \"\$out\" ] && command -v powershell.exe >/dev/null 2>&1; then out=$(powershell.exe -NoProfile -Command Get-Clipboard 2>/dev/null | tr -d \"\\r\" || true); fi; \
 if [ -z \"\$out\" ]; then tmux display-message \"No clipboard content/helper found (install wl-clipboard or xclip/xsel)\"; exit 0; fi; \
 printf \"%s\" \"\$out\"' | tmux load-buffer - && tmux paste-buffer"
 


### PR DESCRIPTION
## Background
- We previously fixed WSL clipboard encoding issues in an earlier PR (the one you opened before), and that fix worked at the time.
- After later updates, `ccb update` started doing a clean reinstall flow (`CCB_CLEAN_INSTALL=1`), which re-applies tmux integration during install.
- In current `main`, tmux install logic still appends the CCB block to `~/.tmux.conf`.

## What Broke
- For Oh My Tmux users, writing CCB config into `~/.tmux.conf` can interfere with its internal reload/apply path (`_apply_configuration`) and cause reload errors like return 127.
- So this is not only a local setup issue: it's a compatibility regression triggered by update/reinstall behavior.

## Root Cause
1. Clipboard behavior was fixed earlier.
2. Later clean reinstall/update rewrote tmux config.
3. Installer target location (`~/.tmux.conf` instead of `~/.tmux.conf.local` for Oh My Tmux) caused the new failure.

## Fix in This PR
- Use a specific tmux marker (avoid broad marker false positives).
- Detect Oh My Tmux (`TMUX_CONF_LOCAL` in main config).
- Install CCB tmux block to `~/.tmux.conf.local` for Oh My Tmux setups.
- Keep default behavior for non-Oh-My-Tmux setups (still `~/.tmux.conf`).
- On install/uninstall, remove stale CCB blocks from both main/local files to avoid legacy leftovers.
- Improve WSL clipboard path by prioritizing `pwsh` / `powershell.exe` in paste flow and keeping UTF-8-safe PowerShell copy pipeline.

## Why This Matters
- Prevents update-time regression: users who were previously fine should not break again after `ccb update`.
- Aligns with Oh My Tmux conventions and CCB's stated compatibility.

## Validation
- `bash -n install.sh`
- `pytest -q test/test_tmux_backend.py test/test_tmux_respawn_pane.py test/test_ccb_tmux_split.py`
- Temp-HOME install simulation:
  - Oh My Tmux layout -> CCB block written to `.tmux.conf.local`
  - Non-Oh-My-Tmux layout -> CCB block written to `.tmux.conf`
  - Stale CCB block in `.tmux.conf` is cleaned on update
