### PR TITLE
fix: WezTerm completion hook response requires manual Enter

### DIFF
--- a/bin/ccb-completion-hook
+++ b/bin/ccb-completion-hook
@@ -146,16 +146,40 @@ def send_via_wezterm(pane_id: str, message: str, session_data: dict) -> bool:
         if not wezterm:
             return False
 
-        # Use stdin to avoid command line length limits on Windows
-        # wezterm cli send-text --pane-id <id> --no-paste reads from stdin if no text arg
+        # Use bracketed paste mode (omit --no-paste) so that intermediate \n characters
+        # in the multi-line response body are treated as literal newlines within the paste
+        # block, not as individual Enter keystrokes. Sending a multi-line message with
+        # --no-paste causes each \n to arrive as a keystroke; raw-mode TUIs like Claude
+        # Code do not submit on \n (LF 0x0A) — they require a real Enter key event.
         result = subprocess.run(
-            [wezterm, "cli", "send-text", "--pane-id", pane_id, "--no-paste"],
+            [wezterm, "cli", "send-text", "--pane-id", pane_id],
             input=message.encode("utf-8"),
             capture_output=True,
             timeout=10
         )
         if result.returncode == 0:
-            # Send Enter after text
+            # Brief pause to let the TUI process the bracketed paste before Enter.
+            import time
+            time.sleep(0.1)
+            # Send a proper Enter key event so raw-mode TUIs (e.g. Claude Code) submit
+            # the pasted content. A bare \r byte is insufficient for many TUIs.
+            # Try both CLI variants across WezTerm versions; fall back to \r byte.
+            for key_variant in ("Enter", "Return"):
+                # Variant A: --key <KeyName>
+                r = subprocess.run(
+                    [wezterm, "cli", "send-key", "--pane-id", pane_id, "--key", key_variant],
+                    capture_output=True, timeout=5
+                )
+                if r.returncode == 0:
+                    return True
+                # Variant B: positional <KeyName>
+                r = subprocess.run(
+                    [wezterm, "cli", "send-key", "--pane-id", pane_id, key_variant],
+                    capture_output=True, timeout=5
+                )
+                if r.returncode == 0:
+                    return True
+            # Final fallback: CR byte (works for readline-based panes)
             subprocess.run(
                 [wezterm, "cli", "send-text", "--pane-id", pane_id, "--no-paste"],
                 input=b"\r",


### PR DESCRIPTION
## Problem

When the completion hook delivers a response back to a Claude Code pane in
WezTerm, the user must press Enter manually to submit it. The response text
appears in the input buffer but is never auto-submitted.

**Root cause:** `send_via_wezterm()` in the completion hook sent the multi-line
response with `--no-paste`, causing each `\n` character to arrive as a raw LF
keystroke (0x0A). Claude Code runs as a raw-mode TUI that does not submit on
LF — it requires a real Enter key event. The subsequent `\r` byte fallback was
also insufficient for raw-mode TUIs.

The send path (`terminal.py` `WeztermBackend.send_text`) already handles this
correctly: bracketed paste for the body + `wezterm cli send-key --key Enter`.
The completion hook was inconsistent with this pattern.

## Fix

- Send the response body using **bracketed paste mode** (omit `--no-paste`) so
  intermediate `\n` characters are treated as literal newlines in a paste block
- After a 0.1s pause for the TUI to process the paste, send a proper Enter key
  event via `wezterm cli send-key`, trying `--key Enter` then positional `Enter`
  across WezTerm CLI versions, with a `\r` byte final fallback

Tmux is not affected: `send_via_tmux()` already uses `paste-buffer` +
`send-keys Enter` correctly.

May also reduce some cases in #142 where fragmented `\n` keystrokes caused
incomplete delivery of responses to Claude Code.

267/268 tests pass (1 pre-existing flaky threading test).

> The 1 failing test (test_per_session_worker_pool_reuses_same_key) is a pre-existing flaky threading test that fails consistently across all recent runs on main and other PRs — not related to this change. 267/268 tests pass.
