### PR TITLE
fix: restore --resume for Gemini and --continue for OpenCode

### DIFF
--- a/ccb
+++ b/ccb
@@ -1827,20 +1827,26 @@ class AILauncher:
             if not candidate or candidate in seen:
                 continue
             seen.add(candidate)
-            project_hash = hashlib.sha256(candidate.encode()).hexdigest()
-            chats_dir = gemini_root / project_hash / "chats"
-            if not chats_dir.exists():
-                continue
-            session_files = list(chats_dir.glob("session-*.json"))
-            if session_files:
-                resume_dir = None
-                try:
-                    p = Path(candidate)
-                    if p.is_dir():
-                        resume_dir = p
-                except Exception:
+            # Gemini CLI has used both sha256(cwd) and Path(cwd).name as the directory name.
+            # Try both to support all versions.
+            dir_names = [
+                hashlib.sha256(candidate.encode()).hexdigest(),
+                Path(candidate).name,
+            ]
+            for dir_name in dir_names:
+                chats_dir = gemini_root / dir_name / "chats"
+                if not chats_dir.exists():
+                    continue
+                session_files = list(chats_dir.glob("session-*.json"))
+                if session_files:
                     resume_dir = None
-                return project_hash, True, resume_dir
+                    try:
+                        p = Path(candidate)
+                        if p.is_dir():
+                            resume_dir = p
+                    except Exception:
+                        resume_dir = None
+                    return dir_name, True, resume_dir
 
         return None, False, None
 
@@ -1923,6 +1929,36 @@ class AILauncher:
         return cmd
 
     def _opencode_resume_allowed(self) -> bool:
+        target_dir = _normalize_path_for_match(str(self.project_root))
+        if not target_dir:
+            return False
+
+        # Newer OpenCode versions store sessions in an SQLite database.
+        xdg = (os.environ.get("XDG_DATA_HOME") or "").strip()
+        db_candidates = []
+        if xdg:
+            db_candidates.append(Path(xdg) / "opencode/opencode.db")
+        db_candidates.append(Path.home() / ".local/share/opencode/opencode.db")
+        for db_path in db_candidates:
+            if not db_path.exists():
+                continue
+            try:
+                import sqlite3
+                conn = sqlite3.connect(str(db_path))
+                try:
+                    row = conn.execute(
+                        "SELECT id FROM session WHERE directory = ? AND time_archived IS NULL "
+                        "ORDER BY time_updated DESC LIMIT 1",
+                        (target_dir,),
+                    ).fetchone()
+                    if row:
+                        return True
+                finally:
+                    conn.close()
+            except Exception:
+                pass
+
+        # Older OpenCode versions store sessions as JSON files.
         try:
             from opencode_comm import OPENCODE_STORAGE_ROOT
         except Exception:
@@ -1931,10 +1967,6 @@ class AILauncher:
         root = Path(OPENCODE_STORAGE_ROOT)
         sessions_root = root / "session"
         if not sessions_root.exists():
-            return False
-
-        target_dir = _normalize_path_for_match(str(self.project_root))
-        if not target_dir:
             return False
 
         def _load_json(path: Path) -> dict:


### PR DESCRIPTION
## Summary

Two independent bugs that both cause `ccb -r` to silently start a fresh session instead of resuming.

### Gemini: project name directory vs sha256 hash

CCB computes `sha256(cwd)` to locate Gemini's session directory, but Gemini CLI stores sessions under `~/.gemini/tmp/<project_name>/chats/` (using the directory basename, not a hash). The hash path never exists, so `has_history` is always `False` and `--resume latest` is never appended.

**Fix:** try both `sha256(cwd)` and `Path(cwd).name` as candidate directory names, returning on first match. Preserves compatibility with any older Gemini version that may have used the hash.

### OpenCode: SQLite database vs JSON files

`_opencode_resume_allowed()` checked for `storage/session/` (JSON files), but OpenCode migrated session storage to `opencode.db` (SQLite). The directory doesn't exist, so the function returned `False` immediately — before any fallback could run.

**Fix:** query the SQLite database first (`SELECT id FROM session WHERE directory = ? AND time_archived IS NULL`), then fall back to the legacy JSON scan for older installations.

## Test plan

- [x] `ccb -r` with Gemini: resumes last session with `--resume latest` (tested on Gemini CLI with `~/.gemini/tmp/<project_name>/chats/` layout)
- [x] `ccb -r` with OpenCode: resumes last session with `--continue` (tested against `opencode.db` SQLite backend)
- [ ] `ccb -r` with no prior history: still starts fresh (no regression)