### PR TITLE
fix(adapters): emit completion on cancellation to avoid stuck processing

### DIFF
--- a/lib/askd/adapters/claude.py
+++ b/lib/askd/adapters/claude.py
@@ -552,18 +552,21 @@ class ClaudeAdapter(BaseProviderAdapter):
     def _finalize_result(self, result: ProviderResult, req: ProviderRequest, task: QueuedTask) -> None:
         _write_log(f"[INFO] done provider=claude req_id={result.req_id} exit={result.exit_code}")
 
-        # Skip completion hook for cancelled tasks
+        reply_for_hook = result.reply
+        notify_done_seen = result.done_seen
         if task.cancelled:
-            _write_log(f"[INFO] Task cancelled, skipping completion hook: req_id={task.req_id}")
-            return
+            _write_log(f"[WARN] Task cancelled, sending failure completion hook: req_id={task.req_id}")
+            notify_done_seen = False
+            if not (reply_for_hook or "").strip():
+                reply_for_hook = "Task cancelled or timed out before completion."
 
-        _write_log(f"[INFO] notify_completion caller={req.caller} done_seen={result.done_seen} email_req_id={req.email_req_id}")
+        _write_log(f"[INFO] notify_completion caller={req.caller} done_seen={notify_done_seen} email_req_id={req.email_req_id}")
         notify_completion(
             provider="claude",
             output_file=req.output_path,
-            reply=result.reply,
+            reply=reply_for_hook,
             req_id=result.req_id,
-            done_seen=result.done_seen,
+            done_seen=notify_done_seen,
             caller=req.caller,
             email_req_id=req.email_req_id,
             email_msg_id=req.email_msg_id,

--- a/lib/askd/adapters/codex.py
+++ b/lib/askd/adapters/codex.py
@@ -279,20 +279,20 @@ class CodexAdapter(BaseProviderAdapter):
             f"anchor={result.anchor_seen} done={result.done_seen}"
         )
 
-        # Skip completion hook for cancelled tasks
+        reply_for_hook = reply
+        notify_done_seen = done_seen
         if task.cancelled:
-            _write_log(f"[INFO] Task cancelled, skipping completion hook: req_id={task.req_id}")
-            return result
-
-        # Log caller info before notify_completion
-        _write_log(f"[INFO] notify_completion caller={req.caller} done_seen={done_seen}")
-
+            _write_log(f"[WARN] Task cancelled, sending failure completion hook: req_id={task.req_id}")
+            notify_done_seen = False
+            if not reply_for_hook.strip():
+                reply_for_hook = "Task cancelled or timed out before completion."
+        _write_log(f"[INFO] notify_completion caller={req.caller} done_seen={notify_done_seen}")
         notify_completion(
             provider="codex",
             output_file=req.output_path,
-            reply=reply,
+            reply=reply_for_hook,
             req_id=task.req_id,
-            done_seen=done_seen,
+            done_seen=notify_done_seen,
             caller=req.caller,
             email_req_id=req.email_req_id,
             email_msg_id=req.email_msg_id,

--- a/lib/askd/adapters/droid.py
+++ b/lib/askd/adapters/droid.py
@@ -195,22 +195,23 @@ class DroidAdapter(BaseProviderAdapter):
         combined = "\n".join(chunks)
         final_reply = extract_reply_for_req(combined, task.req_id)
 
-        # Skip completion hook for cancelled tasks
-        if not task.cancelled:
-            notify_completion(
-                provider="droid",
-                output_file=req.output_path,
-                reply=final_reply,
-                req_id=task.req_id,
-                done_seen=done_seen,
-                caller=req.caller,
-                email_req_id=req.email_req_id,
-                email_msg_id=req.email_msg_id,
-                email_from=req.email_from,
-                work_dir=req.work_dir,
-            )
-        else:
-            _write_log(f"[INFO] Task cancelled, skipping completion hook: req_id={task.req_id}")
+        reply_for_hook = final_reply
+        if task.cancelled:
+            _write_log(f"[WARN] Task cancelled, sending failure completion hook: req_id={task.req_id}")
+            if not reply_for_hook.strip():
+                reply_for_hook = "Task cancelled or timed out before completion."
+        notify_completion(
+            provider="droid",
+            output_file=req.output_path,
+            reply=reply_for_hook,
+            req_id=task.req_id,
+            done_seen=done_seen and (not task.cancelled),
+            caller=req.caller,
+            email_req_id=req.email_req_id,
+            email_msg_id=req.email_msg_id,
+            email_from=req.email_from,
+            work_dir=req.work_dir,
+        )
 
         result = ProviderResult(
             exit_code=0 if done_seen else 2,

--- a/lib/askd/adapters/gemini.py
+++ b/lib/askd/adapters/gemini.py
@@ -274,22 +274,23 @@ class GeminiAdapter(BaseProviderAdapter):
             else:
                 _write_log(f"[WARN] Degraded completion rejected: empty reply for req_id={task.req_id}")
 
-        # Skip completion hook for cancelled tasks
-        if not task.cancelled:
-            notify_completion(
-                provider="gemini",
-                output_file=req.output_path,
-                reply=final_reply,
-                req_id=task.req_id,
-                done_seen=done_seen,
-                caller=req.caller,
-                email_req_id=req.email_req_id,
-                email_msg_id=req.email_msg_id,
-                email_from=req.email_from,
-                work_dir=req.work_dir,
-            )
-        else:
-            _write_log(f"[INFO] Task cancelled, skipping completion hook: req_id={task.req_id}")
+        reply_for_hook = final_reply
+        if task.cancelled:
+            _write_log(f"[WARN] Task cancelled, sending failure completion hook: req_id={task.req_id}")
+            if not reply_for_hook.strip():
+                reply_for_hook = "Task cancelled or timed out before completion."
+        notify_completion(
+            provider="gemini",
+            output_file=req.output_path,
+            reply=reply_for_hook,
+            req_id=task.req_id,
+            done_seen=done_seen and (not task.cancelled),
+            caller=req.caller,
+            email_req_id=req.email_req_id,
+            email_msg_id=req.email_msg_id,
+            email_from=req.email_from,
+            work_dir=req.work_dir,
+        )
 
         result = ProviderResult(
             exit_code=0 if done_seen else 2,

--- a/lib/askd/adapters/opencode.py
+++ b/lib/askd/adapters/opencode.py
@@ -222,22 +222,23 @@ class OpenCodeAdapter(BaseProviderAdapter):
             else:
                 _write_log(f"[WARN] Degraded completion rejected: empty reply for req_id={task.req_id}")
 
-        # Skip completion hook for cancelled tasks
-        if not task.cancelled:
-            notify_completion(
-                provider="opencode",
-                output_file=req.output_path,
-                reply=final_reply,
-                req_id=task.req_id,
-                done_seen=done_seen,
-                caller=req.caller,
-                email_req_id=req.email_req_id,
-                email_msg_id=req.email_msg_id,
-                email_from=req.email_from,
-                work_dir=req.work_dir,
-            )
-        else:
-            _write_log(f"[INFO] Task cancelled, skipping completion hook: req_id={task.req_id}")
+        reply_for_hook = final_reply
+        if task.cancelled:
+            _write_log(f"[WARN] Task cancelled, sending failure completion hook: req_id={task.req_id}")
+            if not reply_for_hook.strip():
+                reply_for_hook = "Task cancelled or timed out before completion."
+        notify_completion(
+            provider="opencode",
+            output_file=req.output_path,
+            reply=reply_for_hook,
+            req_id=task.req_id,
+            done_seen=done_seen and (not task.cancelled),
+            caller=req.caller,
+            email_req_id=req.email_req_id,
+            email_msg_id=req.email_msg_id,
+            email_from=req.email_from,
+            work_dir=req.work_dir,
+        )
 
         result = ProviderResult(
             exit_code=0 if done_seen else 2,


### PR DESCRIPTION
  ## Summary
  This PR normalizes cancellation handling in adapters: cancelled/timed-out tasks now still emit
  completion signals to prevent stuck `processing...`.

  ## Problem
  1. Several adapters previously skipped completion hook when `task.cancelled == true`.
  2. Upstream callers could remain in perpetual `processing...` due to missing terminal signal.
  3. It was hard to distinguish “not started” vs “cancelled without completion”.

  ## Files changed
  1. `lib/askd/adapters/claude.py`
  2. `lib/askd/adapters/codex.py`
  3. `lib/askd/adapters/droid.py`
  4. `lib/askd/adapters/gemini.py`
  5. `lib/askd/adapters/opencode.py`

  ## What changed
  1. Cancellation/timeout path no longer skips completion hook.
  2. Completion is still emitted with `done_seen=false`.
  3. If reply is empty, adapters provide a fallback failure message for deterministic lifecycle
  closure.
  4. Success-path behavior remains unchanged.

  ## User impact
  1. Upstream agent is less likely to get stuck in `processing...`.
  2. Cancellation/failure paths now converge to explicit terminal state.
  3. Better operational clarity in async dispatch workflows.

  ## Risk
  1. Low; scoped to cancellation/error paths.
  2. No changes to normal success flow semantics.
  3. No submodule or non-core side effects.

  ## Out of scope
  1. No caller/session routing updates (covered separately in PR #111).
  2. No `ccb-status`, `ccb-multi`, worktree, or context changes.

  ## Validation
  1. Python syntax checks passed for touched adapter files.
  2. Verified cancellation path still triggers completion notification.
  3. Verified `done_seen=false` behavior in cancellation scenarios.
