### PR TITLE
test(conftest): kill CCB tmux daemons leaked by subprocess ccb calls

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import glob
+import logging
 import os
 import stat
+import subprocess
 import sys
 from pathlib import Path
 
@@ -81,3 +84,63 @@ def _install_provider_stubs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> 
     monkeypatch.setenv("STUB_DELAY", "1.5")
     monkeypatch.setenv("CCB_REPLY_LANG", "en")
     monkeypatch.setenv("CCB_CLAUDE_SKILLS", "0")
+
+
+# ============================================================
+# CCB tmux daemon leak cleanup.
+# Tests in test_v2_phase2_entrypoint.py spawn `ccb` via subprocess.
+# Those subprocesses start the CCB keeper which wraps itself in an
+# independent tmux daemon (socket under tmp_path/.ccb/ccbd/tmux.sock
+# or /run/user/$UID/ccb-runtime/tmux-*.sock). The test's in-process
+# app.shutdown() cannot reach those daemons.
+# ============================================================
+
+_leak_logger = logging.getLogger(__name__)
+
+
+def _safe_kill_tmux_server(sock: str) -> None:
+    try:
+        result = subprocess.run(
+            ['tmux', '-S', sock, 'kill-server'],
+            timeout=5, check=False,
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+        if result.returncode != 0:
+            _leak_logger.warning(
+                "cleanup: tmux kill-server %s returned rc=%d", sock, result.returncode
+            )
+    except FileNotFoundError:
+        return
+    except subprocess.TimeoutExpired:
+        _leak_logger.warning("cleanup: tmux kill-server %s timed out after 5s", sock)
+
+
+def _runtime_socket_pattern() -> str:
+    return f'/run/user/{os.getuid()}/ccb-runtime/tmux-*.sock'
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_ccb_tmux_per_test(tmp_path):
+    before = set(glob.glob(_runtime_socket_pattern()))
+    try:
+        yield
+    finally:
+        for sock_path in tmp_path.rglob('.ccb/ccbd/tmux.sock'):
+            _safe_kill_tmux_server(str(sock_path))
+        after = set(glob.glob(_runtime_socket_pattern()))
+        for sock in after - before:
+            _safe_kill_tmux_server(sock)
+
+
+@pytest.fixture(autouse=True, scope='session')
+def _cleanup_ccb_tmux_session_end(tmp_path_factory):
+    before = set(glob.glob(_runtime_socket_pattern()))
+    try:
+        yield
+    finally:
+        base_tmp = tmp_path_factory.getbasetemp()
+        for sock_path in base_tmp.rglob('.ccb/ccbd/tmux.sock'):
+            _safe_kill_tmux_server(str(sock_path))
+        after = set(glob.glob(_runtime_socket_pattern()))
+        for sock in after - before:
+            _safe_kill_tmux_server(sock)


### PR DESCRIPTION
## Problem

Tests under `test/test_v2_phase2_entrypoint.py` invoke the `ccb` CLI via `subprocess.run`. That subprocess starts the CCB keeper, which wraps itself in an independent tmux daemon whose socket lives under `tmp_path/.ccb/ccbd/tmux.sock` or `/run/user/$UID/ccb-runtime/tmux-*.sock`.

The in-process `app.shutdown()` these tests run at teardown cannot reach the daemons that were started in a separate subprocess. Consequence: each such test leaks ≥1 `tmux: server` process. On a developer workstation running the test suite repeatedly, dozens of orphaned tmux daemons accumulate in `ps`, consuming memory and PIDs.

Observed on a dev box: `pytest-of-sevenx/pytest-52,57,58` each held 25+ orphaned `tmux: server` with ETIME over 2 hours before cleanup.

## Fix

Two `autouse` fixtures in `test/conftest.py`:

- `_cleanup_ccb_tmux_per_test` (per-test scope): after each test, kills any `.ccb/ccbd/tmux.sock` daemon found under the test's own `tmp_path` (safe because `tmp_path` is exclusive per-test), plus any socket that newly appeared in `/run/user/$UID/ccb-runtime/` during the test. The "newly appeared" check is a snapshot diff before/after yield, so existing user sockets in that dir are not touched.
- `_cleanup_ccb_tmux_session_end` (session scope, belt-and-suspenders): after the whole pytest session, sweeps the pytest base tmp and the runtime dir diff in case any per-test cleanup was missed due to a fixture exception.

Missing `tmux` binary raises `FileNotFoundError` and is silently ignored (e.g. Windows CI where tmux is unavailable). Hung `kill-server` (subprocess timeout after 5s) is logged at WARNING level — loud enough to notice but not fatal. No bare `except:` / no silent error swallowing.

Dependencies added to `conftest.py` imports: `glob`, `logging`, `subprocess` (standard library only).

## Tests

- Verified on `test_ccb_v2_project_lifecycle` (real-adapter lifecycle test that definitely spawns the keeper subprocess): zero `tmux: server` processes remain on the host after the test run. Baseline before this patch: ≥1 per such test run.
- No modifications to any production code.
- No modifications to any existing test.

## Scope

Test infrastructure only. Does not change runtime behavior of CCB. Does not modify any `lib/` code. A single file touched: `test/conftest.py` (+63 lines, 0 deletions). No new test files.

## Rollback

Single commit, revert with `git revert` if needed.