### PR TITLE
fix: remove -i shell flag from respawn_pane to prevent setRawMode EIO

### DIFF
--- a/lib/terminal.py
+++ b/lib/terminal.py
@@ -766,9 +766,9 @@ class TmuxBackend(TerminalBackend):
             shell_name = Path(shell).name.lower()
             # Avoid assuming bash-style combined flags on shells like fish.
             if shell_name in {"bash", "zsh", "ksh"}:
-                flags = ["-l", "-i", "-c"]
+                flags = ["-l", "-c"]
             elif shell_name == "fish":
-                flags = ["-l", "-i", "-c"]
+                flags = ["-l", "-c"]
             elif shell_name in {"sh", "dash"}:
                 flags = ["-c"]
             else:


### PR DESCRIPTION
## Summary

- Remove the `-i` (interactive) shell flag from `respawn_pane()` in `lib/terminal.py`
- Fixes `setRawMode failed with errno: 5` (EIO) when launching CLI tools like Claude Code via `tmux respawn-pane`

## Problem

When `respawn_pane` launches a shell with `-l -i -c "<command>"`, the `-i` flag puts the shell in interactive mode. This creates a race condition where the CLI tool (e.g. Claude Code) tries to call `setRawMode` on stdin before the PTY allocated by `tmux respawn-pane` is fully ready, resulting in:

```
ERROR setRawMode failed with errno: 5
```

Errno 5 is `EIO` — the PTY file descriptor isn't ready for I/O yet.

## Fix

Remove `-i` from the shell flags on lines 769 and 771. The shell is only used to execute a command via `-c`, so interactive mode is unnecessary. The `-l` (login) flag is preserved to ensure PATH and environment setup from shell profiles.

```python
# Before
flags = ["-l", "-i", "-c"]

# After
flags = ["-l", "-c"]
```

## Test plan

- [x] Verified `ccb codex claude -a` launches Claude Code without `setRawMode` errors
- [x] Confirmed shell environment (PATH, etc.) is still correctly inherited via `-l`

🤖 Generated with [Claude Code](https://claude.com/claude-code)