### PR TITLE
fix: verify title marker in ensure_pane() fast path (#93)

### DIFF
--- a/lib/baskd_session.py
+++ b/lib/baskd_session.py
@@ -88,12 +88,24 @@ class CodebuddyProjectSession:
             return False, "Terminal backend not available"
 
         pane_id = self.pane_id
+        marker = self.pane_title_marker
+        resolver = getattr(backend, "find_pane_by_title_marker", None)
+
         if pane_id and backend.is_alive(pane_id):
+            if marker and callable(resolver):
+                try:
+                    resolved = resolver(marker)
+                    if resolved and str(resolved) != str(pane_id) and backend.is_alive(str(resolved)):
+                        self.data["pane_id"] = str(resolved)
+                        self.data["updated_at"] = _now_str()
+                        self._write_back()
+                        self._attach_pane_log(backend, str(resolved))
+                        return True, str(resolved)
+                except Exception:
+                    pass
             self._attach_pane_log(backend, pane_id)
             return True, pane_id
 
-        marker = self.pane_title_marker
-        resolver = getattr(backend, "find_pane_by_title_marker", None)
         if marker and callable(resolver):
             resolved = resolver(marker)
             if resolved and backend.is_alive(str(resolved)):

--- a/lib/caskd_session.py
+++ b/lib/caskd_session.py
@@ -92,12 +92,24 @@ class CodexProjectSession:
             return False, "Terminal backend not available"
 
         pane_id = self.pane_id
+        marker = self.pane_title_marker
+        resolver = getattr(backend, "find_pane_by_title_marker", None)
+
         if pane_id and backend.is_alive(pane_id):
+            if marker and callable(resolver):
+                try:
+                    resolved = resolver(marker)
+                    if resolved and str(resolved) != str(pane_id) and backend.is_alive(str(resolved)):
+                        self.data["pane_id"] = str(resolved)
+                        self.data["updated_at"] = _now_str()
+                        self._write_back()
+                        self._attach_pane_log(backend, str(resolved))
+                        return True, str(resolved)
+                except Exception:
+                    pass
             self._attach_pane_log(backend, pane_id)
             return True, pane_id
 
-        marker = self.pane_title_marker
-        resolver = getattr(backend, "find_pane_by_title_marker", None)
         resolved: Optional[str] = None
         if marker and callable(resolver):
             resolved = resolver(marker)

--- a/lib/daskd_session.py
+++ b/lib/daskd_session.py
@@ -90,12 +90,24 @@ class DroidProjectSession:
             return False, "Terminal backend not available"
 
         pane_id = self.pane_id
+        marker = self.pane_title_marker
+        resolver = getattr(backend, "find_pane_by_title_marker", None)
+
         if pane_id and backend.is_alive(pane_id):
+            if marker and callable(resolver):
+                try:
+                    resolved = resolver(marker)
+                    if resolved and str(resolved) != str(pane_id) and backend.is_alive(str(resolved)):
+                        self.data["pane_id"] = str(resolved)
+                        self.data["updated_at"] = _now_str()
+                        self._write_back()
+                        self._attach_pane_log(backend, str(resolved))
+                        return True, str(resolved)
+                except Exception:
+                    pass
             self._attach_pane_log(backend, pane_id)
             return True, pane_id
 
-        marker = self.pane_title_marker
-        resolver = getattr(backend, "find_pane_by_title_marker", None)
         if marker and callable(resolver):
             resolved = resolver(marker)
             if resolved and backend.is_alive(str(resolved)):

--- a/lib/gaskd_session.py
+++ b/lib/gaskd_session.py
@@ -90,12 +90,26 @@ class GeminiProjectSession:
             return False, "Terminal backend not available"
 
         pane_id = self.pane_id
+        marker = self.pane_title_marker
+        resolver = getattr(backend, "find_pane_by_title_marker", None)
+
         if pane_id and backend.is_alive(pane_id):
+            # Verify title marker: if marker resolves to a different pane,
+            # the cached pane_id is stale (tmux recycled the ID).
+            if marker and callable(resolver):
+                try:
+                    resolved = resolver(marker)
+                    if resolved and str(resolved) != str(pane_id) and backend.is_alive(str(resolved)):
+                        self.data["pane_id"] = str(resolved)
+                        self.data["updated_at"] = _now_str()
+                        self._write_back()
+                        self._attach_pane_log(backend, str(resolved))
+                        return True, str(resolved)
+                except Exception:
+                    pass
             self._attach_pane_log(backend, pane_id)
             return True, pane_id
 
-        marker = self.pane_title_marker
-        resolver = getattr(backend, "find_pane_by_title_marker", None)
         if marker and callable(resolver):
             resolved = resolver(marker)
             if resolved and backend.is_alive(str(resolved)):

--- a/lib/haskd_session.py
+++ b/lib/haskd_session.py
@@ -88,12 +88,24 @@ class CopilotProjectSession:
             return False, "Terminal backend not available"
 
         pane_id = self.pane_id
+        marker = self.pane_title_marker
+        resolver = getattr(backend, "find_pane_by_title_marker", None)
+
         if pane_id and backend.is_alive(pane_id):
+            if marker and callable(resolver):
+                try:
+                    resolved = resolver(marker)
+                    if resolved and str(resolved) != str(pane_id) and backend.is_alive(str(resolved)):
+                        self.data["pane_id"] = str(resolved)
+                        self.data["updated_at"] = _now_str()
+                        self._write_back()
+                        self._attach_pane_log(backend, str(resolved))
+                        return True, str(resolved)
+                except Exception:
+                    pass
             self._attach_pane_log(backend, pane_id)
             return True, pane_id
 
-        marker = self.pane_title_marker
-        resolver = getattr(backend, "find_pane_by_title_marker", None)
         if marker and callable(resolver):
             resolved = resolver(marker)
             if resolved and backend.is_alive(str(resolved)):

--- a/lib/laskd_session.py
+++ b/lib/laskd_session.py
@@ -169,12 +169,24 @@ class ClaudeProjectSession:
             return False, "Terminal backend not available"
 
         pane_id = self.pane_id
+        marker = self.pane_title_marker
+        resolver = getattr(backend, "find_pane_by_title_marker", None)
+
         if pane_id and backend.is_alive(pane_id):
+            if marker and callable(resolver):
+                try:
+                    resolved = resolver(marker)
+                    if resolved and str(resolved) != str(pane_id) and backend.is_alive(str(resolved)):
+                        self.data["pane_id"] = str(resolved)
+                        self.data["updated_at"] = _now_str()
+                        self._write_back()
+                        self._attach_pane_log(backend, str(resolved))
+                        return True, str(resolved)
+                except Exception:
+                    pass
             self._attach_pane_log(backend, pane_id)
             return True, pane_id
 
-        marker = self.pane_title_marker
-        resolver = getattr(backend, "find_pane_by_title_marker", None)
         if marker and callable(resolver):
             resolved = resolver(marker)
             if resolved and backend.is_alive(str(resolved)):

--- a/lib/oaskd_session.py
+++ b/lib/oaskd_session.py
@@ -116,12 +116,24 @@ class OpenCodeProjectSession:
             return False, "Terminal backend not available"
 
         pane_id = self.pane_id
+        marker = self.pane_title_marker
+        resolver = getattr(backend, "find_pane_by_title_marker", None)
+
         if pane_id and backend.is_alive(pane_id):
+            if marker and callable(resolver):
+                try:
+                    resolved = resolver(marker)
+                    if resolved and str(resolved) != str(pane_id) and backend.is_alive(str(resolved)):
+                        self.data["pane_id"] = str(resolved)
+                        self.data["updated_at"] = _now_str()
+                        self._write_back()
+                        self._attach_pane_log(backend, str(resolved))
+                        return True, str(resolved)
+                except Exception:
+                    pass
             self._attach_pane_log(backend, pane_id)
             return True, pane_id
 
-        marker = self.pane_title_marker
-        resolver = getattr(backend, "find_pane_by_title_marker", None)
         if marker and callable(resolver):
             resolved = resolver(marker)
             if resolved and backend.is_alive(str(resolved)):

--- a/lib/qaskd_session.py
+++ b/lib/qaskd_session.py
@@ -88,12 +88,24 @@ class QwenProjectSession:
             return False, "Terminal backend not available"
 
         pane_id = self.pane_id
+        marker = self.pane_title_marker
+        resolver = getattr(backend, "find_pane_by_title_marker", None)
+
         if pane_id and backend.is_alive(pane_id):
+            if marker and callable(resolver):
+                try:
+                    resolved = resolver(marker)
+                    if resolved and str(resolved) != str(pane_id) and backend.is_alive(str(resolved)):
+                        self.data["pane_id"] = str(resolved)
+                        self.data["updated_at"] = _now_str()
+                        self._write_back()
+                        self._attach_pane_log(backend, str(resolved))
+                        return True, str(resolved)
+                except Exception:
+                    pass
             self._attach_pane_log(backend, pane_id)
             return True, pane_id
 
-        marker = self.pane_title_marker
-        resolver = getattr(backend, "find_pane_by_title_marker", None)
         if marker and callable(resolver):
             resolved = resolver(marker)
             if resolved and backend.is_alive(str(resolved)):

--- a/test/test_ensure_pane_stale.py
+++ b/test/test_ensure_pane_stale.py
@@ -1,0 +1,164 @@
+"""Tests for ensure_pane() title marker verification in the fast path.
+
+Verifies that when a cached pane_id is alive but the title marker resolves
+to a different pane (tmux ID recycling), ensure_pane() updates to the
+correct pane instead of routing messages to the wrong process.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+from gaskd_session import GeminiProjectSession
+from caskd_session import CodexProjectSession
+from oaskd_session import OpenCodeProjectSession
+from daskd_session import DroidProjectSession
+from baskd_session import CodebuddyProjectSession
+from haskd_session import CopilotProjectSession
+from laskd_session import ClaudeProjectSession
+from qaskd_session import QwenProjectSession
+
+
+class _FakeBackend:
+    """Fake terminal backend for testing ensure_pane()."""
+
+    def __init__(
+        self,
+        alive_panes: set[str],
+        marker_map: Optional[dict[str, str]] = None,
+    ):
+        self.alive_panes = alive_panes
+        self.marker_map = marker_map or {}
+        self.attached: list[str] = []
+
+    def is_alive(self, pane_id: str) -> bool:
+        return pane_id in self.alive_panes
+
+    def find_pane_by_title_marker(self, marker: str) -> Optional[str]:
+        return self.marker_map.get(marker)
+
+    def ensure_pane_log(self, pane_id: str) -> None:
+        self.attached.append(pane_id)
+
+
+def _write_session(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def _make_session(cls, tmp_path: Path, pane_id: str, marker: str, backend: _FakeBackend):
+    """Create a session object with a fake backend."""
+    session_file = tmp_path / ".session"
+    data = {
+        "pane_id": pane_id,
+        "pane_title_marker": marker,
+        "terminal": "tmux",
+        "work_dir": str(tmp_path),
+    }
+    _write_session(session_file, data)
+    session = cls.__new__(cls)
+    session.data = data
+    session.session_file = session_file
+    session._backend = backend
+
+    # Override backend() to return our fake
+    session.backend = lambda: backend
+    # Override _attach_pane_log to be a no-op
+    session._attach_pane_log = lambda b, pid: None
+    # Override _write_back to update the file
+    session._write_back = lambda: _write_session(session_file, session.data)
+    return session
+
+
+# All session classes to test
+SESSION_CLASSES = [
+    GeminiProjectSession,
+    CodexProjectSession,
+    OpenCodeProjectSession,
+    DroidProjectSession,
+    CodebuddyProjectSession,
+    CopilotProjectSession,
+    ClaudeProjectSession,
+    QwenProjectSession,
+]
+
+
+@pytest.mark.parametrize("cls", SESSION_CLASSES, ids=lambda c: c.__name__)
+def test_fast_path_returns_correct_pane_when_marker_matches(cls, tmp_path: Path) -> None:
+    """When pane_id is alive AND marker resolves to the same pane, return it."""
+    backend = _FakeBackend(
+        alive_panes={"%10"},
+        marker_map={"CCB-Gemini-abc": "%10"},
+    )
+    session = _make_session(cls, tmp_path, "%10", "CCB-Gemini-abc", backend)
+
+    ok, pane = session.ensure_pane()
+
+    assert ok is True
+    assert pane == "%10"
+    # pane_id should NOT change
+    assert session.data["pane_id"] == "%10"
+
+
+@pytest.mark.parametrize("cls", SESSION_CLASSES, ids=lambda c: c.__name__)
+def test_fast_path_switches_to_marker_pane_when_id_stale(cls, tmp_path: Path) -> None:
+    """When cached pane_id is alive but marker resolves to a DIFFERENT alive
+    pane, ensure_pane() should switch to the marker's pane."""
+    backend = _FakeBackend(
+        alive_panes={"%10", "%20"},
+        marker_map={"CCB-Gemini-abc": "%20"},
+    )
+    session = _make_session(cls, tmp_path, "%10", "CCB-Gemini-abc", backend)
+
+    ok, pane = session.ensure_pane()
+
+    assert ok is True
+    assert pane == "%20"
+    assert session.data["pane_id"] == "%20"
+
+
+@pytest.mark.parametrize("cls", SESSION_CLASSES, ids=lambda c: c.__name__)
+def test_fast_path_keeps_pane_when_no_marker(cls, tmp_path: Path) -> None:
+    """When no title marker is set, fast path should return the alive pane."""
+    backend = _FakeBackend(alive_panes={"%10"})
+    session = _make_session(cls, tmp_path, "%10", "", backend)
+
+    ok, pane = session.ensure_pane()
+
+    assert ok is True
+    assert pane == "%10"
+
+
+@pytest.mark.parametrize("cls", SESSION_CLASSES, ids=lambda c: c.__name__)
+def test_fallback_resolves_by_marker_when_pane_dead(cls, tmp_path: Path) -> None:
+    """When cached pane_id is dead, fall through to marker resolution."""
+    backend = _FakeBackend(
+        alive_panes={"%20"},
+        marker_map={"CCB-Gemini-abc": "%20"},
+    )
+    session = _make_session(cls, tmp_path, "%10", "CCB-Gemini-abc", backend)
+
+    ok, pane = session.ensure_pane()
+
+    assert ok is True
+    assert pane == "%20"
+    assert session.data["pane_id"] == "%20"
+
+
+@pytest.mark.parametrize("cls", SESSION_CLASSES, ids=lambda c: c.__name__)
+def test_fast_path_keeps_pane_when_resolver_raises(cls, tmp_path: Path) -> None:
+    """If find_pane_by_title_marker raises, fast path should still work."""
+    class _BrokenBackend(_FakeBackend):
+        def find_pane_by_title_marker(self, marker: str) -> Optional[str]:
+            raise RuntimeError("tmux error")
+
+    backend = _BrokenBackend(alive_panes={"%10"})
+    session = _make_session(cls, tmp_path, "%10", "CCB-Gemini-abc", backend)
+
+    ok, pane = session.ensure_pane()
+
+    assert ok is True
+    assert pane == "%10"


### PR DESCRIPTION
## Summary

Fixes #93 — `ensure_pane()` trusts stale `pane_id` without title verification, routing messages to the wrong tmux pane after CCB restart.

**Root cause:** All 8 session modules have the same fast path that returns immediately when `pane_id` is alive, without checking if the title marker resolves to a different pane. When tmux recycles a pane ID to another process, messages are silently delivered to the wrong target.

**Fix:** Add title marker verification to the fast path in all 8 session modules. If the marker resolves to a different alive pane, update the cached `pane_id` and route to the correct pane.

**Files changed:**
- `lib/gaskd_session.py` (Gemini)
- `lib/caskd_session.py` (Codex)
- `lib/oaskd_session.py` (OpenCode)
- `lib/daskd_session.py` (Droid)
- `lib/baskd_session.py` (CodeBuddy)
- `lib/haskd_session.py` (Copilot)
- `lib/laskd_session.py` (Claude)
- `lib/qaskd_session.py` (Qwen)
- `test/test_ensure_pane_stale.py` (40 new tests)

## Test plan

- [x] 40 new tests: 8 session modules × 5 scenarios (marker match, stale ID switch, no marker, dead pane fallback, resolver exception)
- [x] 175 existing tests pass (0 regressions)
- [ ] Manual: restart CCB, verify `ask gemini` routes to correct pane after tmux pane ID recycling