### PR TITLE
fix(caskd): detect stale Codex session log and auto-switch to latest

### DIFF
--- a/lib/askd/adapters/codex.py
+++ b/lib/askd/adapters/codex.py
@@ -14,7 +14,7 @@ from askd.adapters.base import BaseProviderAdapter, ProviderRequest, ProviderRes
 from askd_runtime import log_path, write_log
 from ccb_protocol import REQ_ID_PREFIX, is_done_text, strip_done_text, extract_reply_for_req, wrap_codex_prompt
 from caskd_session import CodexProjectSession, compute_session_key, load_project_session
-from codex_comm import CodexLogReader
+from codex_comm import CodexCommunicator, CodexLogReader
 from completion_hook import (
     COMPLETION_STATUS_CANCELLED,
     COMPLETION_STATUS_COMPLETED,
@@ -46,6 +46,28 @@ def _tail_state_for_log(log_path_val: Optional[Path], *, tail_bytes: int) -> dic
     return {"log_path": log_path_val, "offset": offset}
 
 
+def _scan_latest_any_log(work_dir: Path) -> Optional[Path]:
+    try:
+        return CodexLogReader(log_path=None, session_id_filter=None, work_dir=work_dir).current_log_path()
+    except Exception:
+        return None
+
+
+def _is_log_stale(preferred: Optional[Path], latest: Optional[Path], threshold_s: float) -> bool:
+    if not latest:
+        return False
+    if not preferred or not preferred.exists():
+        return True
+    if threshold_s <= 0:
+        return False
+    try:
+        preferred_mtime = preferred.stat().st_mtime
+        latest_mtime = latest.stat().st_mtime
+    except OSError:
+        return True
+    return latest_mtime - preferred_mtime >= threshold_s
+
+
 class CodexAdapter(BaseProviderAdapter):
     """Adapter for Codex (WezTerm) provider."""
 
@@ -69,6 +91,7 @@ class CodexAdapter(BaseProviderAdapter):
 
     def handle_task(self, task: QueuedTask) -> ProviderResult:
         started_ms = _now_ms()
+        started_at = time.time()
         req = task.request
         work_dir = Path(req.work_dir)
         _write_log(f"[INFO] start provider=codex req_id={task.req_id} work_dir={req.work_dir} caller={req.caller}")
@@ -137,6 +160,10 @@ class CodexAdapter(BaseProviderAdapter):
         last_pane_check = time.time()
         default_interval = "5.0" if is_windows() else "2.0"
         pane_check_interval = float(os.environ.get("CCB_CASKD_PANE_CHECK_INTERVAL", default_interval))
+        stale_grace_s = float(os.environ.get("CCB_CASKD_STALE_LOG_GRACE_SECONDS", "2.5"))
+        stale_check_interval = float(os.environ.get("CCB_CASKD_STALE_LOG_CHECK_INTERVAL", "1.0"))
+        stale_threshold_s = float(os.environ.get("CCB_CODEX_STALE_LOG_SECONDS", "10.0"))
+        last_stale_check = time.time()
 
         while True:
             # Check for cancellation
@@ -183,6 +210,38 @@ class CodexAdapter(BaseProviderAdapter):
             event, state = reader.wait_for_event(state, wait_step)
 
             if event is None:
+                # Stale log detection: if no anchor and no chunks yet,
+                # check whether a newer session log appeared (e.g. after pane restart).
+                if (not anchor_seen) and (not chunks):
+                    now = time.time()
+                    if now - started_at >= stale_grace_s and now - last_stale_check >= stale_check_interval:
+                        last_stale_check = now
+                        latest_log = _scan_latest_any_log(Path(session.work_dir))
+                        current_log = state.get("log_path")
+                        if isinstance(current_log, str):
+                            current_log = Path(current_log)
+                        if latest_log and latest_log != current_log and _is_log_stale(current_log, latest_log, stale_threshold_s):
+                            reader = CodexLogReader(
+                                log_path=latest_log,
+                                session_id_filter=None,
+                                work_dir=Path(session.work_dir),
+                            )
+                            state = reader.capture_state()
+                            fallback_scan = True
+                            try:
+                                new_session_id = CodexCommunicator._extract_session_id(latest_log)
+                            except Exception:
+                                new_session_id = None
+                            try:
+                                session.update_codex_log_binding(
+                                    log_path=str(latest_log),
+                                    session_id=new_session_id,
+                                )
+                            except Exception:
+                                pass
+                            preferred_log = str(latest_log)
+                            codex_session_id = new_session_id or None
+                            _write_log(f"[WARN] stale codex log detected; switching to {latest_log}")
                 continue
 
             role, text = event

--- a/lib/codex_comm.py
+++ b/lib/codex_comm.py
@@ -267,10 +267,47 @@ class CodexLogReader:
 
         return latest
 
+    def _scan_latest_any(self) -> Optional[Path]:
+        if not self.root.exists():
+            return None
+        try:
+            latest: Optional[Path] = None
+            latest_mtime = -1.0
+            for p in (p for p in self.root.glob("**/*.jsonl") if p.is_file()):
+                if self._work_dir:
+                    cwd = self._extract_cwd_from_log(p)
+                    if not cwd or cwd != self._work_dir:
+                        continue
+                try:
+                    mtime = p.stat().st_mtime
+                except OSError:
+                    continue
+                if mtime >= latest_mtime:
+                    latest = p
+                    latest_mtime = mtime
+        except OSError:
+            return None
+        return latest
+
     def _latest_log(self) -> Optional[Path]:
         preferred = self._preferred_log
         if preferred and preferred.exists():
             if self._session_id_filter:
+                latest_any = self._scan_latest_any()
+                if latest_any and latest_any != preferred:
+                    threshold = _env_float("CCB_CODEX_STALE_LOG_SECONDS", 10.0)
+                    if threshold > 0:
+                        try:
+                            preferred_mtime = preferred.stat().st_mtime
+                            latest_mtime = latest_any.stat().st_mtime
+                            if latest_mtime - preferred_mtime >= threshold:
+                                self._preferred_log = latest_any
+                                self._debug(f"Preferred log stale (bound); switching to latest: {latest_any}")
+                                return latest_any
+                        except OSError:
+                            self._preferred_log = latest_any
+                            self._debug(f"Preferred log stat failed (bound); switching to latest: {latest_any}")
+                            return latest_any
                 self._debug(f"Using preferred log (bound): {preferred}")
                 return preferred
 


### PR DESCRIPTION
## Summary

- Fix stale Codex session log binding that causes caskd to hang indefinitely after Codex pane restart
- Add automatic detection and switching to the newest session log file when the bound log becomes stale
- Persist new session binding via `update_codex_log_binding()` so subsequent requests use the correct log

> Replaces #121 (which accidentally included unrelated files)

## Problem

When a Codex pane is restarted (e.g., via `tmux respawn-pane`), it creates a new session and writes to a new `.jsonl` file. However, `.ccb/.codex-session` still points to the old session's `codex_session_id` and `codex_session_path`. The caskd daemon's `CodexLogReader` monitors the old (stale) file that will never be updated, causing all `ask codex` requests to hang indefinitely.

Relates to #93 (stale pane ID routing) and #94 (worker blocks indefinitely - same root cause pattern).

## Changes

### `lib/codex_comm.py`
- Added `_scan_latest_any()` method: scans for the newest `.jsonl` log file matching `work_dir` but **without** `session_id_filter`, so it can find logs from new sessions
- Updated `_latest_log()`: even when `session_id_filter` is set, checks if the preferred log is stale (mtime threshold configurable via `CCB_CODEX_STALE_LOG_SECONDS`, default 10s) and switches to the latest log automatically

### `lib/askd/adapters/codex.py`
- Added stale log detection in the wait loop: when no anchor and no chunks are detected after a grace period (`CCB_CASKD_STALE_LOG_GRACE_SECONDS`, default 2.5s), periodically checks for newer session files
- On stale detection: switches the reader to the new log, persists the binding via `session.update_codex_log_binding()`, and logs a `[WARN]` message
- Added helper functions `_scan_latest_any_log()` and `_is_log_stale()` for clean separation

## Configuration

| Environment Variable | Default | Description |
|---|---|---|
| `CCB_CODEX_STALE_LOG_SECONDS` | `10.0` | Mtime difference threshold to consider a log stale |
| `CCB_CASKD_STALE_LOG_GRACE_SECONDS` | `2.5` | Wait before starting stale checks (avoid false positives) |
| `CCB_CASKD_STALE_LOG_CHECK_INTERVAL` | `1.0` | Interval between stale log checks in wait loop |

## Test plan

- [ ] Restart Codex pane via `tmux respawn-pane`, then send `ask codex` request → should auto-detect new session and complete successfully
- [ ] Normal operation (no restart) → should work as before with no behavior change
- [ ] Verify `[WARN] stale codex log detected` appears in caskd.log when switching occurs
- [ ] Verify `.codex-session` is updated with new `codex_session_id` and `codex_session_path` after auto-switch