### PR TITLE
socket-client: bump default RPC timeout 3s → 30s for cold-start ccbd warmup

### DIFF
--- a/lib/ccbd/socket_client.py
+++ b/lib/ccbd/socket_client.py
@@ -54,7 +54,7 @@ def _resolve_timeout(explicit: float | None) -> float:
         try:
             return max(0.1, float(explicit))
         except Exception:
-            return 3.0
+            return 30.0
     for env_name in ('CCB_CCBD_CLIENT_TIMEOUT_S',):
         raw = os.environ.get(env_name)
         if not raw:
@@ -63,7 +63,7 @@ def _resolve_timeout(explicit: float | None) -> float:
             return max(0.1, float(raw))
         except Exception:
             continue
-    return 3.0
+    return 30.0
 
 
 __all__ = ['CcbdClient', 'CcbdClientError']

--- a/test/test_ccbd_socket_client.py
+++ b/test/test_ccbd_socket_client.py
@@ -7,7 +7,7 @@ from ccbd.socket_client import CcbdClient, CcbdClientError
 
 def test_ccbd_client_uses_stable_default_timeout(tmp_path) -> None:
     client = CcbdClient(tmp_path / "ccbd.sock")
-    assert client._timeout_s == 3.0
+    assert client._timeout_s == 30.0
 
 
 def test_ccbd_client_reads_timeout_from_env(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
## Summary

Bump `CcbdClient._resolve_timeout` default from `3.0s` → `30.0s` (both fallback branches).

## Why

ccbd cold-start warmup reliably takes **10–30 seconds** in practice (first tmux session materialization + completion tracker state load + backend enumeration). The 3s default meant that the first `ccb ask` after `ccb kill` (or on a fresh machine) would routinely fail with `socket_unreachable`, surfacing a brittle workflow:

- Users hit the error, retry manually, and eventually it works; OR
- Users learn to export `CCB_CCBD_CLIENT_TIMEOUT_S=60` as a permanent shell-level workaround (which is what we've been doing in a fork for weeks)

30s covers nearly all observed cold-starts while still being short enough that a truly unreachable ccbd is caught quickly.

## Scope

- `lib/ccbd/socket_client.py:_resolve_timeout` — two fallback `return 3.0` → `return 30.0`
- `test/test_ccbd_socket_client.py::test_ccbd_client_uses_stable_default_timeout` — assertion `3.0` → `30.0`

## What is unchanged

- `CCB_CCBD_CLIENT_TIMEOUT_S` env override (still takes precedence over default)
- Explicit `timeout_s=` kwarg precedence (overrides both env and default)
- Callers passing `timeout_s=0.2` for health probes (`daemon_process.py`, `keeper_runtime/loop.py`) — unaffected
- `max(0.1, ...)` clamp — unaffected

## Test plan

- [x] `pytest test/test_ccbd_socket_client.py` → 7 passed
- [x] `pytest test/` full suite (clean env) → no new failures vs pre-change baseline on this branch's base (`main` @ `52f6d95`). Confirmed by stashing the 4-line diff and re-running: identical pre-existing failure set before/after.