### PR TITLE
fix: _NoopThread._started overwrites Thread._started (#130)

### DIFF
--- a/test/test_worker_pool.py
+++ b/test/test_worker_pool.py
@@ -12,10 +12,18 @@ class _NoopThread(threading.Thread):
     def __init__(self, session_key: str, started: list[str]):
         super().__init__(daemon=True)
         self.session_key = session_key
-        self._started = started
+        self.started_keys = started
+        self._stop_event = threading.Event()
+
+    def run(self) -> None:
+        self._stop_event.wait()
 
     def start(self) -> None:  # type: ignore[override]
-        self._started.append(self.session_key)
+        self.started_keys.append(self.session_key)
+        super().start()
+
+    def stop(self) -> None:
+        self._stop_event.set()
 
 
 def test_per_session_worker_pool_reuses_same_key() -> None:
@@ -29,6 +37,12 @@ def test_per_session_worker_pool_reuses_same_key() -> None:
     assert w1 is not w3
     assert started.count("k1") == 1
     assert started.count("k2") == 1
+
+    # Clean up threads
+    w1.stop()
+    w3.stop()
+    w1.join(timeout=1.0)
+    w3.join(timeout=1.0)
 
 
 @dataclass


### PR DESCRIPTION
## Summary

Fixes #130 — `test_per_session_worker_pool_reuses_same_key` fails on **all 10 CI jobs** (every platform × every Python version).

### Root cause

`_NoopThread` in `test/test_worker_pool.py` used `self._started` (a `list`) as an attribute, which **overwrites** `threading.Thread._started` (an internal `threading.Event`). When `PerSessionWorkerPool.get_or_create()` calls `worker.is_alive()`, it triggers `self._started.is_set()` on a `list` → `AttributeError`.

### Changes

- Renamed `self._started` → `self.started_keys` to avoid collision with `Thread._started`
- Added `super().start()` call so the thread actually starts and `is_alive()` returns `True`
- Added `run()` with `Event.wait()` to keep the thread alive during the test
- Added proper cleanup (`stop()` + `join()`) at the end of the test

**Test-only change** — zero impact on production code.

## Test plan

- [x] `pytest test/test_worker_pool.py -v` — 3 passed (previously 1 failed, 2 passed)
- [x] All other tests unaffected