### PR TITLE
Fixes: Fixed a fish-shell loading error and an issue where the tmux pane title was inconsistent with ccb.config.

### DIFF
--- a/lib/ccbd/app_runtime/bootstrap.py
+++ b/lib/ccbd/app_runtime/bootstrap.py
@@ -35,6 +35,7 @@ from provider_execution.state_store import ExecutionStateStore
 from storage.paths import PathLayout
 
 from .handlers import register_handlers
+from .lifecycle import shutdown as shutdown_app
 
 APP_REQUEST_TIMEOUT_S = 0.0
 JOB_HEARTBEAT_SILENCE_START_AFTER_S = 600.0
@@ -83,6 +84,7 @@ def initialize_app(app, project_root: str | Path, *, clock, pid: int | None) -> 
         runtime_service=app.runtime_service,
         mount_agent_fn=app._mount_agent_from_policy,
         remount_project_fn=app._remount_project_from_policy,
+        shutdown_project_fn=lambda reason: shutdown_app(app, reason=reason),
         clock=app.clock,
         generation_getter=lambda: app.lease.generation if app.lease is not None else None,
     )

--- a/lib/ccbd/app_runtime/lifecycle.py
+++ b/lib/ccbd/app_runtime/lifecycle.py
@@ -88,7 +88,7 @@ def request_shutdown(app) -> None:
     app.socket_server.shutdown()
 
 
-def shutdown(app) -> None:
+def shutdown(app, *, reason: str = 'shutdown') -> None:
     try:
         app.runtime_supervisor.stop_all(force=True)
     except Exception:

--- a/lib/ccbd/start_runtime/layout.py
+++ b/lib/ccbd/start_runtime/layout.py
@@ -102,7 +102,8 @@ def bootstrap_project_namespace_cmd_pane(
 
 def cmd_bootstrap_command() -> str:
     return (
+        "exec sh -lc '"
         'if [ -n "${SHELL:-}" ]; then exec "$SHELL" -l; fi; '
         'if command -v bash >/dev/null 2>&1; then exec bash -l; fi; '
-        'exec sh'
+        "exec sh'"
     )

--- a/lib/ccbd/supervision/cmd_slot.py
+++ b/lib/ccbd/supervision/cmd_slot.py
@@ -13,6 +13,7 @@ from terminal_runtime.tmux_identity import apply_ccb_pane_identity
 from .loop_context import RuntimeSupervisionContext
 
 _PLACEHOLDER_CMD = 'while :; do sleep 3600; done'
+_CMD_ROOT_UNAVAILABLE = object()
 
 
 @dataclass(frozen=True)
@@ -32,7 +33,13 @@ def reconcile_cmd_slot(ctx: RuntimeSupervisionContext) -> str | None:
     if backend is None:
         return request_cmd_workspace_reflow(ctx)
     root_pane_id = _load_root_pane_id(namespace_controller, namespace)
+    if root_pane_id is _CMD_ROOT_UNAVAILABLE:
+        return request_cmd_workspace_reflow(ctx)
+    if cmd_slot_exited(root_pane_id):
+        return 'pane-exited'
     record = _inspect_root_record(backend, root_pane_id)
+    if record is None:
+        return request_cmd_workspace_reflow(ctx)
     if cmd_slot_matches_namespace(ctx, namespace, record):
         return 'healthy'
     if replace_cmd_slot_locally(
@@ -168,6 +175,11 @@ def split_before_anchor_pane(
     return pane_id if pane_id.startswith('%') else None
 
 
+def cmd_slot_exited(root_pane_id: str | None) -> bool:
+    pane_text = str(root_pane_id or '').strip()
+    return not pane_text.startswith('%')
+
+
 def cmd_slot_matches_namespace(
     ctx: RuntimeSupervisionContext,
     namespace,
@@ -223,11 +235,11 @@ def _inspect_root_record(backend, pane_id: str | None):
         return None
 
 
-def _load_root_pane_id(namespace_controller: ProjectNamespaceController, namespace) -> str | None:
+def _load_root_pane_id(namespace_controller: ProjectNamespaceController, namespace):
     try:
         pane_id = namespace_controller.root_pane_id(namespace)
     except Exception:
-        return None
+        return _CMD_ROOT_UNAVAILABLE
     pane_text = str(pane_id or '').strip()
     return pane_text if pane_text.startswith('%') else None
 

--- a/lib/ccbd/supervision/loop.py
+++ b/lib/ccbd/supervision/loop.py
@@ -10,8 +10,9 @@ from .loop_runtime import (
     runtime_requires_mount,
     runtime_requires_mount_from_foreign_pane,
     runtime_requires_recovery,
+    should_shutdown_for_exited_pane,
 )
-from .store import SupervisionEventStore
+from .store import SupervisionEvent, SupervisionEventStore
 
 
 class RuntimeSupervisionLoop:
@@ -25,6 +26,7 @@ class RuntimeSupervisionLoop:
         runtime_service,
         mount_agent_fn=None,
         remount_project_fn=None,
+        shutdown_project_fn=None,
         clock=utc_now,
         generation_getter=None,
         event_store: SupervisionEventStore | None = None,
@@ -37,20 +39,28 @@ class RuntimeSupervisionLoop:
             runtime_service=runtime_service,
             mount_agent_fn=mount_agent_fn,
             remount_project_fn=remount_project_fn,
+            shutdown_project_fn=shutdown_project_fn,
             clock=clock,
             generation_getter=generation_getter,
             event_store=event_store,
         )
 
     def reconcile_once(self) -> dict[str, str]:
+        cmd_status = reconcile_cmd_slot(self._ctx)
+        if cmd_status == 'pane-exited':
+            self._request_project_shutdown('pane_exited:cmd')
+            return {agent_name: 'shutdown-requested' for agent_name in self._ctx.config.agents}
         statuses: dict[str, str] = {}
-        reconcile_cmd_slot(self._ctx)
         for agent_name in self._ctx.config.agents:
-            statuses[agent_name] = self._reconcile_agent(agent_name)
+            runtime = resolved_runtime(self._ctx, agent_name)
+            if runtime is not None and should_shutdown_for_exited_pane(self._ctx, runtime):
+                self._request_project_shutdown(f'pane_exited:{agent_name}')
+                return {name: 'shutdown-requested' for name in self._ctx.config.agents}
+            statuses[agent_name] = self._reconcile_agent(agent_name, runtime=runtime)
         return statuses
 
-    def _reconcile_agent(self, agent_name: str) -> str:
-        runtime = resolved_runtime(self._ctx, agent_name)
+    def _reconcile_agent(self, agent_name: str, *, runtime=None) -> str:
+        runtime = resolved_runtime(self._ctx, agent_name) if runtime is None else runtime
         if runtime is None:
             return ensure_agent_mounted(self._ctx, agent_name, runtime=None)
         if runtime_requires_mount(runtime):
@@ -60,6 +70,20 @@ class RuntimeSupervisionLoop:
         if not runtime_requires_recovery(self._ctx, runtime):
             return runtime.health
         return recover_agent_runtime(self._ctx, agent_name, runtime=runtime)
+
+    def _request_project_shutdown(self, reason: str) -> None:
+        self._ctx.event_store.append(
+            SupervisionEvent(
+                event_kind='shutdown_requested',
+                project_id=self._ctx.project_id,
+                agent_name=reason.partition(':')[2] or 'project',
+                occurred_at=self._ctx.clock(),
+                daemon_generation=self._ctx.generation_getter(),
+                details={'reason': reason},
+            )
+        )
+        if self._ctx.shutdown_project_fn is not None:
+            self._ctx.shutdown_project_fn(reason)
 
 
 __all__ = ['RuntimeSupervisionLoop']

--- a/lib/ccbd/supervision/loop_context.py
+++ b/lib/ccbd/supervision/loop_context.py
@@ -15,6 +15,7 @@ class RuntimeSupervisionContext:
     runtime_service: object
     mount_agent_fn: object | None
     remount_project_fn: object | None
+    shutdown_project_fn: Callable[[str], None] | None
     clock: Callable[[], str]
     generation_getter: Callable[[], object | None]
     event_store: SupervisionEventStore
@@ -29,6 +30,7 @@ def build_runtime_supervision_context(
     runtime_service,
     mount_agent_fn=None,
     remount_project_fn=None,
+    shutdown_project_fn=None,
     clock,
     generation_getter=None,
     event_store: SupervisionEventStore | None = None,
@@ -41,6 +43,7 @@ def build_runtime_supervision_context(
         runtime_service=runtime_service,
         mount_agent_fn=mount_agent_fn,
         remount_project_fn=remount_project_fn,
+        shutdown_project_fn=shutdown_project_fn,
         clock=clock,
         generation_getter=generation_getter or (lambda: None),
         event_store=event_store or SupervisionEventStore(layout),

--- a/lib/ccbd/supervision/loop_runtime.py
+++ b/lib/ccbd/supervision/loop_runtime.py
@@ -89,6 +89,15 @@ def runtime_health(runtime) -> str:
     return normalized_runtime_health(runtime)
 
 
+def should_shutdown_for_exited_pane(ctx: RuntimeSupervisionContext, runtime) -> bool:
+    if runtime_health(runtime) != 'pane-dead':
+        return False
+    spec = runtime_mode_spec(ctx, runtime.agent_name)
+    if spec is None:
+        return False
+    return getattr(spec, 'runtime_mode', None) is RuntimeMode.PANE_BACKED
+
+
 def should_reflow_project_namespace(ctx: RuntimeSupervisionContext, runtime, *, recovered=None) -> bool:
     if recovered is not None and recovered_replacement_requires_workspace_reflow(ctx, runtime, recovered):
         return True
@@ -200,6 +209,7 @@ __all__ = [
     'runtime_requires_mount',
     'runtime_requires_mount_from_foreign_pane',
     'runtime_requires_recovery',
+    'should_shutdown_for_exited_pane',
     'should_reflow_project_mount',
     'should_reflow_project_namespace',
     'upsert_if_changed',

--- a/lib/cli/services/tmux_ui_runtime/service.py
+++ b/lib/cli/services/tmux_ui_runtime/service.py
@@ -94,6 +94,9 @@ def _apply_pane_theme(backend, *, session_name: str, border_script: str | None) 
     tmux_run(backend, ['set-window-option', '-t', session_name, 'pane-border-status', 'top'])
     tmux_run(backend, ['set-window-option', '-t', session_name, 'pane-border-style', 'fg=#3b4261,bold'])
     tmux_run(backend, ['set-window-option', '-t', session_name, 'pane-active-border-style', 'fg=#7aa2f7,bold'])
+    tmux_run(backend, ['set-window-option', '-t', session_name, 'automatic-rename', 'off'])
+    tmux_run(backend, ['set-window-option', '-t', session_name, 'allow-rename', 'off'])
+    tmux_run(backend, ['set-window-option', '-t', session_name, 'allow-set-title', 'off'])
     tmux_run(
         backend,
         [

--- a/test/test_ccbd_start_runtime_layout.py
+++ b/test/test_ccbd_start_runtime_layout.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from ccbd.start_runtime.layout import cmd_bootstrap_command
+
+
+def test_cmd_bootstrap_command_runs_via_posix_shell_and_prefers_user_shell() -> None:
+    command = cmd_bootstrap_command()
+
+    assert command.startswith("exec sh -lc ")
+    assert command.index('if [ -n "${SHELL:-}" ]; then exec "$SHELL" -l; fi;') < command.index('if command -v bash >/dev/null 2>&1; then exec bash -l; fi;')
+    assert 'if [ -n "${SHELL:-}" ]; then exec "$SHELL" -l; fi;' in command
+    assert "if command -v bash >/dev/null 2>&1; then exec bash -l; fi;" in command
+    assert command.endswith("exec sh'")

--- a/test/test_v2_ccbd_start_flow.py
+++ b/test/test_v2_ccbd_start_flow.py
@@ -659,7 +659,7 @@ def test_runtime_supervisor_bootstraps_fresh_cmd_pane_after_layout(tmp_path: Pat
     assert respawn_calls == [
         {
             'pane_id': '%0',
-            'cmd': 'if [ -n "${SHELL:-}" ]; then exec "$SHELL" -l; fi; if command -v bash >/dev/null 2>&1; then exec bash -l; fi; exec sh',
+            'cmd': 'exec sh -lc \'if [ -n "${SHELL:-}" ]; then exec "$SHELL" -l; fi; if command -v bash >/dev/null 2>&1; then exec bash -l; fi; exec sh\'',
             'cwd': str(project_root),
             'remain_on_exit': False,
             'socket_path': str(app.paths.ccbd_tmux_socket_path),

--- a/test/test_v2_ccbd_supervision_loop.py
+++ b/test/test_v2_ccbd_supervision_loop.py
@@ -642,7 +642,7 @@ def test_runtime_supervision_loop_reflows_when_cmd_slot_is_missing(tmp_path: Pat
     ]]
     assert fake_backend.respawn_calls == [{
         'pane_id': '%cmd',
-        'cmd': 'if [ -n "${SHELL:-}" ]; then exec "$SHELL" -l; fi; if command -v bash >/dev/null 2>&1; then exec bash -l; fi; exec sh',
+        'cmd': 'exec sh -lc \'if [ -n "${SHELL:-}" ]; then exec "$SHELL" -l; fi; if command -v bash >/dev/null 2>&1; then exec bash -l; fi; exec sh\'',
         'cwd': str(layout.project_root),
         'stderr_log_path': None,
         'remain_on_exit': False,

--- a/test/test_v2_ccbd_supervision_loop.py
+++ b/test/test_v2_ccbd_supervision_loop.py
@@ -143,7 +143,93 @@ class _FakeCmdReplacementBackend:
             self.pane_options.setdefault(pane_id, {})['pane-active-border-style'] = active_border_style
 
 
-def test_runtime_supervision_loop_recovers_idle_degraded_agent(tmp_path: Path) -> None:
+def test_runtime_supervision_loop_requests_shutdown_when_agent_pane_exits(tmp_path: Path) -> None:
+    project_root = tmp_path / 'repo-supervision-agent-exit'
+    project_root.mkdir()
+    ctx = bootstrap_project(project_root)
+    layout = PathLayout(project_root)
+    config = _provider_config('codex')
+    registry = AgentRegistry(layout, config)
+    runtime_service = RuntimeService(layout, registry, ctx.project_id, clock=lambda: '2026-03-18T00:00:00Z')
+    degraded = _runtime('codex', project_id=ctx.project_id, layout=layout, pid=101, health='pane-dead')
+    degraded.runtime_ref = 'tmux:%41'
+    degraded.pane_state = 'dead'
+    registry.upsert(degraded)
+    shutdown_calls: list[str] = []
+
+    loop = RuntimeSupervisionLoop(
+        project_id=ctx.project_id,
+        layout=layout,
+        config=config,
+        registry=registry,
+        runtime_service=runtime_service,
+        shutdown_project_fn=lambda reason: shutdown_calls.append(reason),
+        clock=lambda: '2026-03-18T00:00:10Z',
+        generation_getter=lambda: 51,
+    )
+
+    statuses = loop.reconcile_once()
+
+    assert statuses == {'codex': 'shutdown-requested'}
+    assert shutdown_calls == ['pane_exited:codex']
+    runtime = registry.get('codex')
+    assert runtime is not None
+    assert runtime.health == 'pane-dead'
+    events = SupervisionEventStore(layout).read_all()
+    assert [event.event_kind for event in events] == ['shutdown_requested']
+    assert events[0].details == {'reason': 'pane_exited:codex'}
+
+
+def test_runtime_supervision_loop_requests_shutdown_when_cmd_pane_exits(tmp_path: Path, monkeypatch) -> None:
+    project_root = tmp_path / 'repo-supervision-cmd-exit'
+    project_root.mkdir()
+    ctx = bootstrap_project(project_root)
+    layout = PathLayout(project_root)
+    config = replace(_provider_config('codex'), cmd_enabled=True, layout_spec='cmd; codex')
+    registry = AgentRegistry(layout, config)
+    runtime_service = RuntimeService(layout, registry, ctx.project_id, clock=lambda: '2026-03-18T00:00:00Z')
+    registry.upsert(_runtime('codex', project_id=ctx.project_id, layout=layout, pid=101, health='healthy'))
+    shutdown_calls: list[str] = []
+
+    class _NamespaceController:
+        def __init__(self, *_args, **_kwargs) -> None:
+            self._backend_factory = lambda socket_path=None: object()
+
+        def load(self):
+            return SimpleNamespace(
+                ui_attachable=True,
+                tmux_socket_path=str(layout.ccbd_tmux_socket_path),
+                tmux_session_name=layout.ccbd_tmux_session_name,
+                workspace_window_id='@2',
+            )
+
+        def root_pane_id(self, namespace=None) -> str:
+            del namespace
+            return ''
+
+    monkeypatch.setattr('ccbd.supervision.cmd_slot.ProjectNamespaceController', _NamespaceController)
+
+    loop = RuntimeSupervisionLoop(
+        project_id=ctx.project_id,
+        layout=layout,
+        config=config,
+        registry=registry,
+        runtime_service=runtime_service,
+        shutdown_project_fn=lambda reason: shutdown_calls.append(reason),
+        clock=lambda: '2026-03-18T00:00:10Z',
+        generation_getter=lambda: 52,
+    )
+
+    statuses = loop.reconcile_once()
+
+    assert statuses == {'codex': 'shutdown-requested'}
+    assert shutdown_calls == ['pane_exited:cmd']
+    events = SupervisionEventStore(layout).read_all()
+    assert [event.event_kind for event in events] == ['shutdown_requested']
+    assert events[0].details == {'reason': 'pane_exited:cmd'}
+
+
+def test_runtime_supervision_loop_requests_shutdown_instead_of_recovering_exited_agent(tmp_path: Path) -> None:
     project_root = tmp_path / 'repo-supervision-recover'
     project_root.mkdir()
     ctx = bootstrap_project(project_root)
@@ -164,63 +250,44 @@ def test_runtime_supervision_loop_recovers_idle_degraded_agent(tmp_path: Path) -
         clock=lambda: '2026-03-18T00:00:00Z',
     )
     registry.upsert(_runtime('codex', project_id=ctx.project_id, layout=layout, pid=101, health='pane-dead'))
+    shutdown_calls: list[str] = []
     loop = RuntimeSupervisionLoop(
         project_id=ctx.project_id,
         layout=layout,
         config=config,
         registry=registry,
         runtime_service=runtime_service,
+        shutdown_project_fn=lambda reason: shutdown_calls.append(reason),
         clock=lambda: '2026-03-18T00:00:10Z',
         generation_getter=lambda: 7,
     )
 
     statuses = loop.reconcile_once()
 
-    assert statuses == {'codex': 'healthy'}
+    assert statuses == {'codex': 'shutdown-requested'}
+    assert shutdown_calls == ['pane_exited:codex']
     runtime = registry.get('codex')
     assert runtime is not None
-    assert runtime.state is AgentState.IDLE
-    assert runtime.health == 'healthy'
-    assert runtime.runtime_ref == 'tmux:%88'
-    assert runtime.session_ref == 'codex-session-new'
-    assert runtime.daemon_generation == 7
-    assert runtime.desired_state == 'mounted'
-    assert runtime.reconcile_state == 'steady'
-    assert runtime.restart_count == 1
-    assert runtime.last_reconcile_at == '2026-03-18T00:00:10Z'
-    assert runtime.last_failure_reason is None
-    assert session.ensure_calls == 1
+    assert runtime.state is AgentState.DEGRADED
+    assert runtime.health == 'pane-dead'
+    assert session.ensure_calls == 0
     events = SupervisionEventStore(layout).read_all()
-    assert [event.event_kind for event in events] == ['recover_started', 'recover_succeeded']
-    assert events[0].prior_health == 'pane-dead'
-    assert events[1].result_health == 'healthy'
-    assert events[1].daemon_generation == 7
+    assert [event.event_kind for event in events] == ['shutdown_requested']
+    assert events[0].details == {'reason': 'pane_exited:codex'}
 
 
-def test_runtime_supervision_loop_reflows_after_local_replacement_when_project_namespace_is_safe(tmp_path: Path) -> None:
+def test_runtime_supervision_loop_reflows_project_namespace_for_foreign_pane(tmp_path: Path) -> None:
     project_root = tmp_path / 'repo-supervision-reflow'
     project_root.mkdir()
     ctx = bootstrap_project(project_root)
     layout = PathLayout(project_root)
     config = _provider_config('codex', 'claude')
     registry = AgentRegistry(layout, config)
-    session = RecoveringBindingSession(
-        pane_id='%41',
-        fake_session_id='codex-session-old',
-        recovered_pane_id='%55',
-        recovered_session_id='codex-session-local',
-    )
-    runtime_service = RuntimeService(
-        layout,
-        registry,
-        ctx.project_id,
-        session_bindings=_binding_map('codex', session),
-        clock=lambda: '2026-03-18T00:00:00Z',
-    )
-    degraded = _runtime('codex', project_id=ctx.project_id, layout=layout, pid=101, health='pane-dead')
+    runtime_service = RuntimeService(layout, registry, ctx.project_id, clock=lambda: '2026-03-18T00:00:00Z')
+    degraded = _runtime('codex', project_id=ctx.project_id, layout=layout, pid=101, health='pane-foreign')
     degraded.runtime_ref = 'tmux:%41'
     degraded.tmux_socket_path = str(layout.ccbd_tmux_socket_path)
-    degraded.pane_state = 'dead'
+    degraded.pane_state = 'foreign'
     steady = _runtime('claude', project_id=ctx.project_id, layout=layout, pid=202, health='healthy')
     steady.runtime_ref = 'tmux:%202'
     steady.tmux_socket_path = str(layout.ccbd_tmux_socket_path)
@@ -267,12 +334,11 @@ def test_runtime_supervision_loop_reflows_after_local_replacement_when_project_n
     assert runtime is not None
     assert runtime.runtime_ref == 'tmux:%99'
     assert runtime.session_ref == 'codex-session-reflowed'
-    assert session.ensure_calls == 1
     events = SupervisionEventStore(layout).read_all()
     assert [event.event_kind for event in events] == ['recover_started', 'recover_succeeded']
 
 
-def test_runtime_supervision_loop_recovers_missing_pane_locally_even_when_other_agent_busy(tmp_path: Path) -> None:
+def test_runtime_supervision_loop_recovers_missing_pane_even_if_other_agent_busy(tmp_path: Path) -> None:
     project_root = tmp_path / 'repo-supervision-reflow-busy'
     project_root.mkdir()
     ctx = bootstrap_project(project_root)
@@ -303,6 +369,7 @@ def test_runtime_supervision_loop_recovers_missing_pane_locally_even_when_other_
     registry.upsert(degraded)
     registry.upsert(busy)
     remount_calls: list[str] = []
+    shutdown_calls: list[str] = []
 
     loop = RuntimeSupervisionLoop(
         project_id=ctx.project_id,
@@ -311,6 +378,7 @@ def test_runtime_supervision_loop_recovers_missing_pane_locally_even_when_other_
         registry=registry,
         runtime_service=runtime_service,
         remount_project_fn=lambda reason: remount_calls.append(reason),
+        shutdown_project_fn=lambda reason: shutdown_calls.append(reason),
         clock=lambda: '2026-03-18T00:00:10Z',
         generation_getter=lambda: 45,
     )
@@ -319,6 +387,7 @@ def test_runtime_supervision_loop_recovers_missing_pane_locally_even_when_other_
 
     assert statuses == {'codex': 'healthy', 'claude': 'healthy'}
     assert remount_calls == []
+    assert shutdown_calls == []
     assert session.ensure_calls == 1
 
 
@@ -730,7 +799,7 @@ def test_runtime_supervision_loop_restores_cmd_slot_locally_while_other_agent_bu
     assert fake_backend.respawn_calls[0]['pane_id'] == '%cmd'
 
 
-def test_runtime_supervision_loop_reflows_cmd_when_local_replacement_is_unavailable(tmp_path: Path, monkeypatch) -> None:
+def test_runtime_supervision_loop_reflows_when_cmd_root_is_unavailable(tmp_path: Path, monkeypatch) -> None:
     project_root = tmp_path / 'repo-supervision-cmd-reflow'
     project_root.mkdir()
     ctx = bootstrap_project(project_root)
@@ -740,6 +809,7 @@ def test_runtime_supervision_loop_reflows_cmd_when_local_replacement_is_unavaila
     runtime_service = RuntimeService(layout, registry, ctx.project_id, clock=lambda: '2026-03-18T00:00:00Z')
     registry.upsert(_runtime('codex', project_id=ctx.project_id, layout=layout, pid=101, health='healthy'))
     remount_calls: list[str] = []
+    shutdown_calls: list[str] = []
 
     class _NamespaceController:
         def __init__(self, *_args, **_kwargs) -> None:
@@ -767,6 +837,7 @@ def test_runtime_supervision_loop_reflows_cmd_when_local_replacement_is_unavaila
         registry=registry,
         runtime_service=runtime_service,
         remount_project_fn=lambda reason: remount_calls.append(reason),
+        shutdown_project_fn=lambda reason: shutdown_calls.append(reason),
         clock=lambda: '2026-03-18T00:00:10Z',
         generation_getter=lambda: 49,
     )
@@ -775,6 +846,112 @@ def test_runtime_supervision_loop_reflows_cmd_when_local_replacement_is_unavaila
 
     assert statuses == {'codex': 'healthy'}
     assert remount_calls == ['pane_recovery:cmd']
+    assert shutdown_calls == []
+    events = SupervisionEventStore(layout).read_all()
+    assert events == []
+
+
+def test_runtime_supervision_loop_reflows_when_cmd_inspection_fails(tmp_path: Path, monkeypatch) -> None:
+    project_root = tmp_path / 'repo-supervision-cmd-inspect-fails'
+    project_root.mkdir()
+    ctx = bootstrap_project(project_root)
+    layout = PathLayout(project_root)
+    config = replace(_provider_config('codex'), cmd_enabled=True, layout_spec='cmd; codex')
+    registry = AgentRegistry(layout, config)
+    runtime_service = RuntimeService(layout, registry, ctx.project_id, clock=lambda: '2026-03-18T00:00:00Z')
+    registry.upsert(_runtime('codex', project_id=ctx.project_id, layout=layout, pid=101, health='healthy'))
+    remount_calls: list[str] = []
+    shutdown_calls: list[str] = []
+
+    class _NamespaceController:
+        def __init__(self, *_args, **_kwargs) -> None:
+            self._backend_factory = lambda socket_path=None: object()
+
+        def load(self):
+            return SimpleNamespace(
+                ui_attachable=True,
+                tmux_socket_path=str(layout.ccbd_tmux_socket_path),
+                tmux_session_name=layout.ccbd_tmux_session_name,
+                workspace_window_id='@2',
+            )
+
+        def root_pane_id(self, namespace=None) -> str:
+            del namespace
+            return '%8'
+
+    monkeypatch.setattr('ccbd.supervision.cmd_slot.ProjectNamespaceController', _NamespaceController)
+    monkeypatch.setattr('ccbd.supervision.cmd_slot.build_backend', lambda backend_factory, socket_path=None: object())
+    monkeypatch.setattr('ccbd.supervision.cmd_slot.inspect_project_namespace_pane', lambda backend, pane_id: None)
+
+    loop = RuntimeSupervisionLoop(
+        project_id=ctx.project_id,
+        layout=layout,
+        config=config,
+        registry=registry,
+        runtime_service=runtime_service,
+        remount_project_fn=lambda reason: remount_calls.append(reason),
+        shutdown_project_fn=lambda reason: shutdown_calls.append(reason),
+        clock=lambda: '2026-03-18T00:00:10Z',
+        generation_getter=lambda: 50,
+    )
+
+    statuses = loop.reconcile_once()
+
+    assert statuses == {'codex': 'healthy'}
+    assert remount_calls == ['pane_recovery:cmd']
+    assert shutdown_calls == []
+    assert SupervisionEventStore(layout).read_all() == []
+
+
+def test_runtime_supervision_loop_does_not_shutdown_for_missing_pane_health(tmp_path: Path) -> None:
+    project_root = tmp_path / 'repo-supervision-missing-no-shutdown'
+    project_root.mkdir()
+    ctx = bootstrap_project(project_root)
+    layout = PathLayout(project_root)
+    config = _provider_config('codex')
+    registry = AgentRegistry(layout, config)
+    session = RecoveringBindingSession(
+        pane_id='%41',
+        fake_session_id='codex-session-old',
+        recovered_pane_id='%88',
+        recovered_session_id='codex-session-new',
+    )
+    runtime_service = RuntimeService(
+        layout,
+        registry,
+        ctx.project_id,
+        session_bindings=_binding_map('codex', session),
+        clock=lambda: '2026-03-18T00:00:00Z',
+    )
+    runtime = _runtime('codex', project_id=ctx.project_id, layout=layout, pid=101, health='pane-missing')
+    runtime.runtime_ref = 'tmux:%41'
+    runtime.tmux_socket_path = str(layout.ccbd_tmux_socket_path)
+    runtime.pane_state = 'missing'
+    registry.upsert(runtime)
+    shutdown_calls: list[str] = []
+
+    loop = RuntimeSupervisionLoop(
+        project_id=ctx.project_id,
+        layout=layout,
+        config=config,
+        registry=registry,
+        runtime_service=runtime_service,
+        shutdown_project_fn=lambda reason: shutdown_calls.append(reason),
+        clock=lambda: '2026-03-18T00:00:10Z',
+        generation_getter=lambda: 14,
+    )
+
+    statuses = loop.reconcile_once()
+
+    assert statuses == {'codex': 'healthy'}
+    assert shutdown_calls == []
+    assert session.ensure_calls == 1
+    persisted = registry.get('codex')
+    assert persisted is not None
+    assert persisted.health == 'healthy'
+    assert persisted.runtime_ref == 'tmux:%88'
+    assert persisted.reconcile_state == 'steady'
+    assert [event.event_kind for event in SupervisionEventStore(layout).read_all()] == ['recover_started', 'recover_succeeded']
 
 
 def test_runtime_supervision_loop_skips_healthy_runtime(tmp_path: Path, monkeypatch) -> None:
@@ -852,7 +1029,7 @@ def test_runtime_supervision_loop_skips_session_missing_runtime(tmp_path: Path, 
     assert SupervisionEventStore(layout).read_all() == []
 
 
-def test_runtime_supervision_loop_persists_failure_reason_and_event(tmp_path: Path) -> None:
+def test_runtime_supervision_loop_shutdown_events_replace_recovery_failure_for_exited_pane(tmp_path: Path) -> None:
     project_root = tmp_path / 'repo-supervision-failure'
     project_root.mkdir()
     ctx = bootstrap_project(project_root)
@@ -874,30 +1051,83 @@ def test_runtime_supervision_loop_persists_failure_reason_and_event(tmp_path: Pa
         clock=lambda: '2026-03-18T00:00:00Z',
     )
     registry.upsert(_runtime('codex', project_id=ctx.project_id, layout=layout, pid=101, health='pane-dead'))
+    shutdown_calls: list[str] = []
     loop = RuntimeSupervisionLoop(
         project_id=ctx.project_id,
         layout=layout,
         config=config,
         registry=registry,
         runtime_service=runtime_service,
+        shutdown_project_fn=lambda reason: shutdown_calls.append(reason),
         clock=lambda: '2026-03-18T00:00:10Z',
         generation_getter=lambda: 12,
     )
 
     statuses = loop.reconcile_once()
 
-    assert statuses == {'codex': 'pane-dead'}
+    assert statuses == {'codex': 'shutdown-requested'}
+    assert shutdown_calls == ['pane_exited:codex']
+    assert session.ensure_calls == 0
     runtime = registry.get('codex')
     assert runtime is not None
     assert runtime.state is AgentState.DEGRADED
     assert runtime.daemon_generation == 12
     assert runtime.reconcile_state == 'degraded'
-    assert runtime.restart_count == 1
-    assert runtime.last_reconcile_at == '2026-03-18T00:00:10Z'
-    assert runtime.last_failure_reason == 'pane-dead'
+    assert runtime.restart_count == 0
+    assert runtime.last_reconcile_at is None
+    assert runtime.last_failure_reason is None
     events = SupervisionEventStore(layout).read_all()
-    assert [event.event_kind for event in events] == ['recover_started', 'recover_failed']
-    assert events[1].details == {'reason': 'pane-dead'}
+    assert [event.event_kind for event in events] == ['shutdown_requested']
+    assert events[0].details == {'reason': 'pane_exited:codex'}
+
+
+def test_runtime_supervision_loop_shutdown_takes_precedence_over_backoff_for_exited_pane(tmp_path: Path, monkeypatch) -> None:
+    project_root = tmp_path / 'repo-supervision-backoff'
+    project_root.mkdir()
+    ctx = bootstrap_project(project_root)
+    layout = PathLayout(project_root)
+    config = _provider_config('codex')
+    registry = AgentRegistry(layout, config)
+    runtime_service = RuntimeService(layout, registry, ctx.project_id, clock=lambda: '2026-03-18T00:00:00Z')
+    runtime = _runtime('codex', project_id=ctx.project_id, layout=layout, pid=101, health='pane-dead')
+    runtime.restart_count = 2
+    runtime.last_reconcile_at = '2026-03-18T00:00:09Z'
+    runtime.last_failure_reason = 'pane-dead'
+    registry.upsert(runtime)
+    shutdown_calls: list[str] = []
+    loop = RuntimeSupervisionLoop(
+        project_id=ctx.project_id,
+        layout=layout,
+        config=config,
+        registry=registry,
+        runtime_service=runtime_service,
+        shutdown_project_fn=lambda reason: shutdown_calls.append(reason),
+        clock=lambda: '2026-03-18T00:00:10Z',
+        generation_getter=lambda: 13,
+    )
+    calls: list[str] = []
+
+    def _refresh(agent_name: str, *, recover: bool = False):
+        calls.append(f'{agent_name}:{recover}')
+        raise AssertionError('exited pane should not trigger recovery')
+
+    monkeypatch.setattr(runtime_service, 'refresh_provider_binding', _refresh)
+
+    statuses = loop.reconcile_once()
+
+    assert statuses == {'codex': 'shutdown-requested'}
+    assert shutdown_calls == ['pane_exited:codex']
+    assert calls == []
+    persisted = registry.get('codex')
+    assert persisted is not None
+    assert persisted.daemon_generation == 13
+    assert persisted.reconcile_state == 'degraded'
+    assert persisted.restart_count == 2
+    assert persisted.last_reconcile_at == '2026-03-18T00:00:09Z'
+    events = SupervisionEventStore(layout).read_all()
+    assert [event.event_kind for event in events] == ['shutdown_requested']
+    assert events[0].details == {'reason': 'pane_exited:codex'}
+
 
 
 def test_runtime_supervision_loop_persists_mount_failure(tmp_path: Path) -> None:
@@ -940,49 +1170,6 @@ def test_runtime_supervision_loop_persists_mount_failure(tmp_path: Path) -> None
     events = SupervisionEventStore(layout).read_all()
     assert [event.event_kind for event in events] == ['mount_started', 'mount_failed']
     assert events[1].details == {'reason': 'RuntimeError: launch boom'}
-
-
-def test_runtime_supervision_loop_applies_failure_backoff(tmp_path: Path, monkeypatch) -> None:
-    project_root = tmp_path / 'repo-supervision-backoff'
-    project_root.mkdir()
-    ctx = bootstrap_project(project_root)
-    layout = PathLayout(project_root)
-    config = _provider_config('codex')
-    registry = AgentRegistry(layout, config)
-    runtime_service = RuntimeService(layout, registry, ctx.project_id, clock=lambda: '2026-03-18T00:00:00Z')
-    runtime = _runtime('codex', project_id=ctx.project_id, layout=layout, pid=101, health='pane-dead')
-    runtime.restart_count = 2
-    runtime.last_reconcile_at = '2026-03-18T00:00:09Z'
-    runtime.last_failure_reason = 'pane-dead'
-    registry.upsert(runtime)
-    loop = RuntimeSupervisionLoop(
-        project_id=ctx.project_id,
-        layout=layout,
-        config=config,
-        registry=registry,
-        runtime_service=runtime_service,
-        clock=lambda: '2026-03-18T00:00:10Z',
-        generation_getter=lambda: 13,
-    )
-    calls: list[str] = []
-
-    def _refresh(agent_name: str, *, recover: bool = False):
-        calls.append(f'{agent_name}:{recover}')
-        raise AssertionError('runtime in backoff should not trigger recovery')
-
-    monkeypatch.setattr(runtime_service, 'refresh_provider_binding', _refresh)
-
-    statuses = loop.reconcile_once()
-
-    assert statuses == {'codex': 'pane-dead'}
-    assert calls == []
-    persisted = registry.get('codex')
-    assert persisted is not None
-    assert persisted.daemon_generation == 13
-    assert persisted.reconcile_state == 'degraded'
-    assert persisted.restart_count == 2
-    assert persisted.last_reconcile_at == '2026-03-18T00:00:09Z'
-    assert SupervisionEventStore(layout).read_all() == []
 
 
 def test_runtime_supervision_loop_applies_mount_failure_backoff(tmp_path: Path, monkeypatch) -> None:

--- a/test/test_v2_tmux_ui.py
+++ b/test/test_v2_tmux_ui.py
@@ -91,6 +91,9 @@ def test_apply_project_tmux_ui_sets_session_theme_and_hook_from_current_install_
     assert ['set-window-option', '-t', 'ccb-demo', 'pane-border-status', 'top'] in calls
     assert ['set-window-option', '-t', 'ccb-demo', 'pane-border-style', 'fg=#3b4261,bold'] in calls
     assert ['set-window-option', '-t', 'ccb-demo', 'pane-active-border-style', 'fg=#7aa2f7,bold'] in calls
+    assert ['set-window-option', '-t', 'ccb-demo', 'automatic-rename', 'off'] in calls
+    assert ['set-window-option', '-t', 'ccb-demo', 'allow-rename', 'off'] in calls
+    assert ['set-window-option', '-t', 'ccb-demo', 'allow-set-title', 'off'] in calls
     assert any(
         call[:4] == ['set-window-option', '-t', 'ccb-demo', 'pane-border-format']
         for call in calls


### PR DESCRIPTION
Keep CCB pane titles stable by disabling tmux title overrides and start the cmd pane with the user's login shell before falling back to bash.