### PR TITLE
feat: add Qwen Code CLI as new provider (#59)

### DIFF
--- a/bin/ask
+++ b/bin/ask
@@ -6,7 +6,7 @@ Usage:
     ask <provider> [options] <message>
 
 Providers:
-    gemini, codex, opencode, droid, claude, copilot, codebuddy
+    gemini, codex, opencode, droid, claude, copilot, codebuddy, qwen
 
 Modes:
     Default (async):  Background task with hook callback
@@ -58,6 +58,7 @@ PROVIDER_DAEMONS = {
     "claude": "lask",
     "copilot": "hask",
     "codebuddy": "bask",
+    "qwen": "qask",
 }
 
 CALLER_SESSION_FILES = {
@@ -68,6 +69,7 @@ CALLER_SESSION_FILES = {
     "droid": ".droid-session",
     "copilot": ".copilot-session",
     "codebuddy": ".codebuddy-session",
+    "qwen": ".qwen-session",
 }
 
 CALLER_PANE_ENV_HINTS = {
@@ -77,6 +79,7 @@ CALLER_PANE_ENV_HINTS = {
     "droid": ("DROID_TMUX_SESSION", "DROID_WEZTERM_PANE"),
     "copilot": ("COPILOT_TMUX_SESSION", "COPILOT_WEZTERM_PANE"),
     "codebuddy": ("CODEBUDDY_TMUX_SESSION", "CODEBUDDY_WEZTERM_PANE"),
+    "qwen": ("QWEN_TMUX_SESSION", "QWEN_WEZTERM_PANE"),
 }
 
 CALLER_ENV_HINTS = {
@@ -86,6 +89,7 @@ CALLER_ENV_HINTS = {
     "droid": ("DROID_SESSION_ID", "DROID_RUNTIME_DIR"),
     "copilot": ("COPILOT_SESSION_ID", "COPILOT_RUNTIME_DIR"),
     "codebuddy": ("CODEBUDDY_SESSION_ID", "CODEBUDDY_RUNTIME_DIR"),
+    "qwen": ("QWEN_SESSION_ID", "QWEN_RUNTIME_DIR"),
 }
 
 VALID_CALLERS = set(CALLER_SESSION_FILES.keys()) | {"email", "manual"}
@@ -479,7 +483,7 @@ def _usage() -> None:
     print("Usage: ask <provider> [options] <message>", file=sys.stderr)
     print("", file=sys.stderr)
     print("Providers:", file=sys.stderr)
-    print("  gemini, codex, opencode, droid, claude, copilot, codebuddy", file=sys.stderr)
+    print("  gemini, codex, opencode, droid, claude, copilot, codebuddy, qwen", file=sys.stderr)
     print("", file=sys.stderr)
     print("Options:", file=sys.stderr)
     print("  -h, --help              Show this help message", file=sys.stderr)

--- a/bin/askd
+++ b/bin/askd
@@ -2,7 +2,7 @@
 """
 askd - Unified Ask Daemon for all AI providers.
 
-Single daemon process handling codex, gemini, opencode, droid, claude, copilot, and codebuddy.
+Single daemon process handling codex, gemini, opencode, droid, claude, copilot, codebuddy, and qwen.
 """
 from __future__ import annotations
 
@@ -28,6 +28,7 @@ from askd.adapters.droid import DroidAdapter
 from askd.adapters.claude import ClaudeAdapter
 from askd.adapters.copilot import CopilotAdapter
 from askd.adapters.codebuddy import CodebuddyAdapter
+from askd.adapters.qwen import QwenAdapter
 
 
 def _parse_listen(value: str) -> tuple[str, int]:
@@ -40,7 +41,7 @@ def _parse_listen(value: str) -> tuple[str, int]:
     return host or "127.0.0.1", int(port_s or "0")
 
 
-ALL_PROVIDERS = ["codex", "gemini", "opencode", "droid", "claude", "copilot", "codebuddy"]
+ALL_PROVIDERS = ["codex", "gemini", "opencode", "droid", "claude", "copilot", "codebuddy", "qwen"]
 
 ADAPTER_CLASSES = {
     "codex": CodexAdapter,
@@ -50,6 +51,7 @@ ADAPTER_CLASSES = {
     "claude": ClaudeAdapter,
     "copilot": CopilotAdapter,
     "codebuddy": CodebuddyAdapter,
+    "qwen": QwenAdapter,
 }
 
 

--- a/bin/qask
+++ b/bin/qask
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""
+qask - Send message to Qwen and wait for reply (sync).
+
+Designed to be used with Claude Code's run_in_background=true.
+If --output is provided, reply is written atomically to that file and stdout stays empty.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+
+script_dir = Path(__file__).resolve().parent
+lib_dir = script_dir.parent / "lib"
+sys.path.insert(0, str(lib_dir))
+from compat import read_stdin_text, setup_windows_encoding
+
+setup_windows_encoding()
+
+from cli_output import EXIT_ERROR, EXIT_NO_REPLY, EXIT_OK, atomic_write_text
+from env_utils import env_bool
+from askd_client import (
+    state_file_from_env,
+    find_project_session_file,
+    resolve_work_dir_with_registry,
+    try_daemon_request,
+    maybe_start_daemon,
+    wait_for_daemon_ready,
+    check_background_mode,
+)
+from providers import QASK_CLIENT_SPEC
+
+
+ASYNC_GUARDRAIL = """[CCB_ASYNC_SUBMITTED provider=qwen]
+IMPORTANT: Task submitted to Qwen. You MUST:
+1. Tell user "Qwen processing..."
+2. END YOUR TURN IMMEDIATELY
+3. Do NOT wait, poll, check status, or use any more tools
+"""
+
+
+def _daemon_startup_wait_s(timeout: float) -> float:
+    raw = (os.environ.get("CCB_QASKD_STARTUP_WAIT_S") or "").strip()
+    if raw:
+        try:
+            v = float(raw)
+        except Exception:
+            v = 0.0
+        if v > 0:
+            return min(max(0.2, v), max(0.2, float(timeout)))
+    return min(8.0, max(1.0, float(timeout)))
+
+
+def _daemon_retry_wait_s(timeout: float) -> float:
+    raw = (os.environ.get("CCB_QASKD_RETRY_WAIT_S") or "").strip()
+    if raw:
+        try:
+            v = float(raw)
+        except Exception:
+            v = 0.0
+        if v > 0:
+            return min(1.0, max(0.05, v))
+    return min(0.3, max(0.05, float(timeout) / 50.0))
+
+
+def _daemon_request_with_retries(
+    work_dir: Path,
+    message: str,
+    timeout: float,
+    quiet: bool,
+    output_path: Path | None,
+) -> tuple[str, int] | None:
+    state_file = state_file_from_env(QASK_CLIENT_SPEC.state_file_env)
+
+    result = try_daemon_request(QASK_CLIENT_SPEC, work_dir, message, timeout, quiet, state_file, output_path=output_path)
+    if result is not None:
+        return result
+
+    if not env_bool(QASK_CLIENT_SPEC.enabled_env, True):
+        return None
+    if not find_project_session_file(work_dir, QASK_CLIENT_SPEC.session_filename):
+        return None
+
+    if state_file and state_file.exists():
+        try:
+            if not wait_for_daemon_ready(QASK_CLIENT_SPEC, 0.2, state_file):
+                try:
+                    state_file.unlink()
+                except Exception:
+                    pass
+        except Exception:
+            pass
+
+    started = maybe_start_daemon(QASK_CLIENT_SPEC, work_dir)
+    if started:
+        wait_for_daemon_ready(QASK_CLIENT_SPEC, _daemon_startup_wait_s(timeout), state_file)
+
+    wait_s = _daemon_retry_wait_s(timeout)
+    deadline = time.time() + min(3.0, max(0.2, float(timeout)))
+    while time.time() < deadline:
+        result = try_daemon_request(QASK_CLIENT_SPEC, work_dir, message, timeout, quiet, state_file, output_path=output_path)
+        if result is not None:
+            return result
+        time.sleep(wait_s)
+
+    return None
+
+
+def _usage() -> None:
+    print("Usage: qask [--sync] [--session-file FILE] [--timeout SECONDS] [--output FILE] <message>", file=sys.stderr)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) <= 1 and sys.stdin.isatty():
+        _usage()
+        return EXIT_ERROR
+
+    output_path: Path | None = None
+    timeout: float | None = None
+    quiet = False
+    sync_mode = False
+    session_file: str | None = None
+
+    parts: list[str] = []
+    it = iter(argv[1:])
+    for token in it:
+        if token in ("-h", "--help"):
+            _usage()
+            return EXIT_OK
+        if token in ("-q", "--quiet"):
+            quiet = True
+            continue
+        if token == "--sync":
+            sync_mode = True
+            continue
+        if token == "--session-file":
+            try:
+                session_file = next(it)
+            except StopIteration:
+                print("[ERROR] --session-file requires a file path", file=sys.stderr)
+                return EXIT_ERROR
+            continue
+        if token in ("-o", "--output"):
+            try:
+                output_path = Path(next(it)).expanduser()
+            except StopIteration:
+                print("[ERROR] --output requires a file path", file=sys.stderr)
+                return EXIT_ERROR
+            continue
+        if token in ("-t", "--timeout"):
+            try:
+                timeout = float(next(it))
+            except StopIteration:
+                print("[ERROR] --timeout requires a number", file=sys.stderr)
+                return EXIT_ERROR
+            except ValueError:
+                print("[ERROR] --timeout must be a number", file=sys.stderr)
+                return EXIT_ERROR
+            continue
+        parts.append(token)
+
+    message = " ".join(parts).strip()
+    if not message and not sys.stdin.isatty():
+        message = read_stdin_text().strip()
+    if not message:
+        print("[ERROR] Message cannot be empty", file=sys.stderr)
+        return EXIT_ERROR
+
+    if timeout is None:
+        try:
+            timeout = float(os.environ.get("CCB_SYNC_TIMEOUT", "3600.0"))
+        except Exception:
+            timeout = 3600.0
+
+    try:
+        work_dir, _ = resolve_work_dir_with_registry(
+            QASK_CLIENT_SPEC,
+            provider="qwen",
+            cli_session_file=session_file,
+            env_session_file=os.environ.get("CCB_SESSION_FILE"),
+        )
+
+        daemon_result = _daemon_request_with_retries(work_dir, message, timeout, quiet, output_path)
+        if daemon_result is not None:
+            reply, exit_code = daemon_result
+            if not sync_mode:
+                print(ASYNC_GUARDRAIL, file=sys.stderr, flush=True)
+            if output_path:
+                atomic_write_text(output_path, reply + "\n")
+                return exit_code
+            sys.stdout.write(reply)
+            if not reply.endswith("\n"):
+                sys.stdout.write("\n")
+            return exit_code
+
+        if not env_bool(QASK_CLIENT_SPEC.enabled_env, True):
+            print(f"[ERROR] {QASK_CLIENT_SPEC.enabled_env}=0: qask daemon mode disabled.", file=sys.stderr)
+            return EXIT_ERROR
+        if not find_project_session_file(work_dir, QASK_CLIENT_SPEC.session_filename):
+            print("[ERROR] No active Qwen session found for this directory.", file=sys.stderr)
+            print("Run `ccb qwen` (or add qwen to ccb.config) in this project first.", file=sys.stderr)
+            return EXIT_ERROR
+        print("[ERROR] qask daemon required but not available.", file=sys.stderr)
+        print("Start it with `qaskd` (or enable autostart via CCB_QASKD_AUTOSTART=1).", file=sys.stderr)
+        return EXIT_ERROR
+    except KeyboardInterrupt:
+        return 130
+    except Exception as exc:
+        print(f"[ERROR] {exc}", file=sys.stderr)
+        return EXIT_ERROR
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/bin/qpend
+++ b/bin/qpend
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""
+qpend - View latest Qwen reply
+"""
+
+import os
+import sys
+from pathlib import Path
+import argparse
+
+script_dir = Path(__file__).resolve().parent
+lib_dir = script_dir.parent / "lib"
+sys.path.insert(0, str(lib_dir))
+from compat import setup_windows_encoding
+
+setup_windows_encoding()
+
+from cli_output import EXIT_ERROR, EXIT_NO_REPLY, EXIT_OK
+from qwen_comm import QwenLogReader
+from ccb_protocol import strip_trailing_markers
+from askd_client import resolve_work_dir_with_registry
+from providers import QASK_CLIENT_SPEC
+
+
+def _debug_enabled() -> bool:
+    return (os.environ.get("CCB_DEBUG") in ("1", "true", "yes")) or (os.environ.get("QPEND_DEBUG") in ("1", "true", "yes"))
+
+
+def _debug(message: str) -> None:
+    if not _debug_enabled():
+        return
+    print(f"[DEBUG] {message}", file=sys.stderr)
+
+
+def _resolve_pane_log(work_dir: Path) -> Path | None:
+    """Try to find the pane log path from the session file."""
+    from session_utils import find_project_session_file
+    import json
+
+    session_file = find_project_session_file(work_dir, ".qwen-session")
+    if not session_file:
+        return None
+    try:
+        with session_file.open("r", encoding="utf-8-sig") as f:
+            data = json.load(f)
+        # Try explicit pane_log_path first
+        raw = data.get("pane_log_path")
+        if raw:
+            return Path(str(raw)).expanduser()
+        # Fall back to runtime_dir / pane.log
+        runtime = data.get("runtime_dir")
+        if runtime:
+            return Path(str(runtime)) / "pane.log"
+    except Exception as exc:
+        _debug(f"Failed to read .qwen-session ({session_file}): {exc}")
+    return None
+
+
+def main(argv: list[str]) -> int:
+    try:
+        parser = argparse.ArgumentParser(prog="qpend", add_help=True)
+        parser.add_argument("n", nargs="?", type=int, default=1, help="Show the latest N conversations")
+        parser.add_argument("--raw", action="store_true", help="Do not strip protocol/harness marker lines")
+        parser.add_argument("--session-file", dest="session_file", default=None, help="Path to .qwen-session (or .ccb/.qwen-session)")
+        args = parser.parse_args(argv[1:])
+
+        n = max(1, int(args.n or 1))
+        raw = bool(args.raw)
+
+        work_dir, _explicit_session_file = resolve_work_dir_with_registry(
+            QASK_CLIENT_SPEC,
+            provider="qwen",
+            cli_session_file=args.session_file,
+            env_session_file=os.environ.get("CCB_SESSION_FILE"),
+        )
+
+        pane_log = _resolve_pane_log(work_dir)
+        reader = QwenLogReader(work_dir=work_dir, pane_log_path=pane_log)
+
+        if n > 1:
+            conversations = reader.latest_conversations(n)
+            if not conversations:
+                print("No reply available", file=sys.stderr)
+                return EXIT_NO_REPLY
+            for i, (question, reply) in enumerate(conversations):
+                if question:
+                    print(f"Q: {question}")
+                cleaned = reply if raw else strip_trailing_markers(reply or "")
+                print(f"A: {cleaned}")
+                if i < len(conversations) - 1:
+                    print("---")
+            return EXIT_OK
+
+        message = reader.latest_message()
+        if not message:
+            print("No reply available", file=sys.stderr)
+            return EXIT_NO_REPLY
+        print(message if raw else strip_trailing_markers(message))
+        return EXIT_OK
+    except Exception as exc:
+        if _debug_enabled():
+            import traceback
+
+            traceback.print_exc()
+        print(f"[ERROR] execution failed: {exc}", file=sys.stderr)
+        return EXIT_ERROR
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/bin/qping
+++ b/bin/qping
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""
+qping - Test Qwen connectivity
+"""
+
+import sys
+import os
+import argparse
+from pathlib import Path
+
+script_dir = Path(__file__).resolve().parent
+lib_dir = script_dir.parent / "lib"
+sys.path.insert(0, str(lib_dir))
+from compat import setup_windows_encoding
+
+setup_windows_encoding()
+
+try:
+    from qwen_comm import QwenCommunicator
+
+    def main():
+        try:
+            parser = argparse.ArgumentParser(prog="qping", add_help=True)
+            parser.add_argument("--session-file", dest="session_file", default=None, help="Path to .qwen-session (or .ccb/.qwen-session)")
+            args = parser.parse_args()
+            if args.session_file:
+                os.environ["CCB_SESSION_FILE"] = str(args.session_file)
+            comm = QwenCommunicator()
+            healthy, message = comm.ping(display=False)
+            print(message)
+            return 0 if healthy else 1
+        except Exception as e:
+            print(f"[ERROR] Qwen connectivity test failed: {e}")
+            return 1
+
+    if __name__ == "__main__":
+        sys.exit(main())
+
+except ImportError as e:
+    print(f"[ERROR] Module import failed: {e}")
+    sys.exit(1)

--- a/install.sh
+++ b/install.sh
@@ -121,6 +121,9 @@ SCRIPTS_TO_LINK=(
   bin/bask
   bin/bpend
   bin/bping
+  bin/qask
+  bin/qpend
+  bin/qping
   bin/ask
   bin/ccb-ping
   bin/pend

--- a/lib/askd/adapters/__init__.py
+++ b/lib/askd/adapters/__init__.py
@@ -15,4 +15,5 @@ __all__ = [
     "ClaudeAdapter",
     "CopilotAdapter",
     "CodebuddyAdapter",
+    "QwenAdapter",
 ]

--- a/lib/askd/adapters/qwen.py
+++ b/lib/askd/adapters/qwen.py
@@ -1,0 +1,241 @@
+"""
+Qwen provider adapter for the unified ask daemon.
+
+Wraps existing qaskd_* modules to provide a consistent interface.
+"""
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+from askd.adapters.base import BaseProviderAdapter, ProviderRequest, ProviderResult, QueuedTask
+from askd_runtime import log_path, write_log
+from ccb_protocol import REQ_ID_PREFIX
+from completion_hook import (
+    COMPLETION_STATUS_CANCELLED,
+    COMPLETION_STATUS_COMPLETED,
+    COMPLETION_STATUS_FAILED,
+    COMPLETION_STATUS_INCOMPLETE,
+    default_reply_for_status,
+    notify_completion,
+)
+from qaskd_protocol import extract_reply_for_req, is_done_text, wrap_qwen_prompt
+from qaskd_session import compute_session_key, load_project_session
+from qwen_comm import QwenLogReader
+from providers import QASKD_SPEC
+from terminal import get_backend_for_session
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _write_log(line: str) -> None:
+    write_log(log_path(QASKD_SPEC.log_file_name), line)
+
+
+def _tail_state_for_log(log_path_val: Optional[Path], *, tail_bytes: int) -> dict:
+    if not log_path_val or not log_path_val.exists():
+        return {"pane_log_path": log_path_val, "offset": 0}
+    try:
+        size = log_path_val.stat().st_size
+    except OSError:
+        size = 0
+    offset = max(0, size - max(0, int(tail_bytes)))
+    return {"pane_log_path": log_path_val, "offset": offset}
+
+
+class QwenAdapter(BaseProviderAdapter):
+    """Adapter for Qwen provider."""
+
+    @property
+    def key(self) -> str:
+        return "qwen"
+
+    @property
+    def spec(self):
+        return QASKD_SPEC
+
+    @property
+    def session_filename(self) -> str:
+        return ".qwen-session"
+
+    def load_session(self, work_dir: Path) -> Optional[Any]:
+        return load_project_session(work_dir)
+
+    def compute_session_key(self, session: Any) -> str:
+        return compute_session_key(session) if session else "qwen:unknown"
+
+    def handle_task(self, task: QueuedTask) -> ProviderResult:
+        started_ms = _now_ms()
+        req = task.request
+        work_dir = Path(req.work_dir)
+        _write_log(f"[INFO] start provider=qwen req_id={task.req_id} work_dir={req.work_dir}")
+
+        session = load_project_session(work_dir)
+        session_key = self.compute_session_key(session)
+
+        if not session:
+            return ProviderResult(
+                exit_code=1,
+                reply="No active Qwen session found for work_dir.",
+                req_id=task.req_id,
+                session_key=session_key,
+                done_seen=False,
+                status=COMPLETION_STATUS_FAILED,
+            )
+
+        ok, pane_or_err = session.ensure_pane()
+        if not ok:
+            return ProviderResult(
+                exit_code=1,
+                reply=f"Session pane not available: {pane_or_err}",
+                req_id=task.req_id,
+                session_key=session_key,
+                done_seen=False,
+                status=COMPLETION_STATUS_FAILED,
+            )
+        pane_id = pane_or_err
+
+        backend = get_backend_for_session(session.data)
+        if not backend:
+            return ProviderResult(
+                exit_code=1,
+                reply="Terminal backend not available",
+                req_id=task.req_id,
+                session_key=session_key,
+                done_seen=False,
+                status=COMPLETION_STATUS_FAILED,
+            )
+
+        # Qwen uses pane-log based communication (no JSONL session logs)
+        pane_log_path: Optional[Path] = None
+        raw_log = session.data.get("pane_log_path")
+        if raw_log:
+            pane_log_path = Path(str(raw_log)).expanduser()
+        elif session.runtime_dir:
+            pane_log_path = session.runtime_dir / "pane.log"
+
+        log_reader = QwenLogReader(work_dir=Path(session.work_dir), pane_log_path=pane_log_path)
+        state = log_reader.capture_state()
+
+        prompt = wrap_qwen_prompt(req.message, task.req_id)
+        backend.send_text(pane_id, prompt)
+
+        deadline = None if float(req.timeout_s) < 0.0 else (time.time() + float(req.timeout_s))
+        chunks: list[str] = []
+        anchor_seen = False
+        fallback_scan = False
+        anchor_ms: Optional[int] = None
+        done_seen = False
+        done_ms: Optional[int] = None
+
+        anchor_grace_deadline = min(deadline, time.time() + 1.5) if deadline else (time.time() + 1.5)
+        anchor_collect_grace = min(deadline, time.time() + 2.0) if deadline else (time.time() + 2.0)
+        rebounded = False
+        tail_bytes = int(os.environ.get("CCB_QASKD_REBIND_TAIL_BYTES", str(2 * 1024 * 1024)))
+        pane_check_interval = float(os.environ.get("CCB_QASKD_PANE_CHECK_INTERVAL", "2.0"))
+        last_pane_check = time.time()
+
+        while True:
+            # Check for cancellation
+            if task.cancel_event and task.cancel_event.is_set():
+                _write_log(f"[INFO] Task cancelled during wait loop: req_id={task.req_id}")
+                break
+
+            if deadline is not None:
+                remaining = deadline - time.time()
+                if remaining <= 0:
+                    break
+                wait_step = min(remaining, 0.5)
+            else:
+                wait_step = 0.5
+
+            if time.time() - last_pane_check >= pane_check_interval:
+                try:
+                    alive = bool(backend.is_alive(pane_id))
+                except Exception:
+                    alive = False
+                if not alive:
+                    _write_log(f"[ERROR] Pane {pane_id} died during request req_id={task.req_id}")
+                    return ProviderResult(
+                        exit_code=1,
+                        reply="Qwen pane died during request",
+                        req_id=task.req_id,
+                        session_key=session_key,
+                        done_seen=False,
+                        anchor_seen=anchor_seen,
+                        fallback_scan=fallback_scan,
+                        anchor_ms=anchor_ms,
+                        status=COMPLETION_STATUS_FAILED,
+                    )
+                last_pane_check = time.time()
+
+            events, state = log_reader.wait_for_events(state, wait_step)
+            if not events:
+                if (not rebounded) and (not anchor_seen) and time.time() >= anchor_grace_deadline:
+                    log_reader = QwenLogReader(work_dir=Path(session.work_dir), pane_log_path=pane_log_path)
+                    state = _tail_state_for_log(pane_log_path, tail_bytes=tail_bytes)
+                    fallback_scan = True
+                    rebounded = True
+                continue
+
+            for role, text in events:
+                if role == "user":
+                    if f"{REQ_ID_PREFIX} {task.req_id}" in text:
+                        anchor_seen = True
+                        if anchor_ms is None:
+                            anchor_ms = _now_ms() - started_ms
+                    continue
+                if role != "assistant":
+                    continue
+                if (not anchor_seen) and time.time() < anchor_collect_grace:
+                    continue
+                chunks.append(text)
+                combined = "\n".join(chunks)
+                if is_done_text(combined, task.req_id):
+                    done_seen = True
+                    done_ms = _now_ms() - started_ms
+                    break
+
+            if done_seen:
+                break
+
+        combined = "\n".join(chunks)
+        final_reply = extract_reply_for_req(combined, task.req_id)
+        status = COMPLETION_STATUS_COMPLETED if done_seen else COMPLETION_STATUS_INCOMPLETE
+        if task.cancelled:
+            status = COMPLETION_STATUS_CANCELLED
+        reply_for_hook = final_reply
+        if not reply_for_hook.strip():
+            reply_for_hook = default_reply_for_status(status, done_seen=done_seen)
+        notify_completion(
+            provider="qwen",
+            output_file=req.output_path,
+            reply=reply_for_hook,
+            req_id=task.req_id,
+            done_seen=done_seen,
+            status=status,
+            caller=req.caller,
+            email_req_id=req.email_req_id,
+            email_msg_id=req.email_msg_id,
+            email_from=req.email_from,
+            work_dir=req.work_dir,
+        )
+
+        result = ProviderResult(
+            exit_code=0 if done_seen else 2,
+            reply=final_reply,
+            req_id=task.req_id,
+            session_key=session_key,
+            done_seen=done_seen,
+            done_ms=done_ms,
+            anchor_seen=anchor_seen,
+            anchor_ms=anchor_ms,
+            fallback_scan=fallback_scan,
+            status=status,
+        )
+        _write_log(f"[INFO] done provider=qwen req_id={task.req_id} exit={result.exit_code}")
+        return result

--- a/lib/providers.py
+++ b/lib/providers.py
@@ -179,3 +179,25 @@ BASK_CLIENT_SPEC = ProviderClientSpec(
     daemon_bin_name="askd",
     daemon_module="askd.daemon",
 )
+
+
+# ── Qwen (qwen-code CLI) ──────────────────────────────────────────────────────
+QASKD_SPEC = ProviderDaemonSpec(
+    daemon_key="qaskd",
+    protocol_prefix="qask",
+    state_file_name="qaskd.json",
+    log_file_name="qaskd.log",
+    idle_timeout_env="CCB_QASKD_IDLE_TIMEOUT_S",
+    lock_name="qaskd",
+)
+
+QASK_CLIENT_SPEC = ProviderClientSpec(
+    protocol_prefix="qask",
+    enabled_env="CCB_QASKD",
+    autostart_env_primary="CCB_QASKD_AUTOSTART",
+    autostart_env_legacy="CCB_AUTO_QASKD",
+    state_file_env="CCB_QASKD_STATE_FILE",
+    session_filename=".qwen-session",
+    daemon_bin_name="askd",
+    daemon_module="askd.daemon",
+)

--- a/lib/qaskd_protocol.py
+++ b/lib/qaskd_protocol.py
@@ -1,0 +1,96 @@
+"""
+Qwen protocol helpers.
+
+Wraps prompts with CCB markers and extracts replies — simplified version
+without skills injection.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from ccb_protocol import (
+    DONE_PREFIX,
+    REQ_ID_PREFIX,
+    is_done_text,
+    make_req_id,
+    strip_done_text,
+)
+
+ANY_DONE_LINE_RE = re.compile(r"^\s*CCB_DONE:\s*(?:[0-9a-f]{32}|\d{8}-\d{6}-\d{3}-\d+-\d+)\s*$", re.IGNORECASE)
+
+
+def wrap_qwen_prompt(message: str, req_id: str) -> str:
+    """Wrap a prompt with CCB protocol markers for Qwen."""
+    message = (message or "").rstrip()
+    return (
+        f"{REQ_ID_PREFIX} {req_id}\n\n"
+        f"{message}\n\n"
+        "IMPORTANT:\n"
+        "- Reply with an execution summary, in English. Do not stay silent.\n"
+        "- End your reply with this exact final line (verbatim, on its own line):\n"
+        f"{DONE_PREFIX} {req_id}\n"
+    )
+
+
+def extract_reply_for_req(text: str, req_id: str) -> str:
+    """
+    Extract the reply segment for req_id from a Qwen message.
+
+    Qwen may emit multiple replies in a single assistant message, each ending with its own
+    `CCB_DONE: <req_id>` line. In that case, we want only the segment between the previous done line
+    (any req_id) and the done line for our req_id.
+    """
+    lines = [ln.rstrip("\n") for ln in (text or "").splitlines()]
+    if not lines:
+        return ""
+
+    target_re = re.compile(rf"^\s*CCB_DONE:\s*{re.escape(req_id)}\s*$", re.IGNORECASE)
+    done_idxs = [i for i, ln in enumerate(lines) if ANY_DONE_LINE_RE.match(ln or "")]
+    target_idxs = [i for i in done_idxs if target_re.match(lines[i] or "")]
+
+    if not target_idxs:
+        # No CCB_DONE for our req_id found
+        # If there are other CCB_DONE markers, this is likely old content - return empty
+        if done_idxs:
+            return ""  # Prevent returning old content
+        return strip_done_text(text, req_id)
+
+    target_i = target_idxs[-1]
+    prev_done_i = -1
+    for i in reversed(done_idxs):
+        if i < target_i:
+            prev_done_i = i
+            break
+
+    segment = lines[prev_done_i + 1 : target_i]
+    while segment and segment[0].strip() == "":
+        segment = segment[1:]
+    while segment and segment[-1].strip() == "":
+        segment = segment[:-1]
+    return "\n".join(segment).rstrip()
+
+
+@dataclass(frozen=True)
+class QaskdRequest:
+    client_id: str
+    work_dir: str
+    timeout_s: float
+    quiet: bool
+    message: str
+    output_path: str | None = None
+    req_id: str | None = None
+    caller: str = "claude"
+
+
+@dataclass(frozen=True)
+class QaskdResult:
+    exit_code: int
+    reply: str
+    req_id: str
+    session_key: str
+    done_seen: bool
+    done_ms: int | None = None
+    anchor_seen: bool = False
+    fallback_scan: bool = False
+    anchor_ms: int | None = None

--- a/lib/qaskd_session.py
+++ b/lib/qaskd_session.py
@@ -1,0 +1,165 @@
+"""
+Qwen project session management.
+
+Simplified session binding for GitHub Qwen CLI — no JSONL session binding,
+pane-log based communication only.
+"""
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Tuple
+
+from ccb_config import apply_backend_env
+from project_id import compute_ccb_project_id
+from session_utils import find_project_session_file as _find_project_session_file, safe_write_session
+from terminal import get_backend_for_session
+
+apply_backend_env()
+
+
+def find_project_session_file(work_dir: Path) -> Optional[Path]:
+    return _find_project_session_file(work_dir, ".qwen-session")
+
+
+def _read_json(path: Path) -> dict:
+    try:
+        raw = path.read_text(encoding="utf-8-sig")
+        obj = json.loads(raw)
+        return obj if isinstance(obj, dict) else {}
+    except Exception:
+        return {}
+
+
+def _now_str() -> str:
+    return time.strftime("%Y-%m-%d %H:%M:%S")
+
+
+@dataclass
+class QwenProjectSession:
+    session_file: Path
+    data: dict
+
+    @property
+    def terminal(self) -> str:
+        return (self.data.get("terminal") or "tmux").strip() or "tmux"
+
+    @property
+    def pane_id(self) -> str:
+        v = self.data.get("pane_id")
+        if not v and self.terminal == "tmux":
+            v = self.data.get("tmux_session")
+        return str(v or "").strip()
+
+    @property
+    def pane_title_marker(self) -> str:
+        return str(self.data.get("pane_title_marker") or "").strip()
+
+    @property
+    def work_dir(self) -> str:
+        return str(self.data.get("work_dir") or self.session_file.parent)
+
+    @property
+    def runtime_dir(self) -> Path:
+        return Path(self.data.get("runtime_dir") or self.session_file.parent)
+
+    @property
+    def start_cmd(self) -> str:
+        return str(self.data.get("start_cmd") or "").strip()
+
+    def backend(self):
+        return get_backend_for_session(self.data)
+
+    def _attach_pane_log(self, backend: object, pane_id: str) -> None:
+        ensure = getattr(backend, "ensure_pane_log", None)
+        if callable(ensure):
+            try:
+                ensure(str(pane_id))
+            except Exception:
+                pass
+
+    def ensure_pane(self) -> Tuple[bool, str]:
+        backend = self.backend()
+        if not backend:
+            return False, "Terminal backend not available"
+
+        pane_id = self.pane_id
+        if pane_id and backend.is_alive(pane_id):
+            self._attach_pane_log(backend, pane_id)
+            return True, pane_id
+
+        marker = self.pane_title_marker
+        resolver = getattr(backend, "find_pane_by_title_marker", None)
+        if marker and callable(resolver):
+            resolved = resolver(marker)
+            if resolved and backend.is_alive(str(resolved)):
+                self.data["pane_id"] = str(resolved)
+                self.data["updated_at"] = _now_str()
+                self._write_back()
+                self._attach_pane_log(backend, str(resolved))
+                return True, str(resolved)
+
+        if self.terminal == "tmux":
+            start_cmd = self.start_cmd
+            respawn = getattr(backend, "respawn_pane", None)
+            if start_cmd and callable(respawn):
+                last_err: str | None = None
+                target = pane_id
+                if marker and callable(resolver):
+                    try:
+                        target = resolver(marker) or target
+                    except Exception:
+                        pass
+                if target and str(target).startswith("%"):
+                    try:
+                        saver = getattr(backend, "save_crash_log", None)
+                        if callable(saver):
+                            try:
+                                runtime = self.runtime_dir
+                                runtime.mkdir(parents=True, exist_ok=True)
+                                crash_log = runtime / f"pane-crash-{int(time.time())}.log"
+                                saver(str(target), str(crash_log), lines=1000)
+                            except Exception:
+                                pass
+                        respawn(str(target), cmd=start_cmd, cwd=self.work_dir, remain_on_exit=True)
+                        if backend.is_alive(str(target)):
+                            self.data["pane_id"] = str(target)
+                            self.data["updated_at"] = _now_str()
+                            self._write_back()
+                            self._attach_pane_log(backend, str(target))
+                            return True, str(target)
+                        last_err = "respawn did not revive pane"
+                    except Exception as exc:
+                        last_err = f"{exc}"
+                if last_err:
+                    return False, f"Pane not alive and respawn failed: {last_err}"
+
+        return False, f"Pane not alive: {pane_id}"
+
+    def _write_back(self) -> None:
+        payload = json.dumps(self.data, ensure_ascii=False, indent=2) + "\n"
+        safe_write_session(self.session_file, payload)
+
+
+def load_project_session(work_dir: Path) -> Optional[QwenProjectSession]:
+    session_file = find_project_session_file(work_dir)
+    if not session_file:
+        return None
+    data = _read_json(session_file)
+    if not data:
+        return None
+    if data.get("active") is False:
+        return None
+    return QwenProjectSession(session_file=session_file, data=data)
+
+
+def compute_session_key(session: QwenProjectSession) -> str:
+    pid = str(session.data.get("ccb_project_id") or "").strip()
+    if not pid:
+        try:
+            pid = compute_ccb_project_id(Path(session.work_dir))
+        except Exception:
+            pid = ""
+    return f"qwen:{pid}" if pid else "qwen:unknown"

--- a/lib/qwen_comm.py
+++ b/lib/qwen_comm.py
@@ -1,0 +1,500 @@
+"""
+Qwen communication module.
+
+Reads replies from tmux pane-log files (raw terminal text) and sends prompts
+by injecting text into the Qwen pane via the configured backend.
+
+Unlike Droid, Qwen does not produce structured JSONL session logs. Instead,
+we read raw terminal output captured via `tmux pipe-pane`, strip ANSI escape
+sequences, and look for CCB protocol markers in the plain text.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from ccb_config import apply_backend_env
+from pane_registry import upsert_registry
+from project_id import compute_ccb_project_id
+from session_utils import find_project_session_file
+from terminal import get_backend_for_session, get_pane_id_from_session
+
+apply_backend_env()
+
+# ---------------------------------------------------------------------------
+# ANSI escape stripping
+# ---------------------------------------------------------------------------
+
+_ANSI_ESCAPE_RE = re.compile(
+    r"""
+    \x1b          # ESC
+    (?:           # followed by one of …
+      \[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]   # CSI sequence
+    | \].*?(?:\x07|\x1b\\)                       # OSC sequence (terminated by BEL or ST)
+    | [\x40-\x5f]                                 # Fe sequence (2-byte)
+    )
+    """,
+    re.VERBOSE,
+)
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI/VT escape sequences from raw terminal output."""
+    return _ANSI_ESCAPE_RE.sub("", text)
+
+
+# ---------------------------------------------------------------------------
+# CCB marker patterns
+# ---------------------------------------------------------------------------
+
+_CCB_REQ_ID_RE = re.compile(r"^\s*CCB_REQ_ID:\s*(\S+)\s*$", re.MULTILINE)
+_CCB_DONE_RE = re.compile(
+    r"^\s*CCB_DONE:\s*(?:[0-9a-f]{32}|\d{8}-\d{6}-\d{3}-\d+-\d+)\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+# ---------------------------------------------------------------------------
+# QwenLogReader — reads from tmux pane-log files
+# ---------------------------------------------------------------------------
+
+
+class QwenLogReader:
+    """Reads Qwen replies from tmux pane-log files (raw terminal text)."""
+
+    def __init__(self, work_dir: Optional[Path] = None, pane_log_path: Optional[Path] = None):
+        self.work_dir = work_dir or Path.cwd()
+        self._pane_log_path: Optional[Path] = pane_log_path
+        try:
+            poll = float(os.environ.get("QWEN_POLL_INTERVAL", "0.05"))
+        except Exception:
+            poll = 0.05
+        self._poll_interval = min(0.5, max(0.02, poll))
+
+    def set_pane_log_path(self, path: Optional[Path]) -> None:
+        """Override the pane log path (e.g. from session file)."""
+        if path:
+            try:
+                candidate = path if isinstance(path, Path) else Path(str(path)).expanduser()
+            except Exception:
+                return
+            self._pane_log_path = candidate
+
+    def _resolve_log_path(self) -> Optional[Path]:
+        """Return the pane log path, or None if unavailable."""
+        if self._pane_log_path and self._pane_log_path.exists():
+            return self._pane_log_path
+        return None
+
+    # ---- public interface identical to DroidLogReader ----
+
+    def capture_state(self) -> Dict[str, Any]:
+        log_path = self._resolve_log_path()
+        offset = 0
+        if log_path and log_path.exists():
+            try:
+                offset = log_path.stat().st_size
+            except OSError:
+                offset = 0
+        return {"pane_log_path": log_path, "offset": offset}
+
+    def wait_for_message(self, state: Dict[str, Any], timeout: float) -> Tuple[Optional[str], Dict[str, Any]]:
+        return self._read_since(state, timeout=timeout, block=True)
+
+    def try_get_message(self, state: Dict[str, Any]) -> Tuple[Optional[str], Dict[str, Any]]:
+        return self._read_since(state, timeout=0.0, block=False)
+
+    def wait_for_events(self, state: Dict[str, Any], timeout: float) -> Tuple[List[Tuple[str, str]], Dict[str, Any]]:
+        return self._read_since_events(state, timeout=timeout, block=True)
+
+    def try_get_events(self, state: Dict[str, Any]) -> Tuple[List[Tuple[str, str]], Dict[str, Any]]:
+        return self._read_since_events(state, timeout=0.0, block=False)
+
+    def latest_message(self) -> Optional[str]:
+        """Scan the full pane log and return the last assistant content block."""
+        log_path = self._resolve_log_path()
+        if not log_path or not log_path.exists():
+            return None
+        try:
+            raw = log_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return None
+        clean = _strip_ansi(raw)
+        blocks = self._extract_assistant_blocks(clean)
+        return blocks[-1] if blocks else None
+
+    def latest_conversations(self, n: int = 1) -> List[Tuple[str, str]]:
+        """Return up to *n* recent (user_prompt, assistant_reply) pairs from the pane log."""
+        log_path = self._resolve_log_path()
+        if not log_path or not log_path.exists():
+            return []
+        try:
+            raw = log_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return []
+        clean = _strip_ansi(raw)
+        pairs = self._extract_conversation_pairs(clean)
+        return pairs[-max(1, int(n)):]
+
+    # ---- internal helpers ----
+
+    def _read_since(self, state: Dict[str, Any], timeout: float, block: bool) -> Tuple[Optional[str], Dict[str, Any]]:
+        deadline = time.time() + max(0.0, float(timeout)) if block else time.time()
+        current_state = dict(state or {})
+
+        while True:
+            log_path = self._resolve_log_path()
+            if log_path is None or not log_path.exists():
+                if not block or time.time() >= deadline:
+                    return None, current_state
+                time.sleep(self._poll_interval)
+                continue
+
+            # If log path changed, reset offset
+            if current_state.get("pane_log_path") != log_path:
+                current_state["pane_log_path"] = log_path
+                current_state["offset"] = 0
+
+            message, current_state = self._read_new_content(log_path, current_state)
+            if message:
+                return message, current_state
+
+            if not block or time.time() >= deadline:
+                return None, current_state
+            time.sleep(self._poll_interval)
+
+    def _read_new_content(self, log_path: Path, state: Dict[str, Any]) -> Tuple[Optional[str], Dict[str, Any]]:
+        """Read new bytes from the pane log, strip ANSI, extract assistant replies."""
+        offset = int(state.get("offset") or 0)
+        try:
+            size = log_path.stat().st_size
+        except OSError:
+            return None, state
+
+        if size < offset:
+            # Log was truncated / rotated — reset
+            offset = 0
+
+        if size == offset:
+            return None, state
+
+        try:
+            with log_path.open("rb") as handle:
+                handle.seek(offset)
+                data = handle.read()
+        except OSError:
+            return None, state
+
+        new_offset = offset + len(data)
+        text = data.decode("utf-8", errors="replace")
+        clean = _strip_ansi(text)
+
+        # Look for assistant content blocks in the new chunk
+        blocks = self._extract_assistant_blocks(clean)
+        latest = blocks[-1] if blocks else None
+
+        new_state = {"pane_log_path": log_path, "offset": new_offset}
+        return latest, new_state
+
+    def _read_since_events(self, state: Dict[str, Any], timeout: float, block: bool) -> Tuple[List[Tuple[str, str]], Dict[str, Any]]:
+        deadline = time.time() + max(0.0, float(timeout)) if block else time.time()
+        current_state = dict(state or {})
+
+        while True:
+            log_path = self._resolve_log_path()
+            if log_path is None or not log_path.exists():
+                if not block or time.time() >= deadline:
+                    return [], current_state
+                time.sleep(self._poll_interval)
+                continue
+
+            if current_state.get("pane_log_path") != log_path:
+                current_state["pane_log_path"] = log_path
+                current_state["offset"] = 0
+
+            events, current_state = self._read_new_events(log_path, current_state)
+            if events:
+                return events, current_state
+
+            if not block or time.time() >= deadline:
+                return [], current_state
+            time.sleep(self._poll_interval)
+
+    def _read_new_events(self, log_path: Path, state: Dict[str, Any]) -> Tuple[List[Tuple[str, str]], Dict[str, Any]]:
+        offset = int(state.get("offset") or 0)
+        try:
+            size = log_path.stat().st_size
+        except OSError:
+            return [], state
+
+        if size < offset:
+            offset = 0
+        if size == offset:
+            return [], state
+
+        try:
+            with log_path.open("rb") as handle:
+                handle.seek(offset)
+                data = handle.read()
+        except OSError:
+            return [], state
+
+        new_offset = offset + len(data)
+        text = data.decode("utf-8", errors="replace")
+        clean = _strip_ansi(text)
+
+        events: List[Tuple[str, str]] = []
+        pairs = self._extract_conversation_pairs(clean)
+        for user_msg, assistant_msg in pairs:
+            if user_msg:
+                events.append(("user", user_msg))
+            if assistant_msg:
+                events.append(("assistant", assistant_msg))
+
+        new_state = {"pane_log_path": log_path, "offset": new_offset}
+        return events, new_state
+
+    @staticmethod
+    def _extract_assistant_blocks(text: str) -> List[str]:
+        """
+        Extract assistant reply blocks from cleaned terminal text.
+
+        A reply block is text between a CCB_REQ_ID marker and the corresponding
+        CCB_DONE marker. If no markers are found, fall back to returning non-empty
+        text chunks that look like assistant output.
+        """
+        blocks: List[str] = []
+        req_positions = [(m.end(), m.group(1)) for m in _CCB_REQ_ID_RE.finditer(text)]
+        done_positions = [m.start() for m in _CCB_DONE_RE.finditer(text)]
+
+        if not req_positions and not done_positions:
+            # No CCB markers — treat the whole text as potential output
+            stripped = text.strip()
+            if stripped:
+                blocks.append(stripped)
+            return blocks
+
+        for req_end, _req_id in req_positions:
+            # Find the next CCB_DONE after this REQ_ID
+            next_done = None
+            for dp in done_positions:
+                if dp > req_end:
+                    next_done = dp
+                    break
+            if next_done is not None:
+                segment = text[req_end:next_done].strip()
+                if segment:
+                    blocks.append(segment)
+            else:
+                # No done marker yet — partial reply, take what we have
+                segment = text[req_end:].strip()
+                if segment:
+                    blocks.append(segment)
+
+        return blocks
+
+    @staticmethod
+    def _extract_conversation_pairs(text: str) -> List[Tuple[str, str]]:
+        """
+        Extract (user_prompt, assistant_reply) pairs from terminal text.
+
+        User prompts are the text injected before CCB_REQ_ID markers.
+        Assistant replies are the text between CCB_REQ_ID and CCB_DONE.
+        """
+        pairs: List[Tuple[str, str]] = []
+        req_matches = list(_CCB_REQ_ID_RE.finditer(text))
+        done_positions = [m.start() for m in _CCB_DONE_RE.finditer(text)]
+
+        prev_end = 0
+        for req_match in req_matches:
+            # User prompt is text before this REQ_ID line (from previous boundary)
+            user_text = text[prev_end:req_match.start()].strip()
+            req_end = req_match.end()
+
+            # Find next CCB_DONE
+            next_done = None
+            for dp in done_positions:
+                if dp > req_end:
+                    next_done = dp
+                    break
+
+            if next_done is not None:
+                assistant_text = text[req_end:next_done].strip()
+                prev_end = next_done
+            else:
+                assistant_text = text[req_end:].strip()
+                prev_end = len(text)
+
+            pairs.append((user_text, assistant_text))
+
+        return pairs
+
+
+# ---------------------------------------------------------------------------
+# QwenCommunicator — loads session, checks pane health
+# ---------------------------------------------------------------------------
+
+
+class QwenCommunicator:
+    """Communicate with Qwen via terminal and read replies from pane logs."""
+
+    def __init__(self, lazy_init: bool = False):
+        self.session_info = self._load_session_info()
+        if not self.session_info:
+            raise RuntimeError(
+                "No active Qwen session found. "
+                "Run 'ccb qwen' (or add qwen to ccb.config) first"
+            )
+
+        self.session_id = str(self.session_info.get("session_id") or "").strip()
+        self.terminal = self.session_info.get("terminal", "tmux")
+        self.pane_id = get_pane_id_from_session(self.session_info) or ""
+        self.pane_title_marker = self.session_info.get("pane_title_marker") or ""
+        self.backend = get_backend_for_session(self.session_info)
+        self.timeout = int(
+            os.environ.get("QWEN_SYNC_TIMEOUT", os.environ.get("CCB_SYNC_TIMEOUT", "3600"))
+        )
+        self.project_session_file = self.session_info.get("_session_file")
+
+        self._log_reader: Optional[QwenLogReader] = None
+        self._log_reader_primed = False
+
+        if self.terminal == "wezterm" and self.backend and self.pane_title_marker:
+            resolver = getattr(self.backend, "find_pane_by_title_marker", None)
+            if callable(resolver):
+                resolved = resolver(self.pane_title_marker)
+                if resolved:
+                    self.pane_id = resolved
+
+        self._publish_registry()
+
+        if not lazy_init:
+            self._ensure_log_reader()
+            healthy, msg = self._check_session_health()
+            if not healthy:
+                raise RuntimeError(
+                    f"Session unhealthy: {msg}\n"
+                    "Hint: run ccb qwen (or add qwen to ccb.config) to start a new session"
+                )
+
+    @property
+    def log_reader(self) -> QwenLogReader:
+        if self._log_reader is None:
+            self._ensure_log_reader()
+        assert self._log_reader is not None
+        return self._log_reader
+
+    def _ensure_log_reader(self) -> None:
+        if self._log_reader is not None:
+            return
+        work_dir_hint = self.session_info.get("work_dir")
+        log_work_dir = Path(work_dir_hint) if isinstance(work_dir_hint, str) and work_dir_hint else None
+
+        # Derive pane log path from session info
+        pane_log_path: Optional[Path] = None
+        raw_log_path = self.session_info.get("pane_log_path")
+        if raw_log_path:
+            pane_log_path = Path(str(raw_log_path)).expanduser()
+        elif self.session_info.get("runtime_dir"):
+            # Convention: runtime_dir / pane.log
+            pane_log_path = Path(str(self.session_info["runtime_dir"])) / "pane.log"
+
+        self._log_reader = QwenLogReader(work_dir=log_work_dir, pane_log_path=pane_log_path)
+        self._log_reader_primed = True
+
+    def _find_session_file(self) -> Optional[Path]:
+        env_session = (os.environ.get("CCB_SESSION_FILE") or "").strip()
+        if env_session:
+            try:
+                session_path = Path(os.path.expanduser(env_session))
+                if session_path.name == ".qwen-session" and session_path.is_file():
+                    return session_path
+            except Exception:
+                pass
+        return find_project_session_file(Path.cwd(), ".qwen-session")
+
+    def _load_session_info(self) -> Optional[dict]:
+        project_session = self._find_session_file()
+        if not project_session:
+            return None
+        try:
+            with project_session.open("r", encoding="utf-8") as f:
+                data = json.load(f)
+            if not isinstance(data, dict) or data.get("active", False) is False:
+                return None
+            data["_session_file"] = str(project_session)
+            return data
+        except Exception:
+            return None
+
+    def _publish_registry(self) -> None:
+        try:
+            wd = self.session_info.get("work_dir")
+            ccb_pid = compute_ccb_project_id(Path(wd)) if isinstance(wd, str) and wd else ""
+            upsert_registry(
+                {
+                    "ccb_session_id": self.session_id,
+                    "ccb_project_id": ccb_pid or None,
+                    "work_dir": wd,
+                    "terminal": self.terminal,
+                    "providers": {
+                        "qwen": {
+                            "pane_id": self.pane_id or None,
+                            "pane_title_marker": self.session_info.get("pane_title_marker"),
+                            "session_file": self.project_session_file,
+                        }
+                    },
+                }
+            )
+        except Exception:
+            pass
+
+    def _check_session_health(self) -> Tuple[bool, str]:
+        return self._check_session_health_impl(probe_terminal=True)
+
+    def _check_session_health_impl(self, probe_terminal: bool) -> Tuple[bool, str]:
+        try:
+            if not self.pane_id:
+                return False, "Session pane id not found"
+            if probe_terminal and self.backend:
+                pane_alive = self.backend.is_alive(self.pane_id)
+                if self.terminal == "wezterm" and self.pane_title_marker and not pane_alive:
+                    resolver = getattr(self.backend, "find_pane_by_title_marker", None)
+                    if callable(resolver):
+                        resolved = resolver(self.pane_title_marker)
+                        if resolved:
+                            self.pane_id = resolved
+                            pane_alive = self.backend.is_alive(self.pane_id)
+                if not pane_alive:
+                    if self.terminal == "wezterm":
+                        err = getattr(self.backend, "last_list_error", None)
+                        if err:
+                            return False, f"WezTerm CLI error: {err}"
+                    return False, f"{self.terminal} session {self.pane_id} not found"
+            return True, "Session OK"
+        except Exception as exc:
+            return False, f"Check failed: {exc}"
+
+    def ping(self, display: bool = True) -> Tuple[bool, str]:
+        healthy, status = self._check_session_health()
+        msg = (
+            f"Qwen connection OK ({status})" if healthy
+            else f"Qwen connection error: {status}"
+        )
+        if display:
+            print(msg)
+        return healthy, msg
+
+    def get_status(self) -> Dict[str, Any]:
+        healthy, status = self._check_session_health()
+        return {
+            "session_id": self.session_id,
+            "terminal": self.terminal,
+            "pane_id": self.pane_id,
+            "healthy": healthy,
+            "status": status,
+        }

--- a/test/stubs/provider_stub.py
+++ b/test/stubs/provider_stub.py
@@ -254,7 +254,7 @@ def main(argv: list[str]) -> int:
     args, _unknown = parser.parse_known_args(argv[1:])
 
     provider = (args.provider or Path(argv[0]).name).strip().lower()
-    if provider not in ("codex", "gemini", "claude", "opencode", "droid", "copilot", "codebuddy"):
+    if provider not in ("codex", "gemini", "claude", "opencode", "droid", "copilot", "codebuddy", "qwen"):
         print(f"[stub] unknown provider: {provider}", file=sys.stderr)
         return 2
 
@@ -272,6 +272,8 @@ def main(argv: list[str]) -> int:
     copilot_session_id = ""
     codebuddy_session_path: Path | None = None
     codebuddy_session_id = ""
+    qwen_session_path: Path | None = None
+    qwen_session_id = ""
 
     if provider == "gemini":
         gemini_session_path = _gemini_session_path()
@@ -315,6 +317,16 @@ def main(argv: list[str]) -> int:
             slug = _droid_slug(Path.cwd())
             codebuddy_session_path = root / slug / f"codebuddy-{codebuddy_session_id}.jsonl"
         _ensure_droid_session_start(codebuddy_session_path, codebuddy_session_id, os.getcwd())
+    elif provider == "qwen":
+        qwen_session_id = (os.environ.get("QWEN_SESSION_ID") or "").strip() or f"stub-{uuid.uuid4().hex}"
+        explicit = (os.environ.get("QWEN_SESSION_PATH") or "").strip()
+        if explicit:
+            qwen_session_path = Path(explicit).expanduser()
+        else:
+            root = _droid_sessions_root()
+            slug = _droid_slug(Path.cwd())
+            qwen_session_path = root / slug / f"qwen-{qwen_session_id}.jsonl"
+        _ensure_droid_session_start(qwen_session_path, qwen_session_id, os.getcwd())
 
     def _handle_request(req_id: str, prompt: str) -> None:
         if provider == "codex":
@@ -348,6 +360,10 @@ def main(argv: list[str]) -> int:
         if provider == "codebuddy":
             assert codebuddy_session_path is not None
             _handle_droid(req_id, prompt, delay_s, codebuddy_session_path, codebuddy_session_id)
+            return
+        if provider == "qwen":
+            assert qwen_session_path is not None
+            _handle_droid(req_id, prompt, delay_s, qwen_session_path, qwen_session_id)
             return
 
     def _signal_handler(_signum, _frame):

--- a/test/test_qask_cli.py
+++ b/test/test_qask_cli.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _run_ask(args: list[str], *, cwd: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    exe = sys.executable
+    script_path = _repo_root() / "bin" / "ask"
+    return subprocess.run(
+        [exe, str(script_path), *args],
+        cwd=str(cwd),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def _run_qask(args: list[str], *, cwd: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    exe = sys.executable
+    script_path = _repo_root() / "bin" / "qask"
+    return subprocess.run(
+        [exe, str(script_path), *args],
+        cwd=str(cwd),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def test_ask_recognizes_qwen_provider(tmp_path: Path) -> None:
+    """ask qwen should be accepted as a valid provider."""
+    env = dict(os.environ)
+    env["CCB_CALLER"] = "claude"
+    env["CCB_UNIFIED_ASKD"] = "1"
+    env["CCB_ASKD_AUTOSTART"] = "0"
+    env["CCB_RUN_DIR"] = str(tmp_path / "run")
+
+    proc = _run_ask(["qwen", "hello"], cwd=tmp_path, env=env)
+
+    # Should fail because daemon is not running, but NOT because of unknown provider
+    assert "Unknown provider" not in proc.stderr
+    assert proc.returncode != 0  # Expected: daemon not available
+
+
+def test_ask_rejects_unknown_provider(tmp_path: Path) -> None:
+    """ask with invalid provider should be rejected."""
+    env = dict(os.environ)
+    env["CCB_CALLER"] = "claude"
+
+    proc = _run_ask(["notaprovider", "hello"], cwd=tmp_path, env=env)
+
+    assert "Unknown provider" in proc.stderr
+    assert proc.returncode != 0
+
+
+def test_qask_no_session_shows_error(tmp_path: Path) -> None:
+    """qask should report error when no Qwen session exists."""
+    env = dict(os.environ)
+    env["CCB_QASKD"] = "1"
+    env["CCB_QASKD_AUTOSTART"] = "0"
+    env["CCB_RUN_DIR"] = str(tmp_path / "run")
+    # Remove any session file env
+    env.pop("CCB_SESSION_FILE", None)
+
+    proc = _run_qask(["hello"], cwd=tmp_path, env=env)
+
+    assert proc.returncode != 0
+    # Should mention Qwen session not found
+    assert "Qwen" in proc.stderr or "qwen" in proc.stderr.lower() or "session" in proc.stderr.lower()
+
+
+def test_qask_help_flag(tmp_path: Path) -> None:
+    """qask --help should show usage without error."""
+    env = dict(os.environ)
+    proc = _run_qask(["--help"], cwd=tmp_path, env=env)
+
+    assert proc.returncode == 0
+    assert "qask" in proc.stderr.lower() or "qask" in proc.stdout.lower() or "usage" in proc.stderr.lower()
+
+
+def test_qask_empty_message_shows_error(tmp_path: Path) -> None:
+    """qask with empty message should show error."""
+    env = dict(os.environ)
+    proc = _run_qask([], cwd=tmp_path, env=env)
+
+    assert proc.returncode != 0

--- a/test/test_qaskd_protocol.py
+++ b/test/test_qaskd_protocol.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from ccb_protocol import DONE_PREFIX, REQ_ID_PREFIX, is_done_text, make_req_id
+from qaskd_protocol import wrap_qwen_prompt, extract_reply_for_req, QaskdRequest, QaskdResult
+
+
+def test_wrap_qwen_prompt_structure() -> None:
+    req_id = make_req_id()
+    message = "hello\nworld"
+    prompt = wrap_qwen_prompt(message, req_id)
+
+    assert f"{REQ_ID_PREFIX} {req_id}" in prompt
+    assert "IMPORTANT:" in prompt
+    assert f"{DONE_PREFIX} {req_id}" in prompt
+    assert prompt.endswith(f"{DONE_PREFIX} {req_id}\n")
+
+
+def test_wrap_qwen_prompt_strips_trailing_whitespace() -> None:
+    req_id = make_req_id()
+    prompt = wrap_qwen_prompt("  test  \n\n", req_id)
+    # Message should be rstripped
+    assert "  test" in prompt
+
+
+def test_extract_reply_for_req_basic() -> None:
+    req_id = make_req_id()
+    text = f"some preamble\nCCB_DONE: {req_id}\n"
+    reply = extract_reply_for_req(text, req_id)
+    assert "some preamble" in reply
+
+
+def test_extract_reply_for_req_empty_on_wrong_id() -> None:
+    req_id = make_req_id()
+    other_id = make_req_id()
+    text = f"content\nCCB_DONE: {other_id}\n"
+    reply = extract_reply_for_req(text, req_id)
+    assert reply == ""
+
+
+def test_extract_reply_for_req_multiple_done_markers() -> None:
+    req1 = make_req_id()
+    req2 = make_req_id()
+    text = (
+        f"reply1\nCCB_DONE: {req1}\n"
+        f"reply2\nCCB_DONE: {req2}\n"
+    )
+    reply = extract_reply_for_req(text, req2)
+    assert "reply2" in reply
+    assert "reply1" not in reply
+
+
+def test_extract_reply_for_req_no_markers() -> None:
+    req_id = make_req_id()
+    text = "just some plain text without markers"
+    reply = extract_reply_for_req(text, req_id)
+    # With no done markers at all, should return stripped text
+    assert "just some plain text" in reply
+
+
+def test_qaskd_request_dataclass() -> None:
+    req = QaskdRequest(
+        client_id="client-1",
+        work_dir="/tmp/test",
+        timeout_s=60.0,
+        quiet=False,
+        message="hello",
+    )
+    assert req.client_id == "client-1"
+    assert req.caller == "claude"  # default
+    assert req.req_id is None
+    assert req.output_path is None
+
+
+def test_qaskd_result_dataclass() -> None:
+    result = QaskdResult(
+        exit_code=0,
+        reply="test reply",
+        req_id="abc123",
+        session_key="qwen:xyz",
+        done_seen=True,
+        done_ms=1500,
+    )
+    assert result.exit_code == 0
+    assert result.done_seen is True
+    assert result.anchor_seen is False  # default
+    assert result.fallback_scan is False  # default

--- a/test/test_qaskd_session_ensure_pane.py
+++ b/test/test_qaskd_session_ensure_pane.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import qaskd_session
+
+
+class FakeTmuxBackend:
+    def __init__(self) -> None:
+        self.alive: dict[str, bool] = {}
+        self.crash_logs: list[tuple[str, str]] = []
+        self.respawned: list[str] = []
+        self.marker_map: dict[str, str] = {}
+
+    def is_alive(self, pane_id: str) -> bool:
+        return bool(self.alive.get(pane_id, False))
+
+    def find_pane_by_title_marker(self, marker: str) -> str | None:
+        for prefix, pane in self.marker_map.items():
+            if marker.startswith(prefix) or prefix.startswith(marker):
+                return pane
+        return None
+
+    def save_crash_log(self, pane_id: str, crash_log_path: str, *, lines: int = 1000) -> None:
+        self.crash_logs.append((pane_id, crash_log_path))
+
+    def respawn_pane(self, pane_id: str, *, cmd: str, cwd: str | None = None,
+                     stderr_log_path: str | None = None, remain_on_exit: bool = True) -> None:
+        self.respawned.append(pane_id)
+        self.alive[pane_id] = True
+
+
+def test_qaskd_ensure_pane_respawns_dead_pane(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """When pane is dead, ensure_pane should respawn it and update session file."""
+    session_path = tmp_path / ".qwen-session"
+    session_path.write_text(
+        json.dumps({
+            "session_id": "test-session",
+            "terminal": "tmux",
+            "pane_id": "%1",
+            "pane_title_marker": "CCB-qwen-test",
+            "runtime_dir": str(tmp_path),
+            "work_dir": str(tmp_path),
+            "active": True,
+            "start_cmd": "qwen",
+        }),
+        encoding="utf-8",
+    )
+
+    backend = FakeTmuxBackend()
+    backend.alive = {"%1": False, "%2": False}
+    backend.marker_map = {"CCB-qwen": "%2"}
+    monkeypatch.setattr(qaskd_session, "get_backend_for_session", lambda data: backend)
+
+    sess = qaskd_session.load_project_session(tmp_path)
+    assert sess is not None
+
+    ok, pane = sess.ensure_pane()
+    assert ok is True
+    assert pane == "%2"
+    assert "%2" in backend.respawned
+
+    data = json.loads(session_path.read_text(encoding="utf-8"))
+    assert data["pane_id"] == "%2"
+
+
+def test_qaskd_ensure_pane_already_alive(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """When pane is already alive, ensure_pane should return success immediately."""
+    session_path = tmp_path / ".qwen-session"
+    session_path.write_text(
+        json.dumps({
+            "session_id": "test-session",
+            "terminal": "tmux",
+            "pane_id": "%1",
+            "pane_title_marker": "CCB-qwen-test",
+            "work_dir": str(tmp_path),
+            "active": True,
+        }),
+        encoding="utf-8",
+    )
+
+    backend = FakeTmuxBackend()
+    backend.alive = {"%1": True}
+    monkeypatch.setattr(qaskd_session, "get_backend_for_session", lambda data: backend)
+
+    sess = qaskd_session.load_project_session(tmp_path)
+    assert sess is not None
+
+    ok, pane = sess.ensure_pane()
+    assert ok is True
+    assert pane == "%1"
+    assert backend.respawned == []  # No respawn needed
+
+
+def test_qaskd_ensure_pane_marker_rediscover(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """When original pane is dead but marker finds alive pane, should update pane_id."""
+    session_path = tmp_path / ".qwen-session"
+    session_path.write_text(
+        json.dumps({
+            "session_id": "test-session",
+            "terminal": "tmux",
+            "pane_id": "%1",
+            "pane_title_marker": "CCB-qwen-test",
+            "work_dir": str(tmp_path),
+            "active": True,
+        }),
+        encoding="utf-8",
+    )
+
+    backend = FakeTmuxBackend()
+    backend.alive = {"%1": False, "%2": True}  # %2 is alive
+    backend.marker_map = {"CCB-qwen": "%2"}
+    monkeypatch.setattr(qaskd_session, "get_backend_for_session", lambda data: backend)
+
+    sess = qaskd_session.load_project_session(tmp_path)
+    assert sess is not None
+
+    ok, pane = sess.ensure_pane()
+    assert ok is True
+    assert pane == "%2"
+    assert backend.respawned == []  # No respawn needed, just rediscovered
+
+    data = json.loads(session_path.read_text(encoding="utf-8"))
+    assert data["pane_id"] == "%2"
+
+
+def test_qaskd_load_session_returns_none_for_inactive(tmp_path: Path) -> None:
+    """Inactive sessions should return None."""
+    session_path = tmp_path / ".qwen-session"
+    session_path.write_text(
+        json.dumps({
+            "session_id": "test-session",
+            "terminal": "tmux",
+            "pane_id": "%1",
+            "work_dir": str(tmp_path),
+            "active": False,
+        }),
+        encoding="utf-8",
+    )
+
+    sess = qaskd_session.load_project_session(tmp_path)
+    assert sess is None
+
+
+def test_qaskd_load_session_returns_none_for_missing_file(tmp_path: Path) -> None:
+    """Missing session file should return None."""
+    sess = qaskd_session.load_project_session(tmp_path)
+    assert sess is None
+
+
+def test_qaskd_compute_session_key_prefix(tmp_path: Path) -> None:
+    """Session key should use 'qwen:' prefix."""
+    session_path = tmp_path / ".qwen-session"
+    session_path.write_text(
+        json.dumps({
+            "session_id": "test-session",
+            "terminal": "tmux",
+            "pane_id": "%1",
+            "work_dir": str(tmp_path),
+            "active": True,
+        }),
+        encoding="utf-8",
+    )
+
+    sess = qaskd_session.load_project_session(tmp_path)
+    assert sess is not None
+
+    key = qaskd_session.compute_session_key(sess)
+    assert key.startswith("qwen:")

--- a/test/test_qwen_comm.py
+++ b/test/test_qwen_comm.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from ccb_protocol import is_done_text, make_req_id
+from qwen_comm import QwenLogReader
+
+
+def _write_pane_log(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_capture_state_returns_offset(tmp_path: Path) -> None:
+    log_path = tmp_path / "pane.log"
+    _write_pane_log(log_path, "hello world\n")
+
+    reader = QwenLogReader(work_dir=tmp_path, pane_log_path=log_path)
+    state = reader.capture_state()
+
+    assert state["pane_log_path"] == log_path
+    assert state["offset"] > 0
+
+
+def test_capture_state_no_log(tmp_path: Path) -> None:
+    reader = QwenLogReader(work_dir=tmp_path, pane_log_path=tmp_path / "nonexistent.log")
+    state = reader.capture_state()
+
+    assert state["offset"] == 0
+
+
+def test_latest_message_extracts_assistant_block(tmp_path: Path) -> None:
+    req_id = make_req_id()
+    log_path = tmp_path / "pane.log"
+    content = (
+        f"CCB_REQ_ID: {req_id}\n"
+        f"This is the reply\n"
+        f"CCB_DONE: {req_id}\n"
+    )
+    _write_pane_log(log_path, content)
+
+    reader = QwenLogReader(work_dir=tmp_path, pane_log_path=log_path)
+    message = reader.latest_message()
+
+    assert message is not None
+    assert "This is the reply" in message
+
+
+def test_latest_message_strips_ansi(tmp_path: Path) -> None:
+    req_id = make_req_id()
+    log_path = tmp_path / "pane.log"
+    content = (
+        f"CCB_REQ_ID: {req_id}\n"
+        f"\x1b[32mcolored text\x1b[0m\n"
+        f"CCB_DONE: {req_id}\n"
+    )
+    _write_pane_log(log_path, content)
+
+    reader = QwenLogReader(work_dir=tmp_path, pane_log_path=log_path)
+    message = reader.latest_message()
+
+    assert message is not None
+    assert "colored text" in message
+    assert "\x1b" not in message
+
+
+def test_latest_message_returns_none_when_no_log(tmp_path: Path) -> None:
+    reader = QwenLogReader(work_dir=tmp_path, pane_log_path=tmp_path / "nonexistent.log")
+    assert reader.latest_message() is None
+
+
+def test_wait_for_message_detects_new_content(tmp_path: Path) -> None:
+    req_id = make_req_id()
+    log_path = tmp_path / "pane.log"
+    _write_pane_log(log_path, "initial content\n")
+
+    reader = QwenLogReader(work_dir=tmp_path, pane_log_path=log_path)
+    state = reader.capture_state()
+
+    # Append new content with CCB markers
+    with log_path.open("a", encoding="utf-8") as f:
+        f.write(f"CCB_REQ_ID: {req_id}\nreply text\nCCB_DONE: {req_id}\n")
+
+    message, new_state = reader.wait_for_message(state, timeout=0.5)
+    assert message is not None
+    assert "reply text" in message
+    assert new_state["offset"] > state["offset"]
+
+
+def test_try_get_message_nonblocking(tmp_path: Path) -> None:
+    log_path = tmp_path / "pane.log"
+    _write_pane_log(log_path, "content\n")
+
+    reader = QwenLogReader(work_dir=tmp_path, pane_log_path=log_path)
+    state = reader.capture_state()
+
+    # No new content - should return None immediately
+    message, new_state = reader.try_get_message(state)
+    assert message is None
+
+
+def test_latest_conversations_extracts_pairs(tmp_path: Path) -> None:
+    req_id = make_req_id()
+    log_path = tmp_path / "pane.log"
+    content = (
+        f"user prompt here\n"
+        f"CCB_REQ_ID: {req_id}\n"
+        f"assistant reply here\n"
+        f"CCB_DONE: {req_id}\n"
+    )
+    _write_pane_log(log_path, content)
+
+    reader = QwenLogReader(work_dir=tmp_path, pane_log_path=log_path)
+    pairs = reader.latest_conversations(n=1)
+
+    assert len(pairs) >= 1
+    user_msg, assistant_msg = pairs[-1]
+    assert "assistant reply here" in assistant_msg
+
+
+def test_wait_for_events_returns_events(tmp_path: Path) -> None:
+    req_id = make_req_id()
+    log_path = tmp_path / "pane.log"
+    _write_pane_log(log_path, "")
+
+    reader = QwenLogReader(work_dir=tmp_path, pane_log_path=log_path)
+    state = reader.capture_state()
+
+    with log_path.open("a", encoding="utf-8") as f:
+        f.write(f"prompt\nCCB_REQ_ID: {req_id}\nreply\nCCB_DONE: {req_id}\n")
+
+    events, new_state = reader.wait_for_events(state, timeout=0.5)
+    assert len(events) > 0
+    roles = [role for role, _ in events]
+    assert "assistant" in roles
+
+
+def test_set_pane_log_path(tmp_path: Path) -> None:
+    reader = QwenLogReader(work_dir=tmp_path)
+    log_path = tmp_path / "custom.log"
+    _write_pane_log(log_path, "test\n")
+
+    reader.set_pane_log_path(log_path)
+    assert reader._pane_log_path == log_path
+
+
+def test_log_truncation_resets_offset(tmp_path: Path) -> None:
+    """When log is truncated (smaller than offset), offset should reset."""
+    log_path = tmp_path / "pane.log"
+    _write_pane_log(log_path, "a" * 1000 + "\n")
+
+    reader = QwenLogReader(work_dir=tmp_path, pane_log_path=log_path)
+    state = reader.capture_state()
+    assert state["offset"] > 500
+
+    # Truncate the log
+    _write_pane_log(log_path, "short\n")
+
+    # Should handle truncation gracefully
+    message, new_state = reader.try_get_message(state)
+    # After truncation, offset resets
+    assert new_state["offset"] < state["offset"]
+
+
+def test_session_file_override_prefers_env(tmp_path: Path, monkeypatch) -> None:
+    """CCB_SESSION_FILE env var should be used to find session."""
+    from qwen_comm import QwenCommunicator
+
+    root = tmp_path / "proj"
+    cfg = root / ".ccb"
+    cfg.mkdir(parents=True)
+    session = cfg / ".qwen-session"
+    session.write_text("{}", encoding="utf-8")
+
+    other = tmp_path / "elsewhere"
+    other.mkdir()
+    monkeypatch.chdir(other)
+    monkeypatch.setenv("CCB_SESSION_FILE", str(session))
+
+    comm = object.__new__(QwenCommunicator)
+    assert comm._find_session_file() == session
+
+
+def test_session_file_override_ignores_wrong_filename(tmp_path: Path, monkeypatch) -> None:
+    """CCB_SESSION_FILE with wrong filename should be ignored."""
+    from qwen_comm import QwenCommunicator
+
+    root = tmp_path / "proj"
+    cfg = root / ".ccb"
+    cfg.mkdir(parents=True)
+    session = cfg / ".copilot-session"  # Wrong filename
+    session.write_text("{}", encoding="utf-8")
+
+    other = tmp_path / "elsewhere"
+    other.mkdir()
+    monkeypatch.chdir(other)
+    monkeypatch.setenv("CCB_SESSION_FILE", str(session))
+
+    comm = object.__new__(QwenCommunicator)
+    assert comm._find_session_file() is None


### PR DESCRIPTION
## Summary

Adds [Qwen Code CLI](https://github.com/QwenLM/qwen-code) (Alibaba/QwenLM) as a new provider in CCB, closing #59.

- **Provider key**: `qwen`, **prefix**: `qask`
- **Communication**: pane-log based (same pattern as Copilot/CodeBuddy providers)
- **Session file**: `.qwen-session` in `.ccb/` project directory
- **CLI scripts**: `bin/qask` (send), `bin/qpend` (view reply), `bin/qping` (connectivity test)
- **Env vars**: `CCB_QASKD`, `CCB_QASKD_AUTOSTART`, `CCB_QASKD_IDLE_TIMEOUT_S`

### New files (7 + 4 tests)

| File | Description |
|------|-------------|
| `lib/qaskd_session.py` | Session management (`QwenProjectSession`) |
| `lib/qaskd_protocol.py` | Protocol helpers (`wrap_qwen_prompt`, `QaskdRequest`/`QaskdResult`) |
| `lib/qwen_comm.py` | Communication (`QwenLogReader`, `QwenCommunicator`) |
| `lib/askd/adapters/qwen.py` | Unified daemon adapter (`QwenAdapter`) |
| `bin/qask`, `bin/qpend`, `bin/qping` | CLI entry points |

### Modified files (6)

`lib/providers.py`, `lib/askd/adapters/__init__.py`, `bin/askd`, `bin/ask`, `install.sh`, `test/stubs/provider_stub.py`

## Test plan

- [x] 32 unit tests added and passing on all platforms
- [x] Full regression: 176 passed, 3 failed (all pre-existing upstream issues)
- [x] Import verification: all new modules load correctly
- [x] Provider specs verified: `QASKD_SPEC`, `QASK_CLIENT_SPEC`

Closes #59