### PR TITLE
fix: CWD-aware pane routing for WezTerm multi-window (fixes #137)

### DIFF
--- a/lib/baskd_session.py
+++ b/lib/baskd_session.py
@@ -92,22 +92,26 @@ class CodebuddyProjectSession:
         resolver = getattr(backend, "find_pane_by_title_marker", None)
 
         if pane_id and backend.is_alive(pane_id):
-            if marker and callable(resolver):
-                try:
-                    resolved = resolver(marker)
-                    if resolved and str(resolved) != str(pane_id) and backend.is_alive(str(resolved)):
-                        self.data["pane_id"] = str(resolved)
-                        self.data["updated_at"] = _now_str()
-                        self._write_back()
-                        self._attach_pane_log(backend, str(resolved))
-                        return True, str(resolved)
-                except Exception:
-                    pass
-            self._attach_pane_log(backend, pane_id)
-            return True, pane_id
+            # WezTerm multi-window: verify the alive pane belongs to this project.
+            cwd_check = getattr(backend, "pane_belongs_to_cwd", None)
+            if not cwd_check or cwd_check(pane_id, self.work_dir):
+                if marker and callable(resolver):
+                    try:
+                        resolved = resolver(marker, self.work_dir)
+                        if resolved and str(resolved) != str(pane_id) and backend.is_alive(str(resolved)):
+                            self.data["pane_id"] = str(resolved)
+                            self.data["updated_at"] = _now_str()
+                            self._write_back()
+                            self._attach_pane_log(backend, str(resolved))
+                            return True, str(resolved)
+                    except Exception:
+                        pass
+                self._attach_pane_log(backend, pane_id)
+                return True, pane_id
+            # else: pane alive but belongs to wrong project — fall through to marker resolution
 
         if marker and callable(resolver):
-            resolved = resolver(marker)
+            resolved = resolver(marker, self.work_dir)
             if resolved and backend.is_alive(str(resolved)):
                 self.data["pane_id"] = str(resolved)
                 self.data["updated_at"] = _now_str()

--- a/lib/caskd_session.py
+++ b/lib/caskd_session.py
@@ -96,23 +96,29 @@ class CodexProjectSession:
         resolver = getattr(backend, "find_pane_by_title_marker", None)
 
         if pane_id and backend.is_alive(pane_id):
-            if marker and callable(resolver):
-                try:
-                    resolved = resolver(marker)
-                    if resolved and str(resolved) != str(pane_id) and backend.is_alive(str(resolved)):
-                        self.data["pane_id"] = str(resolved)
-                        self.data["updated_at"] = _now_str()
-                        self._write_back()
-                        self._attach_pane_log(backend, str(resolved))
-                        return True, str(resolved)
-                except Exception:
-                    pass
-            self._attach_pane_log(backend, pane_id)
-            return True, pane_id
+            # WezTerm multi-window: verify the alive pane belongs to this project.
+            # Without this check a stale pane_id that was recycled by another project
+            # passes is_alive() and routes the ask to the wrong workspace.
+            cwd_check = getattr(backend, "pane_belongs_to_cwd", None)
+            if not cwd_check or cwd_check(pane_id, self.work_dir):
+                if marker and callable(resolver):
+                    try:
+                        resolved = resolver(marker, self.work_dir)
+                        if resolved and str(resolved) != str(pane_id) and backend.is_alive(str(resolved)):
+                            self.data["pane_id"] = str(resolved)
+                            self.data["updated_at"] = _now_str()
+                            self._write_back()
+                            self._attach_pane_log(backend, str(resolved))
+                            return True, str(resolved)
+                    except Exception:
+                        pass
+                self._attach_pane_log(backend, pane_id)
+                return True, pane_id
+            # else: pane alive but belongs to wrong project — fall through to marker resolution
 
         resolved: Optional[str] = None
         if marker and callable(resolver):
-            resolved = resolver(marker)
+            resolved = resolver(marker, self.work_dir)
             if resolved and backend.is_alive(str(resolved)):
                 self.data["pane_id"] = str(resolved)
                 self.data["updated_at"] = _now_str()

--- a/lib/daskd_session.py
+++ b/lib/daskd_session.py
@@ -94,22 +94,26 @@ class DroidProjectSession:
         resolver = getattr(backend, "find_pane_by_title_marker", None)
 
         if pane_id and backend.is_alive(pane_id):
-            if marker and callable(resolver):
-                try:
-                    resolved = resolver(marker)
-                    if resolved and str(resolved) != str(pane_id) and backend.is_alive(str(resolved)):
-                        self.data["pane_id"] = str(resolved)
-                        self.data["updated_at"] = _now_str()
-                        self._write_back()
-                        self._attach_pane_log(backend, str(resolved))
-                        return True, str(resolved)
-                except Exception:
-                    pass
-            self._attach_pane_log(backend, pane_id)
-            return True, pane_id
+            # WezTerm multi-window: verify the alive pane belongs to this project.
+            cwd_check = getattr(backend, "pane_belongs_to_cwd", None)
+            if not cwd_check or cwd_check(pane_id, self.work_dir):
+                if marker and callable(resolver):
+                    try:
+                        resolved = resolver(marker, self.work_dir)
+                        if resolved and str(resolved) != str(pane_id) and backend.is_alive(str(resolved)):
+                            self.data["pane_id"] = str(resolved)
+                            self.data["updated_at"] = _now_str()
+                            self._write_back()
+                            self._attach_pane_log(backend, str(resolved))
+                            return True, str(resolved)
+                    except Exception:
+                        pass
+                self._attach_pane_log(backend, pane_id)
+                return True, pane_id
+            # else: pane alive but belongs to wrong project — fall through to marker resolution
 
         if marker and callable(resolver):
-            resolved = resolver(marker)
+            resolved = resolver(marker, self.work_dir)
             if resolved and backend.is_alive(str(resolved)):
                 self.data["pane_id"] = str(resolved)
                 self.data["updated_at"] = _now_str()

--- a/lib/gaskd_session.py
+++ b/lib/gaskd_session.py
@@ -94,24 +94,27 @@ class GeminiProjectSession:
         resolver = getattr(backend, "find_pane_by_title_marker", None)
 
         if pane_id and backend.is_alive(pane_id):
-            # Verify title marker: if marker resolves to a different pane,
-            # the cached pane_id is stale (tmux recycled the ID).
-            if marker and callable(resolver):
-                try:
-                    resolved = resolver(marker)
-                    if resolved and str(resolved) != str(pane_id) and backend.is_alive(str(resolved)):
-                        self.data["pane_id"] = str(resolved)
-                        self.data["updated_at"] = _now_str()
-                        self._write_back()
-                        self._attach_pane_log(backend, str(resolved))
-                        return True, str(resolved)
-                except Exception:
-                    pass
-            self._attach_pane_log(backend, pane_id)
-            return True, pane_id
+            # WezTerm multi-window: verify the alive pane belongs to this project.
+            # Also keeps PR #132 tmux-recycling detection in the inner block.
+            cwd_check = getattr(backend, "pane_belongs_to_cwd", None)
+            if not cwd_check or cwd_check(pane_id, self.work_dir):
+                if marker and callable(resolver):
+                    try:
+                        resolved = resolver(marker, self.work_dir)
+                        if resolved and str(resolved) != str(pane_id) and backend.is_alive(str(resolved)):
+                            self.data["pane_id"] = str(resolved)
+                            self.data["updated_at"] = _now_str()
+                            self._write_back()
+                            self._attach_pane_log(backend, str(resolved))
+                            return True, str(resolved)
+                    except Exception:
+                        pass
+                self._attach_pane_log(backend, pane_id)
+                return True, pane_id
+            # else: pane alive but belongs to wrong project — fall through to marker resolution
 
         if marker and callable(resolver):
-            resolved = resolver(marker)
+            resolved = resolver(marker, self.work_dir)
             if resolved and backend.is_alive(str(resolved)):
                 self.data["pane_id"] = str(resolved)
                 self.data["updated_at"] = _now_str()

--- a/lib/haskd_session.py
+++ b/lib/haskd_session.py
@@ -92,22 +92,26 @@ class CopilotProjectSession:
         resolver = getattr(backend, "find_pane_by_title_marker", None)
 
         if pane_id and backend.is_alive(pane_id):
-            if marker and callable(resolver):
-                try:
-                    resolved = resolver(marker)
-                    if resolved and str(resolved) != str(pane_id) and backend.is_alive(str(resolved)):
-                        self.data["pane_id"] = str(resolved)
-                        self.data["updated_at"] = _now_str()
-                        self._write_back()
-                        self._attach_pane_log(backend, str(resolved))
-                        return True, str(resolved)
-                except Exception:
-                    pass
-            self._attach_pane_log(backend, pane_id)
-            return True, pane_id
+            # WezTerm multi-window: verify the alive pane belongs to this project.
+            cwd_check = getattr(backend, "pane_belongs_to_cwd", None)
+            if not cwd_check or cwd_check(pane_id, self.work_dir):
+                if marker and callable(resolver):
+                    try:
+                        resolved = resolver(marker, self.work_dir)
+                        if resolved and str(resolved) != str(pane_id) and backend.is_alive(str(resolved)):
+                            self.data["pane_id"] = str(resolved)
+                            self.data["updated_at"] = _now_str()
+                            self._write_back()
+                            self._attach_pane_log(backend, str(resolved))
+                            return True, str(resolved)
+                    except Exception:
+                        pass
+                self._attach_pane_log(backend, pane_id)
+                return True, pane_id
+            # else: pane alive but belongs to wrong project — fall through to marker resolution
 
         if marker and callable(resolver):
-            resolved = resolver(marker)
+            resolved = resolver(marker, self.work_dir)
             if resolved and backend.is_alive(str(resolved)):
                 self.data["pane_id"] = str(resolved)
                 self.data["updated_at"] = _now_str()

--- a/lib/laskd_session.py
+++ b/lib/laskd_session.py
@@ -173,22 +173,26 @@ class ClaudeProjectSession:
         resolver = getattr(backend, "find_pane_by_title_marker", None)
 
         if pane_id and backend.is_alive(pane_id):
-            if marker and callable(resolver):
-                try:
-                    resolved = resolver(marker)
-                    if resolved and str(resolved) != str(pane_id) and backend.is_alive(str(resolved)):
-                        self.data["pane_id"] = str(resolved)
-                        self.data["updated_at"] = _now_str()
-                        self._write_back()
-                        self._attach_pane_log(backend, str(resolved))
-                        return True, str(resolved)
-                except Exception:
-                    pass
-            self._attach_pane_log(backend, pane_id)
-            return True, pane_id
+            # WezTerm multi-window: verify the alive pane belongs to this project.
+            cwd_check = getattr(backend, "pane_belongs_to_cwd", None)
+            if not cwd_check or cwd_check(pane_id, self.work_dir):
+                if marker and callable(resolver):
+                    try:
+                        resolved = resolver(marker, self.work_dir)
+                        if resolved and str(resolved) != str(pane_id) and backend.is_alive(str(resolved)):
+                            self.data["pane_id"] = str(resolved)
+                            self.data["updated_at"] = _now_str()
+                            self._write_back()
+                            self._attach_pane_log(backend, str(resolved))
+                            return True, str(resolved)
+                    except Exception:
+                        pass
+                self._attach_pane_log(backend, pane_id)
+                return True, pane_id
+            # else: pane alive but belongs to wrong project — fall through to marker resolution
 
         if marker and callable(resolver):
-            resolved = resolver(marker)
+            resolved = resolver(marker, self.work_dir)
             if resolved and backend.is_alive(str(resolved)):
                 self.data["pane_id"] = str(resolved)
                 self.data["updated_at"] = _now_str()

--- a/lib/oaskd_session.py
+++ b/lib/oaskd_session.py
@@ -120,22 +120,26 @@ class OpenCodeProjectSession:
         resolver = getattr(backend, "find_pane_by_title_marker", None)
 
         if pane_id and backend.is_alive(pane_id):
-            if marker and callable(resolver):
-                try:
-                    resolved = resolver(marker)
-                    if resolved and str(resolved) != str(pane_id) and backend.is_alive(str(resolved)):
-                        self.data["pane_id"] = str(resolved)
-                        self.data["updated_at"] = _now_str()
-                        self._write_back()
-                        self._attach_pane_log(backend, str(resolved))
-                        return True, str(resolved)
-                except Exception:
-                    pass
-            self._attach_pane_log(backend, pane_id)
-            return True, pane_id
+            # WezTerm multi-window: verify the alive pane belongs to this project.
+            cwd_check = getattr(backend, "pane_belongs_to_cwd", None)
+            if not cwd_check or cwd_check(pane_id, self.work_dir):
+                if marker and callable(resolver):
+                    try:
+                        resolved = resolver(marker, self.work_dir)
+                        if resolved and str(resolved) != str(pane_id) and backend.is_alive(str(resolved)):
+                            self.data["pane_id"] = str(resolved)
+                            self.data["updated_at"] = _now_str()
+                            self._write_back()
+                            self._attach_pane_log(backend, str(resolved))
+                            return True, str(resolved)
+                    except Exception:
+                        pass
+                self._attach_pane_log(backend, pane_id)
+                return True, pane_id
+            # else: pane alive but belongs to wrong project — fall through to marker resolution
 
         if marker and callable(resolver):
-            resolved = resolver(marker)
+            resolved = resolver(marker, self.work_dir)
             if resolved and backend.is_alive(str(resolved)):
                 self.data["pane_id"] = str(resolved)
                 self.data["updated_at"] = _now_str()

--- a/lib/qaskd_session.py
+++ b/lib/qaskd_session.py
@@ -92,22 +92,26 @@ class QwenProjectSession:
         resolver = getattr(backend, "find_pane_by_title_marker", None)
 
         if pane_id and backend.is_alive(pane_id):
-            if marker and callable(resolver):
-                try:
-                    resolved = resolver(marker)
-                    if resolved and str(resolved) != str(pane_id) and backend.is_alive(str(resolved)):
-                        self.data["pane_id"] = str(resolved)
-                        self.data["updated_at"] = _now_str()
-                        self._write_back()
-                        self._attach_pane_log(backend, str(resolved))
-                        return True, str(resolved)
-                except Exception:
-                    pass
-            self._attach_pane_log(backend, pane_id)
-            return True, pane_id
+            # WezTerm multi-window: verify the alive pane belongs to this project.
+            cwd_check = getattr(backend, "pane_belongs_to_cwd", None)
+            if not cwd_check or cwd_check(pane_id, self.work_dir):
+                if marker and callable(resolver):
+                    try:
+                        resolved = resolver(marker, self.work_dir)
+                        if resolved and str(resolved) != str(pane_id) and backend.is_alive(str(resolved)):
+                            self.data["pane_id"] = str(resolved)
+                            self.data["updated_at"] = _now_str()
+                            self._write_back()
+                            self._attach_pane_log(backend, str(resolved))
+                            return True, str(resolved)
+                    except Exception:
+                        pass
+                self._attach_pane_log(backend, pane_id)
+                return True, pane_id
+            # else: pane alive but belongs to wrong project — fall through to marker resolution
 
         if marker and callable(resolver):
-            resolved = resolver(marker)
+            resolved = resolver(marker, self.work_dir)
             if resolved and backend.is_alive(str(resolved)):
                 self.data["pane_id"] = str(resolved)
                 self.data["updated_at"] = _now_str()

--- a/lib/terminal.py
+++ b/lib/terminal.py
@@ -581,7 +581,7 @@ class TmuxBackend(TerminalBackend):
             opt = "@" + opt
         self._tmux_run(["set-option", "-p", "-t", pane_id, opt, value or ""], check=False)
 
-    def find_pane_by_title_marker(self, marker: str) -> Optional[str]:
+    def find_pane_by_title_marker(self, marker: str, cwd_hint: str = "") -> Optional[str]:
         marker = (marker or "").strip()
         if not marker:
             return None
@@ -1121,9 +1121,59 @@ class WeztermBackend(TerminalBackend):
             self._last_list_error = f"wezterm cli list failed: {exc}"
         return None
 
-    def _pane_id_by_title_marker(self, panes: list[dict], marker: str) -> Optional[str]:
+    @staticmethod
+    def _extract_cwd_path(file_url: str) -> str:
+        """Extract filesystem path from a WezTerm file:// CWD URL."""
+        if not file_url:
+            return ""
+        url = str(file_url).strip()
+        if not url.startswith("file://"):
+            return url
+        # file:///path or file://hostname/path
+        rest = url[7:]  # strip "file://"
+        if rest.startswith("/"):
+            path = rest
+        else:
+            # file://hostname/path -> /path
+            slash = rest.find("/")
+            path = rest[slash:] if slash >= 0 else ""
+        # URL-decode percent-encoded characters (e.g. spaces as %20)
+        try:
+            from urllib.parse import unquote
+            path = unquote(path)
+        except Exception:
+            pass
+        return path.rstrip("/") or "/"
+
+    @staticmethod
+    def _cwd_matches(pane_cwd: str, work_dir: str) -> bool:
+        """Check if a pane's CWD matches the expected work directory."""
+        if not pane_cwd or not work_dir:
+            return False
+        extracted = WeztermBackend._extract_cwd_path(pane_cwd)
+        if not extracted:
+            return False
+        try:
+            return os.path.normpath(extracted) == os.path.normpath(work_dir)
+        except Exception:
+            return False
+
+    def _pane_id_by_title_marker(self, panes: list[dict], marker: str, cwd_hint: str = "") -> Optional[str]:
         if not marker:
             return None
+        cwd_hint = (cwd_hint or "").strip()
+        # When cwd_hint is provided, prefer panes matching both marker AND CWD
+        # before falling back to first-match. This prevents cross-project routing
+        # when multiple WezTerm windows share the same title marker.
+        if cwd_hint:
+            for pane in panes:
+                title = pane.get("title") or ""
+                if title.startswith(marker):
+                    if self._cwd_matches(pane.get("cwd", ""), cwd_hint):
+                        pane_id = pane.get("pane_id")
+                        if pane_id is not None:
+                            return str(pane_id)
+        # Fallback: first marker match (original behaviour, tmux-compatible).
         for pane in panes:
             title = pane.get("title") or ""
             if title.startswith(marker):
@@ -1132,11 +1182,24 @@ class WeztermBackend(TerminalBackend):
                     return str(pane_id)
         return None
 
-    def find_pane_by_title_marker(self, marker: str) -> Optional[str]:
+    def find_pane_by_title_marker(self, marker: str, cwd_hint: str = "") -> Optional[str]:
         panes = self._list_panes()
         if panes is None:
             return None
-        return self._pane_id_by_title_marker(panes, marker)
+        return self._pane_id_by_title_marker(panes, marker, cwd_hint)
+
+    def pane_belongs_to_cwd(self, pane_id: str, work_dir: str) -> bool:
+        """Return True if pane's CWD matches work_dir, or if CWD cannot be determined (fail-open)."""
+        panes = self._list_panes()
+        if not panes:
+            return True  # Can't verify — assume OK
+        for pane in panes:
+            if str(pane.get("pane_id")) == str(pane_id):
+                cwd = pane.get("cwd", "")
+                if not cwd:
+                    return True  # No CWD info — assume OK
+                return self._cwd_matches(cwd, work_dir)
+        return False  # Pane not found in list
 
     def is_alive(self, pane_id: str) -> bool:
         panes = self._list_panes()

--- a/test/test_baskd_session_ensure_pane.py
+++ b/test/test_baskd_session_ensure_pane.py
@@ -18,7 +18,7 @@ class FakeTmuxBackend:
     def is_alive(self, pane_id: str) -> bool:
         return bool(self.alive.get(pane_id, False))
 
-    def find_pane_by_title_marker(self, marker: str) -> str | None:
+    def find_pane_by_title_marker(self, marker: str, cwd_hint: str = "") -> str | None:
         for prefix, pane in self.marker_map.items():
             if marker.startswith(prefix) or prefix.startswith(marker):
                 return pane

--- a/test/test_caskd_session_ensure_pane.py
+++ b/test/test_caskd_session_ensure_pane.py
@@ -18,7 +18,7 @@ class FakeTmuxBackend:
     def is_alive(self, pane_id: str) -> bool:
         return bool(self.alive.get(pane_id, False))
 
-    def find_pane_by_title_marker(self, marker: str) -> str | None:
+    def find_pane_by_title_marker(self, marker: str, cwd_hint: str = "") -> str | None:
         for prefix, pane in self.marker_map.items():
             if marker.startswith(prefix) or prefix.startswith(marker):
                 return pane

--- a/test/test_ensure_pane_stale.py
+++ b/test/test_ensure_pane_stale.py
@@ -37,7 +37,7 @@ class _FakeBackend:
     def is_alive(self, pane_id: str) -> bool:
         return pane_id in self.alive_panes
 
-    def find_pane_by_title_marker(self, marker: str) -> Optional[str]:
+    def find_pane_by_title_marker(self, marker: str, cwd_hint: str = "") -> Optional[str]:
         return self.marker_map.get(marker)
 
     def ensure_pane_log(self, pane_id: str) -> None:
@@ -152,7 +152,7 @@ def test_fallback_resolves_by_marker_when_pane_dead(cls, tmp_path: Path) -> None
 def test_fast_path_keeps_pane_when_resolver_raises(cls, tmp_path: Path) -> None:
     """If find_pane_by_title_marker raises, fast path should still work."""
     class _BrokenBackend(_FakeBackend):
-        def find_pane_by_title_marker(self, marker: str) -> Optional[str]:
+        def find_pane_by_title_marker(self, marker: str, cwd_hint: str = "") -> Optional[str]:
             raise RuntimeError("tmux error")
 
     backend = _BrokenBackend(alive_panes={"%10"})

--- a/test/test_gaskd_session_ensure_pane.py
+++ b/test/test_gaskd_session_ensure_pane.py
@@ -18,7 +18,7 @@ class FakeTmuxBackend:
     def is_alive(self, pane_id: str) -> bool:
         return bool(self.alive.get(pane_id, False))
 
-    def find_pane_by_title_marker(self, marker: str) -> str | None:
+    def find_pane_by_title_marker(self, marker: str, cwd_hint: str = "") -> str | None:
         for prefix, pane in self.marker_map.items():
             if marker.startswith(prefix) or prefix.startswith(marker):
                 return pane

--- a/test/test_qaskd_session_ensure_pane.py
+++ b/test/test_qaskd_session_ensure_pane.py
@@ -18,7 +18,7 @@ class FakeTmuxBackend:
     def is_alive(self, pane_id: str) -> bool:
         return bool(self.alive.get(pane_id, False))
 
-    def find_pane_by_title_marker(self, marker: str) -> str | None:
+    def find_pane_by_title_marker(self, marker: str, cwd_hint: str = "") -> str | None:
         for prefix, pane in self.marker_map.items():
             if marker.startswith(prefix) or prefix.startswith(marker):
                 return pane

--- a/test/test_registry_project_id.py
+++ b/test/test_registry_project_id.py
@@ -20,7 +20,7 @@ class _FakeBackend:
     def is_alive(self, pane_id: str) -> bool:
         return pane_id in self._alive
 
-    def find_pane_by_title_marker(self, marker: str) -> str | None:
+    def find_pane_by_title_marker(self, marker: str, cwd_hint: str = "") -> str | None:
         return self._marker_map.get(marker)
 
 

--- a/test/test_session_ensure_pane.py
+++ b/test/test_session_ensure_pane.py
@@ -16,7 +16,7 @@ class FakeBackend:
     def is_alive(self, pane_id: str) -> bool:
         return self.alive.get(pane_id, False)
 
-    def find_pane_by_title_marker(self, marker: str) -> str | None:
+    def find_pane_by_title_marker(self, marker: str, cwd_hint: str = "") -> str | None:
         for prefix, pane in self.marker_map.items():
             if marker.startswith(prefix) or prefix.startswith(marker):
                 return pane


### PR DESCRIPTION
Fixes #137

## Problem

When running multiple CCB workspaces in separate WezTerm windows, `/ask` queries  
 are routed to panes in the wrong workspace.

Two root causes collaborate:

**Bug 1 — `ensure_pane()` has no project-awareness:**

- `is_alive(pane_id)` checks globally across all WezTerm windows. A stale pane_id  
  that now belongs to a different project passes this check.
- `find_pane_by_title_marker("CCB-Codex")` returns the first match across all windows.  
  All codex panes share the same marker, so it picks the wrong project's pane and  
  writes it back to the session file, permanently corrupting it.  


**Note on PR #132:** The tmux-recycling fix introduced in #132 worsens this for  
 WezTerm multi-window: when the cached pane_id is alive but the marker resolves to  
 a different alive pane (which belongs to another project), it actively switches to  
 the wrong pane. Our fix is complementary — it wraps the #132 fast-path with a CWD  
 check so the switch only happens when the pane genuinely belongs to this project.

## Fix

Add CWD-aware pane resolution to `WeztermBackend` in `lib/terminal.py`:

- `_extract_cwd_path()` — parses `file://` CWD URLs from `wezterm cli list --format json`
- `_cwd_matches()` — compares a pane's CWD against the expected work directory
- `_pane_id_by_title_marker(marker, cwd_hint)` — when `cwd_hint` is provided, prefers  
  panes matching both the marker AND the CWD, before falling back to first-match
- `find_pane_by_title_marker(marker, cwd_hint="")` — backward-compatible default
- `pane_belongs_to_cwd(pane_id, work_dir)` — validates pane project ownership; fail-open  


Update `ensure_pane()` in all session modules (caskd, laskd, gaskd, daskd, oaskd,  
 baskd, haskd, qaskd):

1. After `is_alive(pane_id)` returns True, call `pane_belongs_to_cwd()` to verify  
   the pane belongs to this project. If not, fall through to marker resolution.
2. Pass `self.work_dir` as `cwd_hint` to `find_pane_by_title_marker()` in both  
   the fast-path and the dead-pane resolution path.  


`TmuxBackend.find_pane_by_title_marker()` gains optional `cwd_hint=""` (ignored)  
 for API compatibility.

## Testing

- 267/268 tests pass (1 pre-existing flaky threading test unrelated to this change)
- Verified manually with 3 simultaneous WezTerm windows on Linux
