### PR TITLE
fix(core): improve ask caller routing and cross-dir session resolution

### DIFF
--- a/bin/ask
+++ b/bin/ask
@@ -22,6 +22,8 @@ Examples:
 from __future__ import annotations
 
 import os
+import json
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -44,6 +46,7 @@ from compat import read_stdin_text, setup_windows_encoding
 setup_windows_encoding()
 
 from cli_output import EXIT_ERROR, EXIT_OK
+from session_utils import find_project_session_file
 
 
 # Provider to daemon command mapping
@@ -54,6 +57,30 @@ PROVIDER_DAEMONS = {
     "droid": "dask",
     "claude": "lask",
 }
+
+CALLER_SESSION_FILES = {
+    "claude": ".claude-session",
+    "codex": ".codex-session",
+    "gemini": ".gemini-session",
+    "opencode": ".opencode-session",
+    "droid": ".droid-session",
+}
+
+CALLER_PANE_ENV_HINTS = {
+    "codex": ("CODEX_TMUX_SESSION", "CODEX_WEZTERM_PANE"),
+    "gemini": ("GEMINI_TMUX_SESSION", "GEMINI_WEZTERM_PANE"),
+    "opencode": ("OPENCODE_TMUX_SESSION", "OPENCODE_WEZTERM_PANE"),
+    "droid": ("DROID_TMUX_SESSION", "DROID_WEZTERM_PANE"),
+}
+
+CALLER_ENV_HINTS = {
+    "codex": ("CODEX_SESSION_ID", "CODEX_RUNTIME_DIR"),
+    "gemini": ("GEMINI_SESSION_ID", "GEMINI_RUNTIME_DIR"),
+    "opencode": ("OPENCODE_SESSION_ID", "OPENCODE_RUNTIME_DIR"),
+    "droid": ("DROID_SESSION_ID", "DROID_RUNTIME_DIR"),
+}
+
+VALID_CALLERS = set(CALLER_SESSION_FILES.keys()) | {"email", "manual"}
 
 
 def _env_int(name: str, default: int) -> int:
@@ -83,11 +110,99 @@ def _cleanup_task_logs(log_dir: Path) -> None:
         logs.sort(key=lambda p: p.name, reverse=True)
     for path in logs[max_files:]:
         prefix = path.name[:-4]  # strip .log
-        for ext in (".log", ".sh", ".ps1", ".msg"):
+        for ext in (".log", ".sh", ".ps1", ".msg", ".status"):
             try:
                 (log_dir / f"{prefix}{ext}").unlink(missing_ok=True)
             except Exception:
                 pass
+
+
+def _normalize_caller(raw: str) -> str:
+    caller = (raw or "").strip().lower()
+    if caller in VALID_CALLERS:
+        return caller
+    return ""
+
+
+def _load_json_dict(path: Path) -> dict:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+        if isinstance(data, dict):
+            return data
+    except Exception:
+        pass
+    return {}
+
+
+def _infer_caller_from_pane() -> str:
+    pane_id = (os.environ.get("TMUX_PANE") or os.environ.get("WEZTERM_PANE") or "").strip()
+    if not pane_id:
+        return ""
+
+    # Fast-path: CCB may export known pane ids in env for cross-pane routing.
+    for caller, keys in CALLER_PANE_ENV_HINTS.items():
+        for key in keys:
+            value = (os.environ.get(key) or "").strip()
+            if value and value == pane_id:
+                return caller
+
+    # Fallback: resolve by local session files for the current project/cwd.
+    cwd = Path.cwd()
+    for caller, session_filename in CALLER_SESSION_FILES.items():
+        try:
+            session_file = find_project_session_file(cwd, session_filename)
+        except Exception:
+            session_file = None
+        if not session_file:
+            continue
+        data = _load_json_dict(session_file)
+        session_pane = str(data.get("pane_id") or data.get("tmux_session") or "").strip()
+        if session_pane and session_pane == pane_id:
+            return caller
+
+    return ""
+
+
+def _infer_caller_from_env_hints() -> str:
+    matches: list[str] = []
+    for caller, keys in CALLER_ENV_HINTS.items():
+        if any((os.environ.get(key) or "").strip() for key in keys):
+            matches.append(caller)
+    if len(matches) == 1:
+        return matches[0]
+    return ""
+
+
+def _detect_caller() -> str:
+    direct = _normalize_caller(os.environ.get("CCB_CALLER", ""))
+    if direct:
+        return direct
+
+    # Email worker may carry email metadata even when CCB_CALLER isn't exported.
+    if (os.environ.get("CCB_EMAIL_REQ_ID") or "").strip():
+        return "email"
+
+    pane = _infer_caller_from_pane()
+    if pane:
+        return pane
+
+    hinted = _infer_caller_from_env_hints()
+    if hinted:
+        return hinted
+
+    return ""
+
+
+def _append_task_status_line(status_file: Path, line: str) -> None:
+    """Append one timestamped lifecycle line for async task observability."""
+    ts = datetime.now().strftime("%Y-%m-%dT%H:%M:%S%z")
+    try:
+        status_file.parent.mkdir(parents=True, exist_ok=True)
+        with status_file.open("a", encoding="utf-8") as handle:
+            handle.write(f"{ts} {line}\n")
+    except Exception:
+        pass
 
 
 def _use_unified_daemon() -> bool:
@@ -301,19 +416,40 @@ def _default_foreground() -> bool:
         return False
     if _env_bool("CCB_ASK_FOREGROUND", False):
         return True
-    # If CCB_CALLER is set, use background (nohup) mode
-    if os.environ.get("CCB_CALLER"):
+    # Default async only for Claude caller to preserve historical guardrail behavior.
+    # Other callers (codex/gemini/opencode/droid/manual) default to foreground.
+    caller = _detect_caller()
+    if caller == "claude":
         return False
-    # No caller set, use foreground mode
     return True
 
 
+def _should_emit_async_guardrail(caller: str) -> bool:
+    """
+    Decide whether to print strict async guardrail text.
+
+    Override with CCB_ASK_EMIT_GUARDRAIL=0/1.
+    Default: enabled only when caller is Claude.
+    """
+    raw = (os.environ.get("CCB_ASK_EMIT_GUARDRAIL") or "").strip().lower()
+    if raw:
+        return raw not in ("0", "false", "no", "off")
+    return (caller or "").strip().lower() == "claude"
+
+
 def _require_caller() -> str:
-    caller = (os.environ.get("CCB_CALLER") or "").strip()
+    caller = _detect_caller()
     if caller:
         return caller
-    print("[ERROR] CCB_CALLER is required. Set CCB_CALLER=<provider> (e.g. CCB_CALLER=claude).", file=sys.stderr)
-    sys.exit(1)
+    default_caller = _normalize_caller(os.environ.get("CCB_CALLER_DEFAULT", ""))
+    if not default_caller:
+        default_caller = "manual"
+    print(
+        f"[WARN] CCB_CALLER not set; using '{default_caller}'. "
+        "Set CCB_CALLER explicitly to override.",
+        file=sys.stderr,
+    )
+    return default_caller
 
 
 def make_task_id() -> str:
@@ -446,22 +582,32 @@ def main(argv: list[str]) -> int:
                 print(f"[ERROR] {e}", file=sys.stderr)
                 return EXIT_ERROR
 
-    # Default async mode: background task via nohup
+    # Default async mode: background task
     task_id = make_task_id()
     log_dir = Path(tempfile.gettempdir()) / "ccb-tasks"
     log_dir.mkdir(parents=True, exist_ok=True)
     log_file = log_dir / f"ask-{provider}-{task_id}.log"
+    status_file = log_dir / f"ask-{provider}-{task_id}.status"
     try:
         log_file.touch(exist_ok=True)
+    except Exception:
+        pass
+    try:
+        status_file.touch(exist_ok=True)
     except Exception:
         pass
     _cleanup_task_logs(log_dir)
 
     # Detect caller from environment or default to "claude"
     caller = _require_caller()
+    _append_task_status_line(
+        status_file,
+        f"submitted task={task_id} provider={provider} caller={caller} work_dir={os.getcwd()}",
+    )
 
     # Get the path to this script for recursive call with --foreground
     ask_cmd = str(Path(__file__).resolve())
+    bg_pid: int | None = None
 
     # Platform-specific background execution
     if os.name == "nt":
@@ -476,24 +622,40 @@ def main(argv: list[str]) -> int:
 
         # Write PowerShell script - call ask --foreground to use unified daemon
         script_file = log_dir / f"ask-{provider}-{task_id}.ps1"
+        status_file_win = str(status_file).replace('"', '`"')
+        log_file_win = str(log_file).replace('"', '`"')
         script_content = f'''$ErrorActionPreference = "SilentlyContinue"
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 $env:CCB_REQ_ID = "{task_id}"
 $env:CCB_CALLER = "{caller}"
 $env:CCB_WORK_DIR = "{os.getcwd()}"
+$statusFile = "{status_file_win}"
+$logFile = "{log_file_win}"
+function Write-CcbStatus([string]$line) {{
+  Add-Content -Path $statusFile -Value ("{{0}} {{1}}" -f (Get-Date -Format "yyyy-MM-ddTHH:mm:sszzz"), $line) -Encoding UTF8
+}}
+Write-CcbStatus "running pid=$PID"
 Get-Content -Path "{msg_file}" -Encoding UTF8 | python "{ask_cmd}" {provider} --foreground --timeout {timeout}
+$rc = $LASTEXITCODE
+Write-CcbStatus "finished exit_code=$rc"
+if ($rc -ne 0) {{
+  Write-CcbStatus "failed exit_code=$rc"
+}}
+exit $rc
 '''
         script_file.write_text(script_content, encoding="utf-8")
 
-        subprocess.Popen(
-            ["powershell", "-ExecutionPolicy", "Bypass", "-NoProfile", "-File", str(script_file)],
-            stdin=subprocess.DEVNULL,
-            stdout=open(log_file, "w"),
-            stderr=subprocess.STDOUT,
-            creationflags=DETACHED_PROCESS | CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP,
-        )
+        with log_file.open("a", encoding="utf-8") as log_handle:
+            proc = subprocess.Popen(
+                ["powershell", "-ExecutionPolicy", "Bypass", "-NoProfile", "-File", str(script_file)],
+                stdin=subprocess.DEVNULL,
+                stdout=log_handle,
+                stderr=subprocess.STDOUT,
+                creationflags=DETACHED_PROCESS | CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP,
+            )
+        bg_pid = proc.pid
     else:
-        # Unix: use nohup, call ask --foreground to use unified daemon
+        # Unix: run detached shell script, call ask --foreground to use unified daemon
         # Collect CCB_EMAIL_* env vars for email caller
         email_env_lines = ""
         if caller == "email":
@@ -506,31 +668,62 @@ Get-Content -Path "{msg_file}" -Encoding UTF8 | python "{ask_cmd}" {provider} --
         ccb_run_dir = os.environ.get("CCB_RUN_DIR", "")
         run_dir_line = f'export CCB_RUN_DIR="{ccb_run_dir}"\n' if ccb_run_dir else ""
 
-        bg_script = f'''
+        quoted_status = shlex.quote(str(status_file))
+        quoted_ask_cmd = shlex.quote(ask_cmd)
+        quoted_provider = shlex.quote(provider)
+        bg_script = f'''#!/bin/sh
+set +e
+_now() {{
+  date '+%Y-%m-%dT%H:%M:%S%z'
+}}
+echo "$(_now) running pid=$$" >> {quoted_status}
+echo "[CCB_TASK_START] task={task_id} provider={provider} caller={caller} pid=$$"
 export CCB_REQ_ID="{task_id}"
 export CCB_CALLER="{caller}"
 export CCB_WORK_DIR="{os.getcwd()}"
-{run_dir_line}{email_env_lines}python3 "{ask_cmd}" {provider} --foreground --timeout {timeout} <<'ASKEOF'
+{run_dir_line}{email_env_lines}python3 {quoted_ask_cmd} {quoted_provider} --foreground --timeout {timeout} <<'ASKEOF'
 {message}
 ASKEOF
+rc=$?
+echo "[CCB_TASK_END] task={task_id} provider={provider} exit_code=$rc"
+echo "$(_now) finished exit_code=$rc" >> {quoted_status}
+if [ "$rc" -ne 0 ]; then
+  echo "$(_now) failed exit_code=$rc" >> {quoted_status}
+fi
+exit "$rc"
 '''
-        # Write script to temp file for nohup execution
+        # Write script to temp file for detached execution
         script_file = log_dir / f"ask-{provider}-{task_id}.sh"
         script_file.write_text(bg_script, encoding="utf-8")
         script_file.chmod(0o755)
 
-        # Use nohup to run in background, independent of terminal
-        subprocess.Popen(
-            f'nohup sh "{script_file}" > "{log_file}" 2>&1 &',
-            shell=True,
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
+        # Run detached in its own session and stream stdout/stderr to task log.
+        with log_file.open("a", encoding="utf-8") as log_handle:
+            proc = subprocess.Popen(
+                ["sh", str(script_file)],
+                stdin=subprocess.DEVNULL,
+                stdout=log_handle,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+                close_fds=True,
+            )
+        bg_pid = proc.pid
+
+    if bg_pid is not None:
+        _append_task_status_line(status_file, f"spawned pid={bg_pid}")
+    else:
+        _append_task_status_line(status_file, "spawned pid=unknown")
 
     print(f"[CCB_ASYNC_SUBMITTED provider={provider}]")
     print(f"{display_name(provider)} processing (task: {task_id})")
-    print(f"MANDATORY: END YOUR TURN NOW. Reply ONLY '{display_name(provider)} processing...', then stop. See 'Async Guardrail' in CLAUDE.md.")
+    if bg_pid is not None:
+        print(f"[CCB_ASYNC_PID task={task_id} pid={bg_pid}]")
+    print(f"[CCB_ASYNC_STATUS_FILE task={task_id}] {status_file}")
+    print(f"[CCB_ASYNC_LOG_FILE task={task_id}] {log_file}")
+    if _should_emit_async_guardrail(caller):
+        print(
+            f"MANDATORY: END YOUR TURN NOW. Reply ONLY '{display_name(provider)} processing...', then stop. See 'Async Guardrail' in CLAUDE.md."
+        )
     return EXIT_OK
 
 

--- a/bin/ccb-completion-hook
+++ b/bin/ccb-completion-hook
@@ -33,6 +33,7 @@ lib_dir = script_dir.parent / "lib"
 sys.path.insert(0, str(lib_dir))
 
 from compat import read_stdin_text, setup_windows_encoding
+from session_utils import find_project_session_file
 
 setup_windows_encoding()
 
@@ -61,6 +62,45 @@ def load_session_file(session_path: Path) -> dict:
             return json.load(f)
     except Exception:
         return {}
+
+
+def _normalize_path_for_match(value: str) -> str:
+    s = (value or "").strip()
+    if not s:
+        return ""
+    try:
+        normalized = str(Path(s).expanduser().resolve())
+    except Exception:
+        try:
+            normalized = str(Path(s).expanduser().absolute())
+        except Exception:
+            normalized = s
+    normalized = normalized.replace("\\", "/").rstrip("/")
+    if os.name == "nt":
+        normalized = normalized.lower()
+    return normalized
+
+
+def _path_is_same_or_parent(parent: str, child: str) -> bool:
+    p = _normalize_path_for_match(parent)
+    c = _normalize_path_for_match(child)
+    if not p or not c:
+        return False
+    if p == c:
+        return True
+    if not c.startswith(p):
+        return False
+    return c[len(p):].startswith("/")
+
+
+def _work_dirs_compatible(session_work_dir: str, request_work_dir: str) -> bool:
+    if not session_work_dir or not request_work_dir:
+        return True
+    # Accept exact match and parent/child relationship to support calls from subdirectories.
+    return (
+        _path_is_same_or_parent(session_work_dir, request_work_dir)
+        or _path_is_same_or_parent(request_work_dir, session_work_dir)
+    )
 
 
 def send_via_terminal(pane_id: str, message: str, terminal: str, session_data: dict) -> bool:
@@ -360,36 +400,58 @@ Result: {reply_content}
     session_files = {
         "claude": ".claude-session",
         "codex": ".codex-session",
+        "gemini": ".gemini-session",
+        "opencode": ".opencode-session",
         "droid": ".droid-session",
     }
     session_filename = session_files.get(caller, ".claude-session")
 
     # Search for session file in multiple locations (order matters - most specific first)
     work_dir = os.environ.get("CCB_WORK_DIR", "")
-    search_paths = []
+    search_paths: list[Path] = []
+    seen_paths: set[str] = set()
     config_dirnames = (".ccb", ".ccb_config")
 
-    # 1. Request's work_dir (most specific)
-    if work_dir:
-        for dirname in config_dirnames:
-            search_paths.append(Path(work_dir) / dirname / session_filename)
+    def add_search_path(path: Path | None) -> None:
+        if not path:
+            return
+        p = Path(path)
+        key = str(p)
+        if key in seen_paths:
+            return
+        seen_paths.add(key)
+        search_paths.append(p)
 
-    # 2. Current working directory (fallback)
+    # 1. Request's work_dir (most specific), with upward lookup for nested dirs.
+    if work_dir:
+        try:
+            add_search_path(find_project_session_file(Path(work_dir), session_filename))
+        except Exception:
+            pass
+
+    # 2. Current working directory (fallback), with upward lookup.
     cwd = os.getcwd()
     if cwd != work_dir:
-        for dirname in config_dirnames:
-            search_paths.append(Path(cwd) / dirname / session_filename)
+        try:
+            add_search_path(find_project_session_file(Path(cwd), session_filename))
+        except Exception:
+            pass
 
     # 3. User's home-based locations
     for dirname in config_dirnames:
-        search_paths.append(Path.home() / ".local" / "share" / "codex-dual" / dirname / session_filename)
+        add_search_path(Path.home() / ".local" / "share" / "codex-dual" / dirname / session_filename)
 
     # 4. On Windows, also check LOCALAPPDATA
     if os.name == "nt":
         localappdata = os.environ.get("LOCALAPPDATA", "")
         if localappdata:
             for dirname in reversed(config_dirnames):
-                search_paths.insert(0, Path(localappdata) / "codex-dual" / dirname / session_filename)
+                p = Path(localappdata) / "codex-dual" / dirname / session_filename
+                key = str(p)
+                if key in seen_paths:
+                    continue
+                seen_paths.add(key)
+                search_paths.insert(0, p)
 
     pane_id = None
     terminal = "tmux"  # default
@@ -405,7 +467,7 @@ Result: {reply_content}
                 found_session_path = session_path
                 # Validate: check if session's work_dir matches request's work_dir
                 session_work_dir = session_data.get("work_dir", "")
-                if work_dir and session_work_dir and session_work_dir != work_dir:
+                if work_dir and session_work_dir and not _work_dirs_compatible(str(session_work_dir), str(work_dir)):
                     # Session file is for a different project, skip it
                     pane_id = None
                     continue

--- a/ccb
+++ b/ccb
@@ -26,7 +26,7 @@ from pathlib import Path
 
 script_dir = Path(__file__).resolve().parent
 sys.path.insert(0, str(script_dir / "lib"))
-from terminal import TmuxBackend, WeztermBackend, detect_terminal, is_wsl, get_shell_type
+from terminal import TmuxBackend, WeztermBackend, detect_terminal, is_wsl, get_shell_type, get_backend_for_session
 from compat import setup_windows_encoding
 from ccb_config import get_backend_env
 from ccb_start_config import DEFAULT_PROVIDERS, ensure_default_start_config, load_start_config
@@ -38,7 +38,7 @@ from session_utils import (
     resolve_project_config_dir,
     safe_write_session,
 )
-from pane_registry import upsert_registry
+from pane_registry import upsert_registry, load_registry_by_project_id
 from project_id import compute_ccb_project_id
 from providers import CASK_CLIENT_SPEC, GASK_CLIENT_SPEC, OASK_CLIENT_SPEC, LASK_CLIENT_SPEC, DASK_CLIENT_SPEC
 from process_lock import ProviderLock
@@ -604,6 +604,14 @@ class AILauncher:
             env["CCB_RUN_DIR"] = os.environ["CCB_RUN_DIR"]
         return env
 
+    def _provider_env_overrides(self, provider: str) -> dict:
+        """Managed env + explicit caller marker for the pane/provider process."""
+        env = self._managed_env_overrides()
+        prov = (provider or "").strip().lower()
+        if prov in {"claude", "codex", "gemini", "opencode", "droid", "email", "manual"}:
+            env["CCB_CALLER"] = prov
+        return env
+
     def _project_config_dir(self) -> Path:
         return resolve_project_config_dir(self.project_root)
 
@@ -749,13 +757,13 @@ class AILauncher:
     def _maybe_start_caskd(self) -> None:
         self._maybe_start_provider_daemon("codex")
 
-    def _maybe_start_unified_askd(self) -> None:
+    def _maybe_start_unified_askd(self, *, quiet: bool = False) -> None:
         """Start unified askd daemon (provider-agnostic)."""
         # Try to start for any enabled provider that uses askd (including claude)
         for provider in ["codex", "gemini", "opencode", "droid", "claude"]:
             if provider in [p.lower() for p in self.providers]:
                 # Try to start and check if successful
-                self._maybe_start_provider_daemon(provider)
+                self._maybe_start_provider_daemon(provider, quiet=quiet)
                 # Verify daemon actually started by pinging
                 try:
                     from askd_runtime import state_file_path
@@ -767,7 +775,7 @@ class AILauncher:
                     pass
                 # If not successful, continue to next provider
 
-    def _maybe_start_provider_daemon(self, provider: str) -> None:
+    def _maybe_start_provider_daemon(self, provider: str, *, quiet: bool = False) -> None:
         def _bool_from_env(name: str):
             raw = os.environ.get(name)
             if raw is None or raw == "":
@@ -778,6 +786,11 @@ class AILauncher:
             if v in {"1", "true", "yes", "on"}:
                 return True
             return None
+
+        def _emit(msg: str, *, err: bool = False) -> None:
+            if quiet and not _env_bool("CCB_DEBUG", False):
+                return
+            print(msg, file=sys.stderr if err else sys.stdout)
 
         provider = (provider or "").strip().lower()
         specs = {
@@ -808,7 +821,7 @@ class AILauncher:
             read_state = getattr(daemon_module, "read_state", None)
             shutdown_daemon_fn = getattr(daemon_module, "shutdown_daemon", None)
         except Exception as exc:
-            print(f"⚠️ Failed to import {spec.daemon_module}: {exc}")
+            _emit(f"⚠️ Failed to import {spec.daemon_module}: {exc}")
             return
 
         def _owned_by_ccb(state: dict | None) -> bool:
@@ -854,9 +867,9 @@ class AILauncher:
                     if force_rebind or not foreign_parent_alive:
                         # Safe to rebind: either forced or foreign parent is dead/stale
                         if force_rebind:
-                            print(f"⚠️ CCB_FORCE_REBIND=1 set, forcing askd rebind despite live parent (PID {foreign_parent_pid})...")
+                            _emit(f"⚠️ CCB_FORCE_REBIND=1 set, forcing askd rebind despite live parent (PID {foreign_parent_pid})...")
                         else:
-                            print(f"⚠️ askd owned by dead parent (PID {foreign_parent_pid}), restarting to bind lifecycle...")
+                            _emit(f"⚠️ askd owned by dead parent (PID {foreign_parent_pid}), restarting to bind lifecycle...")
                         if callable(shutdown_daemon_fn):
                             try:
                                 shutdown_daemon_fn(timeout_s=1.0, state_file=state_file)
@@ -864,14 +877,14 @@ class AILauncher:
                                 pass
                     else:
                         # Foreign parent is still alive, don't force rebind
-                        print(f"⚠️ askd owned by live parent (PID {foreign_parent_pid}), skipping rebind to avoid disruption")
-                        print(f"   Set CCB_FORCE_REBIND=1 to override this safety check")
+                        _emit(f"⚠️ askd owned by live parent (PID {foreign_parent_pid}), skipping rebind to avoid disruption")
+                        _emit(f"   Set CCB_FORCE_REBIND=1 to override this safety check")
                         host = st.get("host") if isinstance(st, dict) else None
                         port = st.get("port") if isinstance(st, dict) else None
                         if host and port:
-                            print(f"✅ {spec.daemon_bin_name} already running at {host}:{port}")
+                            _emit(f"✅ {spec.daemon_bin_name} already running at {host}:{port}")
                         else:
-                            print(f"✅ {spec.daemon_bin_name} already running")
+                            _emit(f"✅ {spec.daemon_bin_name} already running")
                         return
                     deadline = time.time() + 2.0
                     while time.time() < deadline:
@@ -879,34 +892,34 @@ class AILauncher:
                             break
                         time.sleep(0.1)
                     if ping_daemon(timeout_s=0.2, state_file=state_file):
-                        print("⚠️ askd restart skipped: existing daemon still running")
+                        _emit("⚠️ askd restart skipped: existing daemon still running")
                         host = st.get("host") if isinstance(st, dict) else None
                         port = st.get("port") if isinstance(st, dict) else None
                         if host and port:
-                            print(f"✅ {spec.daemon_bin_name} already running at {host}:{port}")
+                            _emit(f"✅ {spec.daemon_bin_name} already running at {host}:{port}")
                         else:
-                            print(f"✅ {spec.daemon_bin_name} already running")
+                            _emit(f"✅ {spec.daemon_bin_name} already running")
                         return
                 else:
                     host = st.get("host") if isinstance(st, dict) else None
                     port = st.get("port") if isinstance(st, dict) else None
                     if host and port:
-                        print(f"✅ {spec.daemon_bin_name} already running at {host}:{port}")
+                        _emit(f"✅ {spec.daemon_bin_name} already running at {host}:{port}")
                     else:
-                        print(f"✅ {spec.daemon_bin_name} already running")
+                        _emit(f"✅ {spec.daemon_bin_name} already running")
                     return
             else:
                 host = st.get("host") if isinstance(st, dict) else None
                 port = st.get("port") if isinstance(st, dict) else None
                 if host and port:
-                    print(f"✅ {spec.daemon_bin_name} already running at {host}:{port}")
+                    _emit(f"✅ {spec.daemon_bin_name} already running at {host}:{port}")
                 else:
-                    print(f"✅ {spec.daemon_bin_name} already running")
+                    _emit(f"✅ {spec.daemon_bin_name} already running")
                 return
 
         daemon_script = self.script_dir / "bin" / spec.daemon_bin_name
         if not daemon_script.exists():
-            print(f"⚠️ {spec.daemon_bin_name} not found (bin/{spec.daemon_bin_name}). Reinstall or update your checkout.")
+            _emit(f"⚠️ {spec.daemon_bin_name} not found (bin/{spec.daemon_bin_name}). Reinstall or update your checkout.")
             return
 
         kwargs = {
@@ -929,7 +942,7 @@ class AILauncher:
                 with self._daemon_proc_lock:
                     self._daemon_proc = proc
         except Exception as exc:
-            print(f"⚠️ Failed to start {spec.daemon_bin_name}: {exc}")
+            _emit(f"⚠️ Failed to start {spec.daemon_bin_name}: {exc}")
             return
 
         deadline = time.time() + 2.0
@@ -939,12 +952,12 @@ class AILauncher:
                 host = st.get("host") if isinstance(st, dict) else None
                 port = st.get("port") if isinstance(st, dict) else None
                 if host and port:
-                    print(f"✅ {spec.daemon_bin_name} started at {host}:{port}")
+                    _emit(f"✅ {spec.daemon_bin_name} started at {host}:{port}")
                 else:
-                    print(f"✅ {spec.daemon_bin_name} started")
+                    _emit(f"✅ {spec.daemon_bin_name} started")
                 return
             time.sleep(0.1)
-        print(f"⚠️ {spec.daemon_bin_name} start requested, but daemon not reachable yet")
+        _emit(f"⚠️ {spec.daemon_bin_name} start requested, but daemon not reachable yet")
 
     def _start_daemon_watchdog(self) -> None:
         """Start watchdog thread to monitor askd daemon health."""
@@ -971,6 +984,12 @@ class AILauncher:
         from askd_runtime import state_file_path
         from askd.daemon import ping_daemon, read_state
 
+        verbose_watchdog = _env_bool("CCB_WATCHDOG_VERBOSE", False) or _env_bool("CCB_DEBUG", False)
+
+        def _wd_log(msg: str) -> None:
+            if verbose_watchdog:
+                print(msg, file=sys.stderr)
+
         # Validate and clamp check interval
         try:
             check_interval = float(os.environ.get("CCB_WATCHDOG_INTERVAL_S", "10"))
@@ -994,7 +1013,7 @@ class AILauncher:
                         exit_code = self._daemon_proc.poll()
                         if exit_code is not None:
                             # Daemon process has exited
-                            print(f"⚠️ askd daemon process exited with code {exit_code}", file=sys.stderr)
+                            _wd_log(f"⚠️ askd daemon process exited with code {exit_code}")
                             self._daemon_proc = None
                             # Will be restarted by health check below
 
@@ -1004,8 +1023,8 @@ class AILauncher:
                     consecutive_failures += 1
                     if consecutive_failures >= max_failures:
                         # Daemon is unhealthy, try to restart
-                        print(f"⚠️ askd daemon unhealthy (failed {consecutive_failures} checks), attempting restart...", file=sys.stderr)
-                        self._maybe_start_unified_askd()
+                        _wd_log(f"⚠️ askd daemon unhealthy (failed {consecutive_failures} checks), attempting restart...")
+                        self._maybe_start_unified_askd(quiet=not verbose_watchdog)
                         consecutive_failures = 0
                 else:
                     # Daemon is healthy, verify ownership
@@ -1015,7 +1034,7 @@ class AILauncher:
                         managed = bool(state.get("managed"))
                         if managed and parent_pid != self.ccb_pid:
                             ownership_mismatch_count += 1
-                            print(f"⚠️ askd daemon ownership mismatch (parent_pid={parent_pid}, expected={self.ccb_pid}, count={ownership_mismatch_count})", file=sys.stderr)
+                            _wd_log(f"⚠️ askd daemon ownership mismatch (parent_pid={parent_pid}, expected={self.ccb_pid}, count={ownership_mismatch_count})")
                             if ownership_mismatch_count >= max_ownership_mismatches:
                                 # Check if forced rebind is enabled (case-insensitive)
                                 force_rebind = _env_bool("CCB_FORCE_REBIND", False)
@@ -1032,21 +1051,21 @@ class AILauncher:
                                 if force_rebind or not foreign_parent_alive:
                                     # Safe to rebind: either forced or foreign parent is dead/stale
                                     if force_rebind:
-                                        print(f"⚠️ CCB_FORCE_REBIND=1 set, forcing rebind despite live parent (PID {parent_pid})...", file=sys.stderr)
+                                        _wd_log(f"⚠️ CCB_FORCE_REBIND=1 set, forcing rebind despite live parent (PID {parent_pid})...")
                                     else:
-                                        print(f"⚠️ Foreign parent (PID {parent_pid}) is dead, attempting to rebind daemon...", file=sys.stderr)
+                                        _wd_log(f"⚠️ Foreign parent (PID {parent_pid}) is dead, attempting to rebind daemon...")
                                     try:
                                         from askd_rpc import shutdown_daemon
                                         shutdown_daemon("ask", timeout_s=2.0, state_file=state_file)
                                         time.sleep(1.0)  # Wait for shutdown
                                     except Exception:
                                         pass
-                                    self._maybe_start_unified_askd()
+                                    self._maybe_start_unified_askd(quiet=not verbose_watchdog)
                                     ownership_mismatch_count = 0
                                 else:
                                     # Foreign parent is still alive, don't force rebind
-                                    print(f"⚠️ Foreign parent (PID {parent_pid}) is still alive, skipping forced rebind to avoid disruption", file=sys.stderr)
-                                    print(f"   Set CCB_FORCE_REBIND=1 to override this safety check", file=sys.stderr)
+                                    _wd_log(f"⚠️ Foreign parent (PID {parent_pid}) is still alive, skipping forced rebind to avoid disruption")
+                                    _wd_log(f"   Set CCB_FORCE_REBIND=1 to override this safety check")
                                     ownership_mismatch_count = 0  # Reset to avoid repeated warnings
                         else:
                             ownership_mismatch_count = 0  # Reset on correct ownership
@@ -1236,7 +1255,7 @@ class AILauncher:
 
         pane_title_marker = f"CCB-{provider.capitalize()}"
         title_cmd = _build_pane_title_cmd(pane_title_marker)
-        env_overrides = self._managed_env_overrides()
+        env_overrides = self._provider_env_overrides(provider)
         full_cmd = title_cmd + self._build_env_prefix(env_overrides) + _build_export_path_cmd(self.script_dir / "bin") + start_cmd
         backend = WeztermBackend()
         pane_id = backend.create_pane(full_cmd, str(Path.cwd()), direction=use_direction, percent=50, parent_pane=use_parent)
@@ -2068,7 +2087,7 @@ class AILauncher:
         if not output_fifo.exists():
             os.mkfifo(output_fifo, 0o644)
 
-        env_overrides = self._managed_env_overrides()
+        env_overrides = self._provider_env_overrides("codex")
         start_cmd = self._build_env_prefix(env_overrides) + _build_export_path_cmd(self.script_dir / "bin") + self._build_codex_start_cmd()
         pane_title_marker = "CCB-Codex"
 
@@ -2159,7 +2178,7 @@ class AILauncher:
         runtime = self.runtime_dir / "gemini"
         runtime.mkdir(parents=True, exist_ok=True)
 
-        env_overrides = self._managed_env_overrides()
+        env_overrides = self._provider_env_overrides("gemini")
         start_cmd = self._build_env_prefix(env_overrides) + _build_export_path_cmd(self.script_dir / "bin") + self._build_gemini_start_cmd()
         pane_title_marker = "CCB-Gemini"
 
@@ -2210,7 +2229,7 @@ class AILauncher:
         runtime = self.runtime_dir / "opencode"
         runtime.mkdir(parents=True, exist_ok=True)
 
-        env_overrides = self._managed_env_overrides()
+        env_overrides = self._provider_env_overrides("opencode")
         start_cmd = self._build_env_prefix(env_overrides) + _build_export_path_cmd(self.script_dir / "bin") + self._build_opencode_start_cmd()
         pane_title_marker = "CCB-OpenCode"
 
@@ -2264,7 +2283,7 @@ class AILauncher:
         runtime = self.runtime_dir / "droid"
         runtime.mkdir(parents=True, exist_ok=True)
 
-        env_overrides = self._managed_env_overrides()
+        env_overrides = self._provider_env_overrides("droid")
         start_cmd = self._build_env_prefix(env_overrides) + _build_export_path_cmd(self.script_dir / "bin") + self._build_droid_start_cmd()
         pane_title_marker = "CCB-Droid"
 
@@ -2320,7 +2339,7 @@ class AILauncher:
         start_cmd = (cmd_settings.get("start_cmd") or "").strip() or self._default_cmd_start_cmd()
         full_cmd = (
             _build_pane_title_cmd(title)
-            + self._build_env_prefix(self._managed_env_overrides())
+            + self._build_env_prefix(self._provider_env_overrides("codex"))
             + _build_export_path_cmd(self.script_dir / "bin")
             + _build_cd_cmd(Path.cwd())
             + start_cmd
@@ -2374,7 +2393,7 @@ class AILauncher:
         title_cmd = _build_pane_title_cmd(pane_title_marker) if self.terminal_type == "wezterm" else ""
         start_cmd = (
             title_cmd
-            + self._build_env_prefix(self._managed_env_overrides())
+            + self._build_env_prefix(self._provider_env_overrides("codex"))
             + _build_export_path_cmd(self.script_dir / "bin")
             + self._build_codex_start_cmd()
         )
@@ -2421,7 +2440,7 @@ class AILauncher:
         # 因而会触发 [WinError 2] 找不到可执行文件。这里改为通过 shell 执行以确保可启动。
         if os.name == "nt":
             env = self._with_bin_path_env()
-            env.update(self._managed_env_overrides())
+            env.update(self._provider_env_overrides("codex"))
             env["CODEX_SESSION_ID"] = self.session_id
             env["CODEX_RUNTIME_DIR"] = str(runtime)
             env["CODEX_INPUT_FIFO"] = str(input_fifo)
@@ -2435,7 +2454,7 @@ class AILauncher:
 
         cmd_parts = shlex.split(self._build_codex_start_cmd())
         env = self._with_bin_path_env()
-        env.update(self._managed_env_overrides())
+        env.update(self._provider_env_overrides("codex"))
         env["CODEX_SESSION_ID"] = self.session_id
         env["CODEX_RUNTIME_DIR"] = str(runtime)
         env["CODEX_INPUT_FIFO"] = str(input_fifo)
@@ -2481,7 +2500,7 @@ class AILauncher:
         title_cmd = _build_pane_title_cmd(pane_title_marker) if self.terminal_type == "wezterm" else ""
         start_cmd = (
             title_cmd
-            + self._build_env_prefix(self._managed_env_overrides())
+            + self._build_env_prefix(self._provider_env_overrides("gemini"))
             + _build_export_path_cmd(self.script_dir / "bin")
             + self._build_gemini_start_cmd()
         )
@@ -2514,11 +2533,12 @@ class AILauncher:
                 pass
 
         title_cmd = _build_pane_title_cmd(pane_title_marker) if self.terminal_type == "wezterm" else ""
+        opencode_cmd = self._build_opencode_start_cmd()
         start_cmd = (
             title_cmd
-            + self._build_env_prefix(self._managed_env_overrides())
+            + self._build_env_prefix(self._provider_env_overrides("opencode"))
             + _build_export_path_cmd(self.script_dir / "bin")
-            + self._build_opencode_start_cmd()
+            + opencode_cmd
         )
         self._write_opencode_session(
             runtime,
@@ -2527,6 +2547,31 @@ class AILauncher:
             pane_title_marker=pane_title_marker,
             start_cmd=start_cmd,
         )
+
+        # tmux path: run OpenCode directly (without shell -lc) to avoid shell startup side-effects
+        # that can make the TUI appear to hang before rendering.
+        if self.terminal_type == "tmux" and os.name != "nt":
+            env = self._with_bin_path_env()
+            env.update(self._provider_env_overrides("opencode"))
+            env["OPENCODE_SESSION_ID"] = self.session_id
+            env["OPENCODE_RUNTIME_DIR"] = str(runtime)
+            env["OPENCODE_TERMINAL"] = self.terminal_type
+            env["OPENCODE_TMUX_SESSION"] = pane_id
+            try:
+                cmd_parts = shlex.split(opencode_cmd)
+                if not cmd_parts:
+                    print("❌ Empty OpenCode start command", file=sys.stderr)
+                    return 1
+                # Single-provider `ccb opencode`: fully hand over the pane process to OpenCode.
+                # This mirrors manual `opencode` startup and avoids a long-lived Python parent.
+                exec_raw = (os.environ.get("CCB_OPENCODE_EXEC") or "").strip().lower()
+                use_exec = (exec_raw not in {"0", "false", "no", "off"}) and (len(self.providers) == 1)
+                if use_exec:
+                    os.execvpe(cmd_parts[0], cmd_parts, env)
+                return subprocess.run(cmd_parts, env=env, cwd=str(Path.cwd())).returncode
+            except Exception as exc:
+                print(f"❌ Failed to start OpenCode: {exc}", file=sys.stderr)
+                return 1
 
         return self._run_shell_command(start_cmd, cwd=str(Path.cwd()))
 
@@ -2551,7 +2596,7 @@ class AILauncher:
         title_cmd = _build_pane_title_cmd(pane_title_marker) if self.terminal_type == "wezterm" else ""
         start_cmd = (
             title_cmd
-            + self._build_env_prefix(self._managed_env_overrides())
+            + self._build_env_prefix(self._provider_env_overrides("droid"))
             + _build_export_path_cmd(self.script_dir / "bin")
             + self._build_droid_start_cmd()
         )
@@ -2955,7 +3000,7 @@ class AILauncher:
 
     def _claude_env_overrides(self) -> dict:
         env: dict[str, str] = {}
-        env.update(self._managed_env_overrides())
+        env.update(self._provider_env_overrides("claude"))
         if "codex" in self.providers:
             runtime = self.runtime_dir / "codex"
             env["CODEX_SESSION_ID"] = self.session_id
@@ -3544,6 +3589,31 @@ def cmd_start(args):
             print(f"❌ Failed to create {cfg}: {exc}", file=sys.stderr)
             return 2
 
+    # Parse explicit provider args early so lock-collision path can reuse an existing pane.
+    requested_providers, _requested_cmd_enabled = _parse_providers_with_cmd(args.providers or [])
+
+    def _existing_provider_pane_for_project(project_work_dir: Path, provider: str) -> tuple[dict | None, str]:
+        prov = (provider or "").strip().lower()
+        if not prov:
+            return None, ""
+        try:
+            project_id = compute_ccb_project_id(project_work_dir)
+        except Exception:
+            return None, ""
+        if not project_id:
+            return None, ""
+        record = load_registry_by_project_id(project_id, prov)
+        if not isinstance(record, dict):
+            return None, ""
+        providers_map = record.get("providers")
+        if not isinstance(providers_map, dict):
+            return record, ""
+        entry = providers_map.get(prov)
+        if not isinstance(entry, dict):
+            return record, ""
+        pane_id = str(entry.get("pane_id") or "").strip()
+        return record, pane_id
+
     # Enforce single ccb instance per directory.
     lock_cwd = str(Path.cwd().resolve())
     ccb_lock = ProviderLock("ccb", timeout=0.1, cwd=lock_cwd)
@@ -3554,12 +3624,35 @@ def cmd_start(args):
         except Exception:
             pid = ""
         pid_msg = f" (pid {pid})" if pid else ""
+
+        # Fast-path: if user requests a single provider, try activating its existing pane
+        # in the already-running instance instead of hard failing.
+        focus_provider = requested_providers[0] if len(requested_providers) == 1 else ""
+        if focus_provider:
+            record, pane_id = _existing_provider_pane_for_project(work_dir, focus_provider)
+            if record and pane_id:
+                try:
+                    backend = get_backend_for_session(record)
+                    if backend and backend.is_alive(pane_id):
+                        if os.environ.get("TMUX") or sys.stdin.isatty():
+                            backend.activate(pane_id)
+                        print(
+                            f"ℹ️ Reusing existing ccb instance for this directory{pid_msg}; "
+                            f"activated {focus_provider} pane {pane_id}.",
+                            file=sys.stderr,
+                        )
+                        return 0
+                except Exception:
+                    pass
+
         print(f"❌ Another ccb instance is already running for this directory{pid_msg}.", file=sys.stderr)
         print("💡 Only one ccb instance is allowed per directory.", file=sys.stderr)
+        if focus_provider:
+            print(f"💡 Try switching to the existing {focus_provider} pane in that ccb session.", file=sys.stderr)
         return 2
     atexit.register(ccb_lock.release)
 
-    providers, cmd_enabled = _parse_providers_with_cmd(args.providers or [])
+    providers, cmd_enabled = requested_providers, _requested_cmd_enabled
     config = load_start_config(work_dir)
     config_data = config.data if isinstance(config.data, dict) else {}
 

--- a/lib/session_utils.py
+++ b/lib/session_utils.py
@@ -143,19 +143,26 @@ def find_project_session_file(work_dir: Path, session_filename: str) -> Optional
     """
     Find a session file for the given work_dir.
 
-    Lookup is local-only (no upward traversal):
-      1) <work_dir>/.ccb/<session_filename>
-      2) <work_dir>/.ccb_config/<session_filename>  (legacy)
-      3) <work_dir>/<session_filename>  (legacy)
+    Lookup walks upward from `work_dir` to support calls from subdirectories:
+      1) <dir>/.ccb/<session_filename>
+      2) <dir>/.ccb_config/<session_filename>  (legacy)
+      3) <dir>/<session_filename>  (legacy)
+
+    The nearest match wins.
     """
-    current = Path(work_dir).resolve()
-    candidate = current / CCB_PROJECT_CONFIG_DIRNAME / session_filename
-    if candidate.exists():
-        return candidate
-    legacy_candidate = current / CCB_PROJECT_CONFIG_LEGACY_DIRNAME / session_filename
-    if legacy_candidate.exists():
-        return legacy_candidate
-    legacy = current / session_filename
-    if legacy.exists():
-        return legacy
+    try:
+        current = Path(work_dir).resolve()
+    except Exception:
+        current = Path(work_dir).absolute()
+
+    for root in [current, *current.parents]:
+        candidate = root / CCB_PROJECT_CONFIG_DIRNAME / session_filename
+        if candidate.exists():
+            return candidate
+        legacy_candidate = root / CCB_PROJECT_CONFIG_LEGACY_DIRNAME / session_filename
+        if legacy_candidate.exists():
+            return legacy_candidate
+        legacy = root / session_filename
+        if legacy.exists():
+            return legacy
     return None


### PR DESCRIPTION
 ## Summary
  This PR hardens async task routing and session resolution in core flows.

  ## Problem
  1. In nested-directory and cross-pane scenarios, `ask` can route to the wrong caller/session
  when `CCB_CALLER` is missing or incomplete.
  2. Users may see `processing...` while the target session never actually starts work.
  3. On single-instance lock collisions, current behavior hard-fails instead of reusing the
  existing provider pane.

  ## Files changed
  1. `bin/ask`
  2. `bin/ccb-completion-hook`
  3. `ccb`
  4. `lib/session_utils.py`

  ## What changed
  1. `bin/ask`
  2. Added robust caller detection (`CCB_CALLER` + pane/env hints + fallback).
  3. Removed strict hard-fail when caller is missing; use controlled fallback caller.
  4. Added async observability output (task status/log file paths and lifecycle markers).
  5. Guardrail text is now strict-by-default only for Claude caller to reduce false guidance for
  other callers.

  6. `bin/ccb-completion-hook`
  7. Improved session file lookup and work-dir compatibility checks for nested-dir workflows.

  8. `lib/session_utils.py`
  9. `find_project_session_file` now searches upward from cwd and picks nearest valid session
  file.

  10. `ccb`
  11. On lock collision in single-provider mode, try to reuse/activate existing live pane
  instead of hard-failing.
  12. Explicitly inject `CCB_CALLER` into provider pane env to reduce caller ambiguity across
  processes.
  13. OpenCode startup path is hardened in single-provider handoff scenarios.

  ## User impact
  1. Better routing from subdirectories.
  2. Faster diagnosis when tasks appear stuck (`status/log` lifecycle is visible).
  3. Fewer hard failures when an existing ccb instance is already active.

  ## Risk
  1. Low-to-medium; mostly default routing/session resolution behavior.
  2. Changes are additive with fallbacks.
  3. No protocol-level model behavior changes.

  ## Out of scope
  1. No `ccb-status` submodule updates.
  2. No `ccb-multi`, worktree, or context-related changes.
  3. No non-core package changes.

  ## Validation
  1. Python syntax checks passed for all touched files.
  2. Verified nested-dir session routing behavior.
  3. Verified single-provider lock-collision pane reuse path.
