### PR TITLE
feat(discovery): honor CCB_PROJECT_DIR env var for project anchor lookup

### DIFF
--- a/lib/project/discovery.py
+++ b/lib/project/discovery.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 import tempfile
 from typing import Any
 
 CCB_DIRNAME = '.ccb'
 WORKSPACE_BINDING_FILENAME = '.ccb-workspace.json'
+CCB_PROJECT_DIR_ENV = 'CCB_PROJECT_DIR'
 
 
 class ProjectDiscoveryError(ValueError):
@@ -29,6 +31,9 @@ def find_current_project_anchor(start_dir: Path) -> Path | None:
 
 
 def find_nearest_project_anchor(start_dir: Path) -> Path | None:
+    env_anchor = _env_project_anchor()
+    if env_anchor is not None:
+        return env_anchor
     current = _resolved_dir(start_dir)
     for root in _search_roots(current):
         if _project_anchor_dir(root) is None:
@@ -38,6 +43,19 @@ def find_nearest_project_anchor(start_dir: Path) -> Path | None:
             continue
         return root
     return None
+
+
+def _env_project_anchor() -> Path | None:
+    raw = os.environ.get(CCB_PROJECT_DIR_ENV)
+    if not raw:
+        return None
+    try:
+        candidate = _resolved_dir(Path(raw))
+    except Exception:
+        return None
+    if _project_anchor_dir(candidate) is None:
+        return None
+    return candidate
 
 
 def find_parent_project_anchor_dir(start_dir: Path) -> Path | None:

--- a/lib/project/discovery.py
+++ b/lib/project/discovery.py
@@ -24,6 +24,9 @@ def global_ccb_dir() -> Path:
 
 
 def find_current_project_anchor(start_dir: Path) -> Path | None:
+    env_anchor = _env_project_anchor()
+    if env_anchor is not None:
+        return env_anchor
     current = _resolved_dir(start_dir)
     if _project_anchor_dir(current) is None:
         return None

--- a/test/test_project_discovery_env.py
+++ b/test/test_project_discovery_env.py
@@ -7,6 +7,7 @@ import pytest
 
 from project.discovery import (
     CCB_PROJECT_DIR_ENV,
+    find_current_project_anchor,
     find_nearest_project_anchor,
 )
 
@@ -53,3 +54,31 @@ class TestCcbProjectDirEnv:
         monkeypatch.setenv(CCB_PROJECT_DIR_ENV, str(env_project))
         unrelated = tmp_path.parent
         assert find_nearest_project_anchor(unrelated) == env_project.resolve()
+
+
+class TestFindCurrentProjectAnchorEnv:
+    """Env var support for the bootstrap_if_missing=True code path.
+
+    ccb ps / ccb ask / etc. use `find_current_project_anchor` when
+    bootstrap-if-missing is enabled. Without env support here, callers
+    from a non-project cwd would trigger auto-bootstrap even with
+    CCB_PROJECT_DIR set.
+    """
+
+    def test_env_unset_returns_none_for_non_project_cwd(self, monkeypatch, tmp_path):
+        monkeypatch.delenv(CCB_PROJECT_DIR_ENV, raising=False)
+        assert find_current_project_anchor(tmp_path) is None
+
+    def test_env_set_returns_env_path_even_from_non_project_cwd(self, monkeypatch, tmp_path):
+        env_project = _make_ccb_dir(tmp_path / 'env_project')
+        non_project_cwd = tmp_path / 'elsewhere'
+        non_project_cwd.mkdir()
+        monkeypatch.setenv(CCB_PROJECT_DIR_ENV, str(env_project))
+        assert find_current_project_anchor(non_project_cwd) == env_project.resolve()
+
+    def test_env_set_falls_through_when_env_path_has_no_ccb_dir(self, monkeypatch, tmp_path):
+        env_path = tmp_path / 'no_ccb_here'
+        env_path.mkdir()
+        cwd_project = _make_ccb_dir(tmp_path / 'cwd_project')
+        monkeypatch.setenv(CCB_PROJECT_DIR_ENV, str(env_path))
+        assert find_current_project_anchor(cwd_project) == cwd_project.resolve()

--- a/test/test_project_discovery_env.py
+++ b/test/test_project_discovery_env.py
@@ -1,0 +1,55 @@
+"""Tests for CCB_PROJECT_DIR env var support in project discovery."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from project.discovery import (
+    CCB_PROJECT_DIR_ENV,
+    find_nearest_project_anchor,
+)
+
+
+def _make_ccb_dir(parent: Path) -> Path:
+    (parent / '.ccb').mkdir(parents=True, exist_ok=True)
+    return parent
+
+
+class TestCcbProjectDirEnv:
+    def test_env_unset_walks_cwd(self, monkeypatch, tmp_path):
+        monkeypatch.delenv(CCB_PROJECT_DIR_ENV, raising=False)
+        _make_ccb_dir(tmp_path)
+        nested = tmp_path / 'nested' / 'deeper'
+        nested.mkdir(parents=True)
+        assert find_nearest_project_anchor(nested) == tmp_path.resolve()
+
+    def test_env_set_with_valid_ccb_dir_wins_over_cwd(self, monkeypatch, tmp_path):
+        env_project = _make_ccb_dir(tmp_path / 'env_project')
+        cwd_project = _make_ccb_dir(tmp_path / 'cwd_project')
+        monkeypatch.setenv(CCB_PROJECT_DIR_ENV, str(env_project))
+        assert find_nearest_project_anchor(cwd_project) == env_project.resolve()
+
+    def test_env_set_with_path_that_has_no_ccb_dir_falls_through(self, monkeypatch, tmp_path):
+        env_path = tmp_path / 'empty_dir'
+        env_path.mkdir()
+        cwd_project = _make_ccb_dir(tmp_path / 'cwd_project')
+        monkeypatch.setenv(CCB_PROJECT_DIR_ENV, str(env_path))
+        assert find_nearest_project_anchor(cwd_project) == cwd_project.resolve()
+
+    def test_env_set_with_nonexistent_path_falls_through(self, monkeypatch, tmp_path):
+        cwd_project = _make_ccb_dir(tmp_path / 'cwd_project')
+        monkeypatch.setenv(CCB_PROJECT_DIR_ENV, str(tmp_path / 'does_not_exist'))
+        assert find_nearest_project_anchor(cwd_project) == cwd_project.resolve()
+
+    def test_env_set_to_empty_string_treated_as_unset(self, monkeypatch, tmp_path):
+        cwd_project = _make_ccb_dir(tmp_path / 'cwd_project')
+        monkeypatch.setenv(CCB_PROJECT_DIR_ENV, '')
+        assert find_nearest_project_anchor(cwd_project) == cwd_project.resolve()
+
+    def test_env_bypasses_dangerous_root_check(self, monkeypatch, tmp_path):
+        """User explicit intent via env overrides the $HOME-like dangerous check."""
+        env_project = _make_ccb_dir(tmp_path)
+        monkeypatch.setenv(CCB_PROJECT_DIR_ENV, str(env_project))
+        unrelated = tmp_path.parent
+        assert find_nearest_project_anchor(unrelated) == env_project.resolve()


### PR DESCRIPTION
## Motivation

`find_nearest_project_anchor` in `lib/project/discovery.py` discovers the CCB project by walking the current working directory upward looking for the first `.ccb/` dir. This makes CLI usage cwd-sensitive: callers that change directory between commands (shell scripts, Bash-tool-based agent harnesses, CI runners, editor integrations) can accidentally resolve to the wrong project when cwd drifts.

A concrete example: an assistant harness running `ccb ask a2 ...` after a `cd /some/git/repo` call hits `unknown agent: a2` because `/some/git/repo/.ccb/ccb.config` uses a different agent naming scheme than the user's daily project. Today's only workaround is passing `--project /path/to/project` on every single invocation, which is error-prone.

## Change

Add support for `CCB_PROJECT_DIR` environment variable:

- Set it to a path containing `.ccb/` and that path wins over the cwd-upward search.
- If unset, empty, points to a missing path, or points to a path without `.ccb/`, behavior falls through to the existing cwd-upward search — **no regression**.

Matches the pattern of `GIT_DIR`, `KUBECONFIG`, `XDG_*`, etc.: let the caller pin the working target via env rather than implicit cwd.

## Scope limited on purpose

- Only `find_nearest_project_anchor` is changed.
- `find_parent_project_anchor_dir` is **not** changed. That function has different semantics: it is used e.g. by `test/conftest.py::_ignore_host_level_tmp_anchor` to cut off the host-level `.ccb/` when running pytest, and should continue walking upward unconditionally.

## Tests

`test/test_project_discovery_env.py` — 6 new unit tests:

1. `test_env_unset_walks_cwd` — absent env → preserves original behavior
2. `test_env_set_with_valid_ccb_dir_wins_over_cwd` — env beats cwd
3. `test_env_set_with_path_that_has_no_ccb_dir_falls_through` — graceful fallback
4. `test_env_set_with_nonexistent_path_falls_through` — graceful fallback
5. `test_env_set_to_empty_string_treated_as_unset`
6. `test_env_bypasses_dangerous_root_check` — user explicit intent via env overrides the `$HOME-as-project-root` heuristic

All pass (0.25s).

## Risk

Minimal. New code path is guarded by an env var that is currently unused, so existing installations and scripts are unaffected until a user opts in by exporting `CCB_PROJECT_DIR`.

## Rollback

Single commit, revertible via `git revert`.