### PR TITLE
feat: support CCB_CLAUDE_MD_MODE=route to reduce CLAUDE.md context bloat

### DIFF
--- a/config/claude-md-ccb-route.md
+++ b/config/claude-md-ccb-route.md
@@ -1,0 +1,7 @@
+<!-- CCB_CONFIG_START -->
+## AI Collaboration
+
+For full CCB multi-agent configuration, see `~/.claude/rules/ccb-config.md`.
+Key commands: `/ask <provider>` to consult, `/cping <provider>` to check connectivity, `/pend <provider>` to view replies.
+Providers: `codex`, `gemini`, `opencode`, `droid`, `claude`
+<!-- CCB_CONFIG_END -->

--- a/install.sh
+++ b/install.sh
@@ -159,6 +159,9 @@ Optional environment variables:
   CODEX_CLAUDE_COMMAND_DIR Custom Claude commands directory (default: auto-detect)
   CCB_DROID_AUTOINSTALL    Auto-register Droid MCP tools if droid exists (default: 1)
   CCB_DROID_AUTOINSTALL_FORCE Re-register Droid MCP tools (default: 0)
+  CCB_CLAUDE_MD_MODE       CLAUDE.md injection mode: "inline" (default) or "route"
+                           inline = full config in CLAUDE.md (~57 lines)
+                           route  = minimal pointer in CLAUDE.md, full config in ~/.claude/rules/ccb-config.md
 USAGE
 }
 
@@ -970,7 +973,19 @@ except Exception as e:
 
 install_claude_md_config() {
   local claude_md="$HOME/.claude/CLAUDE.md"
-  local template="$INSTALL_PREFIX/config/claude-md-ccb.md"
+  local md_mode="${CCB_CLAUDE_MD_MODE:-inline}"
+  local full_template="$INSTALL_PREFIX/config/claude-md-ccb.md"
+  local route_template="$INSTALL_PREFIX/config/claude-md-ccb-route.md"
+  local external_config="$HOME/.claude/rules/ccb-config.md"
+
+  # Select template based on mode
+  local template
+  if [[ "$md_mode" == "route" ]]; then
+    template="$route_template"
+  else
+    template="$full_template"
+  fi
+
   mkdir -p "$HOME/.claude"
   if ! pick_python_bin; then
     echo "ERROR: python required to update CLAUDE.md"
@@ -982,12 +997,19 @@ install_claude_md_config() {
     return 1
   fi
 
+  # In route mode, write full config to external file
+  if [[ "$md_mode" == "route" ]]; then
+    mkdir -p "$HOME/.claude/rules"
+    cp "$full_template" "$external_config"
+    echo "Wrote full CCB config to $external_config"
+  fi
+
   local ccb_content
   ccb_content="$(cat "$template")"
 
   if [[ -f "$claude_md" ]]; then
     if grep -q "$CCB_START_MARKER" "$claude_md" 2>/dev/null; then
-      echo "Updating existing CCB config block..."
+      echo "Updating existing CCB config block (mode: $md_mode)..."
       "$PYTHON_BIN" -c "
 import re, sys
 
@@ -1030,7 +1052,7 @@ with open(sys.argv[1], 'w', encoding='utf-8') as f:
     cat "$template" > "$claude_md"
   fi
 
-  echo "Updated AI collaboration rules in $claude_md"
+  echo "Updated AI collaboration rules in $claude_md (mode: $md_mode)"
 }
 
 CCB_ROLES_START_MARKER="<!-- CCB_ROLES_START -->"
@@ -1525,7 +1547,12 @@ install_all() {
   echo "   Project dir    : $INSTALL_PREFIX"
   echo "   Executable dir : $BIN_DIR"
   echo "   Claude commands updated"
-  echo "   Global CLAUDE.md configured with CCB collaboration rules"
+  local md_mode="${CCB_CLAUDE_MD_MODE:-inline}"
+  if [[ "$md_mode" == "route" ]]; then
+    echo "   Global CLAUDE.md configured with CCB route pointer (full config in ~/.claude/rules/ccb-config.md)"
+  else
+    echo "   Global CLAUDE.md configured with CCB collaboration rules (inline)"
+  fi
   echo "   AGENTS.md configured with review rubrics"
   echo "   .clinerules configured with role assignments"
   echo "   Global settings.json permissions added"
@@ -1582,6 +1609,13 @@ with open('$claude_md', 'w', encoding='utf-8') as f:
     else
       echo "WARN: python required to clean CLAUDE.md, please manually remove collaboration rules"
     fi
+  fi
+
+  # Clean up external config file if it exists (route mode)
+  local external_config="$HOME/.claude/rules/ccb-config.md"
+  if [[ -f "$external_config" ]]; then
+    rm -f "$external_config"
+    echo "Removed external CCB config: $external_config"
   fi
 }
 


### PR DESCRIPTION
## Summary

Closes #113

Adds `CCB_CLAUDE_MD_MODE` environment variable (Proposal A from the issue) to support externalizing CCB config from `CLAUDE.md`.

Great problem analysis by @bookandlover in the original issue — this PR implements the approach discussed there.

## What it does

Two modes controlled by `CCB_CLAUDE_MD_MODE`:

- **`inline`** (default) — current behavior, full config in CLAUDE.md (~57 lines). Fully backward compatible, nothing changes for existing users.
- **`route`** — minimal 3-line pointer in CLAUDE.md, full config written to `~/.claude/rules/ccb-config.md`

## Usage

```bash
# Default (no change needed)
./install.sh install

# Minimal mode
CCB_CLAUDE_MD_MODE=route ./install.sh install
```

Switching between modes is safe — re-running install with a different mode updates the `<!-- CCB_CONFIG_START -->` block in-place.

## Changes

| File | Change |
|------|--------|
| `install.sh` | `install_claude_md_config()` — select template based on `CCB_CLAUDE_MD_MODE` env var |
| `install.sh` | `usage()` — document new env var |
| `install.sh` | `install_all()` — output message shows active mode |
| `install.sh` | `uninstall_claude_md_config()` — clean up external config file |
| `config/claude-md-ccb-route.md` | New minimal route template (6 lines) |

## Test plan

- [ ] `./install.sh install` — default inline behavior unchanged
- [ ] `CCB_CLAUDE_MD_MODE=route ./install.sh install` — verify minimal CLAUDE.md + full `~/.claude/rules/ccb-config.md`
- [ ] Re-run with different mode — verify in-place update
- [ ] `./install.sh uninstall` — verify both CLAUDE.md block and external file cleaned up

---

## 概要

关闭 #113

新增 `CCB_CLAUDE_MD_MODE` 环境变量，支持将 CCB 配置从 CLAUDE.md 外部化。

- `inline`（默认）：行为不变，完全向后兼容
- `route`：CLAUDE.md 只保留 3 行指针，完整配置写入 `~/.claude/rules/ccb-config.md`

感谢 @bookandlover 在 issue 中的详细分析和方案设计。