### PR TITLE
Security: WebSocket status endpoint lacks authentication/authorization

### DIFF
--- a/lib/web/routes/ws.py
+++ b/lib/web/routes/ws.py
@@ -4,6 +4,7 @@ WebSocket routes for real-time status updates.
 
 import asyncio
 import json
+import os
 from typing import Set
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
@@ -12,6 +13,20 @@ router = APIRouter()
 
 # Connected clients
 connected_clients: Set[WebSocket] = set()
+
+
+def _extract_websocket_token(websocket: WebSocket) -> str | None:
+    authorization = websocket.headers.get("authorization")
+    if authorization:
+        scheme, _, token = authorization.partition(" ")
+        if scheme.lower() == "bearer" and token:
+            return token
+
+    token = websocket.query_params.get("token")
+    if token:
+        return token
+
+    return None
 
 
 async def broadcast_status(data: dict):
@@ -49,6 +64,13 @@ async def get_current_status() -> dict:
 @router.websocket("/status")
 async def websocket_status(websocket: WebSocket):
     """WebSocket endpoint for real-time status updates."""
+    expected_token = getattr(websocket.app.state, "api_token", None) or os.getenv("API_TOKEN")
+    provided_token = _extract_websocket_token(websocket)
+
+    if not expected_token or provided_token != expected_token:
+        await websocket.close(code=1008)
+        return
+
     await websocket.accept()
     connected_clients.add(websocket)
 


### PR DESCRIPTION
## Problem

The `/ws/status` endpoint accepts connections without calling authentication dependencies. Any reachable client can receive daemon/provider status data and keep a persistent connection, exposing operational metadata and enabling unauthenticated monitoring.

**Severity**: `high`
**File**: `lib/web/routes/ws.py`

## Solution

Enforce auth in the WebSocket handshake (token/query/header validation) and reject unauthorized clients before `accept()`. Reuse the same auth policy as HTTP routes.

## Changes

- `lib/web/routes/ws.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
