### PR TITLE
fix: add sleep before Enter send to fix auto-submit on older WezTerm

### DIFF
--- a/bin/ccb-completion-hook
+++ b/bin/ccb-completion-hook
@@ -227,6 +227,7 @@ def send_via_wezterm(pane_id: str, message: str, session_data: dict) -> bool:
         )
         _debug_log(f"wezterm send-text pane={pane_id!r} rc={result.returncode}")
         if result.returncode == 0:
+            time.sleep(0.1)  # Give TUI time to process bracketed paste before Enter
             if _send_wezterm_enter(base_args, pane_id):
                 _debug_log(f"wezterm submit via send-key pane={pane_id!r} rc=0")
                 return True


### PR DESCRIPTION
## Summary

- WezTerm builds pre-dating `send-key` (e.g. `20240203-110809-5046fc22`) fall through to the CR byte fallback in `send_via_wezterm()` immediately after `send-text` completes
- Without a short delay, `\r` arrives before the TUI has finished processing the bracketed paste sequence — Claude Code ignores it and requires a manual Enter
- Adds `time.sleep(0.1)` before any Enter-sending attempt, so the bracketed paste is fully consumed first

This reproduces the timing that was present in #149 and was inadvertently dropped in #151.

## Root cause

`_send_wezterm_enter()` tries 6 `send-key` variants that all fail instantly on older WezTerm (unrecognized subcommand). The fallback `\r` is then sent with no delay — too fast for the TUI's paste handler.

## Test plan

- [x] Tested on WezTerm `20240203` (no `send-key`): completion hook response auto-submits without manual Enter
- [ ] Tested on newer WezTerm (has `send-key`): `_send_wezterm_enter()` succeeds as before, sleep is a no-op overhead

Related: #149, #151