### PR TITLE
Security: Authentication bypass via trusted X-Forwarded-For header

### DIFF
--- a/lib/web/auth.py
+++ b/lib/web/auth.py
@@ -18,13 +18,6 @@ async def verify_local_access(request: Request) -> bool:
     if client_host in local_hosts:
         return True
 
-    # Check X-Forwarded-For for reverse proxy setups
-    forwarded = request.headers.get("X-Forwarded-For", "")
-    if forwarded:
-        first_ip = forwarded.split(",")[0].strip()
-        if first_ip in local_hosts:
-            return True
-
     return False
 
 


### PR DESCRIPTION
## Problem

Local-access checks trust the `X-Forwarded-For` header directly. A remote client can forge `X-Forwarded-For: 127.0.0.1` (or `localhost`/`::1`) to be treated as local, bypassing bearer-token authentication and potentially bypassing `local_only` restrictions.

**Severity**: `critical`
**File**: `lib/web/auth.py`

## Solution

Do not trust `X-Forwarded-For` unless requests are guaranteed to come through a trusted reverse proxy that sanitizes this header. Prefer `request.client.host` only, or enforce trusted proxy configuration and parse forwarded headers only when proxy source IP is trusted.

## Changes

- `lib/web/auth.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
