### PR TITLE
cli-parser: return empty on socket stdin to unblock Claude Code Bash tool

### DIFF
--- a/lib/cli/parser.py
+++ b/lib/cli/parser.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+import stat
 import sys
 from typing import Iterable
 
@@ -84,6 +86,12 @@ class CliParser:
     def _read_optional_stdin(self) -> str:
         if sys.stdin.isatty():
             return ''
+        try:
+            mode = os.fstat(0).st_mode
+            if stat.S_ISSOCK(mode):
+                return ''  # Unix socket stdin (e.g. Claude Code Bash tool) — never closes; don't block on read
+        except OSError:
+            pass  # Fall through to read_stdin_text on fstat failure (AC5)
         try:
             return read_stdin_text()
         except OSError:

--- a/test/test_cli_parser.py
+++ b/test/test_cli_parser.py
@@ -1,0 +1,102 @@
+"""TD-007: CLI parser stdin detection tests."""
+from __future__ import annotations
+import stat
+import sys
+from unittest.mock import MagicMock, patch
+import pytest
+
+from cli.parser import CliParser
+
+
+class TestReadOptionalStdin:
+    """Test _read_optional_stdin socket detection (TD-007)."""
+
+    def test_stdin_socket_returns_empty(self, monkeypatch):
+        """AC1: Unix socket stdin should return empty without blocking."""
+        parser = CliParser()
+        
+        # Mock isatty to return False (not TTY)
+        monkeypatch.setattr(sys.stdin, 'isatty', lambda: False)
+        
+        # Mock os.fstat to return socket mode
+        mock_stat = MagicMock()
+        mock_stat.st_mode = stat.S_IFSOCK | 0o600
+        monkeypatch.setattr('os.fstat', lambda fd: mock_stat)
+        
+        # Mock read_stdin_text to verify it's NOT called
+        mock_read = MagicMock(return_value="should not be read")
+        monkeypatch.setattr('cli.parser.read_stdin_text', mock_read)
+        
+        result = parser._read_optional_stdin()
+        
+        assert result == ''
+        mock_read.assert_not_called()  # Should not block on socket
+
+    def test_stdin_fifo_reads_normally(self, monkeypatch):
+        """AC2: FIFO (pipe) stdin should read normally."""
+        parser = CliParser()
+        
+        monkeypatch.setattr(sys.stdin, 'isatty', lambda: False)
+        
+        mock_stat = MagicMock()
+        mock_stat.st_mode = stat.S_IFIFO | 0o600
+        monkeypatch.setattr('os.fstat', lambda fd: mock_stat)
+        
+        monkeypatch.setattr('cli.parser.read_stdin_text', lambda: "piped content")
+        
+        result = parser._read_optional_stdin()
+        
+        assert result == "piped content"
+
+    def test_stdin_regular_file_reads_normally(self, monkeypatch):
+        """AC3: Regular file stdin should read normally."""
+        parser = CliParser()
+        
+        monkeypatch.setattr(sys.stdin, 'isatty', lambda: False)
+        
+        mock_stat = MagicMock()
+        mock_stat.st_mode = stat.S_IFREG | 0o644
+        monkeypatch.setattr('os.fstat', lambda fd: mock_stat)
+        
+        monkeypatch.setattr('cli.parser.read_stdin_text', lambda: "file content")
+        
+        result = parser._read_optional_stdin()
+        
+        assert result == "file content"
+
+    def test_stdin_tty_returns_empty_without_checking_mode(self, monkeypatch):
+        """AC4: TTY stdin should return empty without calling fstat."""
+        parser = CliParser()
+        
+        # Mock isatty to return True (TTY)
+        monkeypatch.setattr(sys.stdin, 'isatty', lambda: True)
+        
+        # Track if fstat is called
+        fstat_called = []
+        def mock_fstat(fd):
+            fstat_called.append(True)
+            return MagicMock()
+        monkeypatch.setattr('os.fstat', mock_fstat)
+        
+        result = parser._read_optional_stdin()
+        
+        assert result == ''
+        assert len(fstat_called) == 0  # fstat should NOT be called for TTY
+
+    def test_fstat_oserror_falls_back_to_read(self, monkeypatch):
+        """AC5: OSError from fstat should fall back to read_stdin_text."""
+        parser = CliParser()
+        
+        monkeypatch.setattr(sys.stdin, 'isatty', lambda: False)
+        
+        # Mock fstat to raise OSError
+        def mock_fstat(fd):
+            raise OSError("fstat failed")
+        monkeypatch.setattr('os.fstat', mock_fstat)
+        
+        # read_stdin_text should still be called as fallback
+        monkeypatch.setattr('cli.parser.read_stdin_text', lambda: "fallback content")
+        
+        result = parser._read_optional_stdin()
+        
+        assert result == "fallback content"


### PR DESCRIPTION
## Problem

`ccb ask` (and other commands that call `_read_optional_stdin`) hangs indefinitely when invoked from Claude Code's Bash tool, because the tool passes a Unix-domain socket as child stdin:

1. `sys.stdin.isatty()` returns `False` (socket is not a TTY)
2. `_read_optional_stdin` unconditionally falls into `read_stdin_text()`, which blocks on `read()` until EOF
3. Claude Code's Bash tool never closes its end of the socket until the child exits → mutual wait → 100% hang

The workaround users have been living with is appending `< /dev/null` to every `ccb ask` invocation from Bash tool contexts. This is easy to forget and propagates through docs and agent scripts.

## Fix

Add a `stat.S_ISSOCK` early-exit check using `os.fstat(0)` before entering `read_stdin_text()`. Other stdin types (TTY, pipe/FIFO, regular file) keep their original behavior. On `fstat` `OSError`, fall through to `read_stdin_text()` so the original code path is preserved (no regression when fd 0 is closed).

Code change: +8 lines in `lib/cli/parser.py`, one function touched.

## Why `S_ISSOCK`?

Only `fstat` + `S_ISSOCK` can distinguish a Unix socket from a FIFO/pipe; `fcntl(F_GETFL)` exposes only flags (`O_NONBLOCK` etc.), not the underlying file type. Pipe/FIFO stdin (e.g. `cat file | ccb ask ...`) must continue to be read, so a coarser check (e.g. "any non-TTY non-regular-file") would break valid usage.

## Tests

5 unit tests in `test/test_cli_parser.py` covering:

- Socket stdin → returns empty without calling `read_stdin_text`
- FIFO stdin → reads normally
- Regular file stdin → reads normally
- TTY stdin → returns empty without calling `fstat` (priority check)
- `fstat` raising `OSError` → falls back to `read_stdin_text` (no regression)

All 5 pass locally. E2E verified from Claude Code Bash tool: `ccb ask --wait a2 "ping"` (no `< /dev/null`) returns a normal reply in 15s instead of hanging.

## Risk

Minimal. The only scenario that behaves differently is stdin-is-Unix-socket — previously that hung forever, now it returns `''` (treated as "no stdin content supplied"). No known legitimate use case where `ccb ask` is fed meaningful data via a Unix socket stdin; the normal transports (pipe, file redirect, interactive TTY) are unaffected.

## Rollback

Single commit, revert with `git revert` if needed.