### PR TITLE
fix: 修复ghostty终端下包装脚本的TERM变量设置

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1232,6 +1232,9 @@ write_managed_venv_python_wrapper() {
   clear_installed_path "$destination_path"
   cat > "$destination_path" <<EOF
 #!/usr/bin/env bash
+if [[ "\${TERM:-}" == "xterm-ghostty" ]]; then
+  export TERM=xterm-256color
+fi
 exec "$venv_python" "$absolute_source" "\$@"
 EOF
   chmod +x "$destination_path" 2>/dev/null || true

--- a/test/test_install_watchdog_optional.py
+++ b/test/test_install_watchdog_optional.py
@@ -163,8 +163,11 @@ def test_release_managed_venv_wraps_installed_python_entrypoints(tmp_path: Path)
 
     wrapper = tmp_path / "bin" / "ccb"
     ask_wrapper = tmp_path / "bin" / "ask"
-    assert wrapper.read_text(encoding="utf-8").startswith("#!/usr/bin/env bash")
-    assert str(tmp_path / "install" / ".venv" / "bin" / "python") in wrapper.read_text(encoding="utf-8")
+    wrapper_text = wrapper.read_text(encoding="utf-8")
+    assert wrapper_text.startswith("#!/usr/bin/env bash")
+    assert '[[ "${TERM:-}" == "xterm-ghostty" ]]' in wrapper_text
+    assert "export TERM=xterm-256color" in wrapper_text
+    assert str(tmp_path / "install" / ".venv" / "bin" / "python") in wrapper_text
     assert str(tmp_path / "install" / ".venv" / "bin" / "python") in ask_wrapper.read_text(encoding="utf-8")
 
 


### PR DESCRIPTION
在生成的虚拟环境包装脚本中添加条件检查，当TERM环境变量为"xterm-ghostty"时，将其设置为"xterm-256color"。这解决了ghostty终端模拟器与某些应用程序的兼容性问题。

同时更新相关测试用例，验证包装脚本中包含了正确的TERM变量处理逻辑。