### PR TITLE
Fix Python path detection for pyenv users

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -93,8 +93,8 @@ function Show-Usage {
 
 function Find-Python {
   if (Get-Command py -ErrorAction SilentlyContinue) { return "py -3" }
-  if (Get-Command python -ErrorAction SilentlyContinue) { return "python" }
-  if (Get-Command python3 -ErrorAction SilentlyContinue) { return "python3" }
+  if (Get-Command python -ErrorAction SilentlyContinue) { return (Get-Command python).Source }
+  if (Get-Command python3 -ErrorAction SilentlyContinue) { return (Get-Command python3).Source }
   return $null
 }
 


### PR DESCRIPTION
## Problem
When using pyenv-win on Windows, the installation fails with:
"Failed to query Python version using: python"
"The system cannot find the file specified"

This happens because `ProcessStartInfo.FileName` requires the full path
to the executable, but `Find-Python` was returning just "python".

## Solution
Use `(Get-Command python).Source` to get the full path instead of just
the command name.

## Testing
- [x] Tested with pyenv-win on Windows 11
- [x] Python 3.12.10 installed via pyenv