### PR TITLE
feat: add config/local/ overlay for persistent custom configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ GEMINI.md
 openspec
 *.log
 .hippocampus
+config/local/*
+!config/local/.gitkeep

--- a/ccb
+++ b/ccb
@@ -4292,6 +4292,115 @@ def cmd_reinstall(_args) -> int:
     return _run_installer("install")
 
 
+CONFIG_TEMPLATES = [
+    "claude-md-ccb.md",
+    "agents-md-ccb.md",
+    "clinerules-ccb.md",
+]
+
+
+def cmd_config(argv: list[str]) -> int:
+    """Handle ccb config subcommands for local config overrides."""
+    parser = argparse.ArgumentParser(
+        prog="ccb config",
+        description="Manage local config overrides that persist across updates",
+    )
+    subparsers = parser.add_subparsers(dest="subcommand", help="Config subcommands")
+    subparsers.add_parser("show", help="Show which configs have local overrides")
+    init_parser = subparsers.add_parser(
+        "init", help="Create local override from current template"
+    )
+    init_parser.add_argument(
+        "template",
+        nargs="?",
+        choices=CONFIG_TEMPLATES,
+        help="Template to override (default: all)",
+    )
+    edit_parser = subparsers.add_parser(
+        "edit", help="Edit a local override in your $EDITOR"
+    )
+    edit_parser.add_argument(
+        "template", choices=CONFIG_TEMPLATES, help="Template to edit"
+    )
+    reset_parser = subparsers.add_parser(
+        "reset", help="Remove local override, reverting to upstream default"
+    )
+    reset_parser.add_argument(
+        "template",
+        nargs="?",
+        choices=CONFIG_TEMPLATES,
+        help="Template to reset (default: all)",
+    )
+
+    args = parser.parse_args(argv)
+
+    local_dir = script_dir / "config" / "local"
+
+    if args.subcommand == "show":
+        print("Local config overrides:")
+        print(f"  Directory: {local_dir}")
+        print()
+        for tpl in CONFIG_TEMPLATES:
+            local_file = local_dir / tpl
+            default_file = script_dir / "config" / tpl
+            if local_file.exists():
+                print(f"  ✅ {tpl} (local override active)")
+            elif default_file.exists():
+                print(f"  ── {tpl} (using upstream default)")
+            else:
+                print(f"  ❌ {tpl} (template not found)")
+        return 0
+
+    if args.subcommand == "init":
+        local_dir.mkdir(parents=True, exist_ok=True)
+        templates = [args.template] if args.template else CONFIG_TEMPLATES
+        for tpl in templates:
+            src = script_dir / "config" / tpl
+            dst = local_dir / tpl
+            if not src.exists():
+                print(f"  WARN: Template not found: {src}", file=sys.stderr)
+                continue
+            if dst.exists():
+                print(f"  Skip: {tpl} (local override already exists)")
+                continue
+            shutil.copy2(str(src), str(dst))
+            print(f"  Created: config/local/{tpl}")
+        print()
+        print("Edit your local overrides, then run 'ccb reinstall' to apply.")
+        return 0
+
+    if args.subcommand == "edit":
+        local_file = local_dir / args.template
+        if not local_file.exists():
+            # Auto-init if not present
+            local_dir.mkdir(parents=True, exist_ok=True)
+            src = script_dir / "config" / args.template
+            if not src.exists():
+                print(f"Template not found: {src}", file=sys.stderr)
+                return 1
+            shutil.copy2(str(src), str(local_file))
+            print(f"Created config/local/{args.template} from upstream template.")
+
+        editor = os.environ.get("EDITOR", "vi")
+        return subprocess.call([editor, str(local_file)])
+
+    if args.subcommand == "reset":
+        templates = [args.template] if args.template else CONFIG_TEMPLATES
+        for tpl in templates:
+            local_file = local_dir / tpl
+            if local_file.exists():
+                local_file.unlink()
+                print(f"  Removed: config/local/{tpl}")
+            else:
+                print(f"  Skip: {tpl} (no local override)")
+        print()
+        print("Run 'ccb reinstall' to apply upstream defaults.")
+        return 0
+
+    parser.print_help()
+    return 1
+
+
 def _droid_server_path() -> Path:
     return script_dir / "mcp" / "ccb-delegation" / "server.py"
 
@@ -4510,6 +4619,10 @@ def main():
     if argv and argv[0] == "droid" and len(argv) > 1 and argv[1] in {"setup-delegation", "test-delegation"}:
         return cmd_droid_subcommand(argv[1:])
 
+    # Handle 'ccb config' subcommand
+    if argv and argv[0] == "config":
+        return cmd_config(argv[1:])
+
     if argv and argv[0] in {"kill", "update", "version", "uninstall", "reinstall"}:
         parser = argparse.ArgumentParser(description="Claude AI unified launcher", add_help=True)
         subparsers = parser.add_subparsers(dest="command", help="Subcommands")
@@ -4548,7 +4661,7 @@ def main():
     start_parser = argparse.ArgumentParser(
         description="Claude AI unified launcher",
         add_help=True,
-        epilog="Other commands: ccb update | ccb version | ccb kill | ccb uninstall | ccb reinstall | ccb droid setup-delegation | ccb mail setup",
+        epilog="Other commands: ccb update | ccb version | ccb kill | ccb config | ccb uninstall | ccb reinstall | ccb droid setup-delegation | ccb mail setup",
     )
     start_parser.add_argument(
         "providers",

--- a/docs/custom-config.md
+++ b/docs/custom-config.md
@@ -1,0 +1,84 @@
+# Custom Config Overrides
+
+CCB ships with default config templates in `config/`. These templates define:
+
+- **Role assignments** (which AI handles which role)
+- **Review framework** (peer review rules and rubrics)
+- **Collaboration rules** (async guardrails, inspiration consultation)
+
+By default, `ccb update` downloads the latest version and overwrites these
+templates. If you customize roles or review rules, your changes are lost.
+
+## Local Overrides
+
+The `config/local/` directory lets you persist custom configurations across
+updates. Files placed here take priority over the upstream defaults.
+
+### Supported override files
+
+| File | Injected into | Controls |
+|------|--------------|----------|
+| `claude-md-ccb.md` | `~/.claude/CLAUDE.md` | Role table, review framework, collaboration rules |
+| `agents-md-ccb.md` | `AGENTS.md` | Role table, review rubrics for Codex |
+| `clinerules-ccb.md` | `.clinerules` | Role table for Cline/Roo |
+
+### Quick start
+
+```bash
+# Initialize local overrides from current upstream templates
+ccb config init
+
+# Edit a specific override
+ccb config edit claude-md-ccb.md
+
+# Apply changes
+ccb reinstall
+
+# Check which overrides are active
+ccb config show
+
+# Remove a local override (revert to upstream)
+ccb config reset claude-md-ccb.md
+```
+
+### Example: Custom role assignments
+
+1. Initialize the override:
+   ```bash
+   ccb config init claude-md-ccb.md
+   ```
+
+2. Edit `config/local/claude-md-ccb.md` and change the role table:
+   ```markdown
+   | Role | Provider | Description |
+   |------|----------|-------------|
+   | `architect` | `claude` | Primary planner, orchestrator, final acceptance |
+   | `executor` | `codex` | Code implementation, testing, bug fixing |
+   | `reviewer` | `gemini` | Code review, quality assessment |
+   ```
+
+3. Apply:
+   ```bash
+   ccb reinstall
+   ```
+
+4. Future `ccb update` commands will preserve your `config/local/` directory
+   and continue using your custom role assignments.
+
+## How it works
+
+- `copy_project()` in `install.sh` saves and restores `config/local/` during
+  updates, so the directory survives even full version upgrades.
+- `install_*_config()` functions check for a local override before falling
+  back to the upstream default template.
+- The `ccb config` CLI provides convenient management commands.
+
+## Important notes
+
+- Local overrides replace the **entire** template file, not individual
+  sections. If upstream adds new sections, you may need to merge them
+  manually. Run `ccb config show` after updates to check.
+- To see what changed upstream, compare your override with the default:
+  ```bash
+  diff config/local/claude-md-ccb.md config/claude-md-ccb.md
+  ```


### PR DESCRIPTION
Problem

  ccb update downloads the latest release and replaces the entire install directory, including config templates (config/claude-md-ccb.md,
  config/agents-md-ccb.md, config/clinerules-ccb.md). Users who customize role assignments or review rules lose their changes on every update.

  Solution

  Introduce a config/local/ directory that acts as a persistent overlay layer:

  1. Preservation: copy_project() saves and restores config/local/ during directory replacement
  2. Template resolution: New resolve_config_template() helper checks for local override before falling back to upstream default
  3. CLI management: New ccb config subcommand (init/edit/show/reset)
  4. Documentation: docs/custom-config.md

  Usage

  ccb config init                        # Copy templates to config/local/
  ccb config edit claude-md-ccb.md       # Edit role assignments
  ccb reinstall                          # Apply changes
  ccb config show                        # Check active overrides
  ccb config reset                       # Revert to upstream

  Files changed

  ┌───────────────────────┬──────────────────────────────────────────────────────────────────────────────────────────────────┐
  │         File          │                                              Change                                              │
  ├───────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ install.sh            │ Preserve/restore config/local/; add resolve_config_template(); update 3 config install functions │
  ├───────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ccb                   │ Add cmd_config() with init/edit/show/reset                                                       │
  ├───────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ config/local/.gitkeep │ Placeholder directory                                                                            │
  ├───────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ docs/custom-config.md │ Usage documentation                                                                              │
  ├───────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ .gitignore            │ Ignore user files, track .gitkeep                                                                │
  └───────────────────────┴──────────────────────────────────────────────────────────────────────────────────────────────────┘

  Design decisions

  - Full-file override keeps implementation simple and predictable
  - config/local/ inside install dir aligns with existing project layout
  - Backward compatible: No changes when config/local/ is empty

  Test plan

  - ccb config init creates local overrides from upstream templates
  - ccb config show correctly identifies active overrides
  - ccb reinstall uses local overrides when present
  - ccb update preserves config/local/ directory
  - ccb config reset removes overrides and reverts to defaults
  - No behavioral change when config/local/ is empty