### PR TITLE
Fix macOS Claude keychain preference projection

### DIFF
--- a/lib/provider_backends/claude/launcher_runtime/home.py
+++ b/lib/provider_backends/claude/launcher_runtime/home.py
@@ -181,6 +181,7 @@ def _prepare_managed_home(
         )
 
     _materialize_settings(source_home, target_layout, profile=profile)
+    _materialize_macos_keychain_preferences(source_home, target_layout, profile=profile)
     _materialize_auth(source_home, target_layout, profile=profile)
     _materialize_trust(source_home, target_layout, profile=profile)
     return _materialize_inherited_assets(
@@ -448,6 +449,19 @@ def _materialize_auth(source_home: Path, target_layout: ClaudeHomeLayout, *, pro
         if source_auth.is_file():
             _sync_file(source_auth, target_auth)
     _materialize_macos_keychain_auth(target_layout)
+
+
+def _materialize_macos_keychain_preferences(source_home: Path, target_layout: ClaudeHomeLayout, *, profile) -> None:
+    target = target_layout.home_root / 'Library' / 'Preferences' / 'com.apple.security.plist'
+    if not _inherits_auth(profile):
+        _remove_file(target)
+        return
+    if platform.system() != 'Darwin':
+        return
+    _sync_file(
+        source_home / 'Library' / 'Preferences' / 'com.apple.security.plist',
+        target,
+    )
 
 
 def _projected_claude_json_payload(

--- a/test/test_provider_profiles.py
+++ b/test/test_provider_profiles.py
@@ -957,6 +957,69 @@ def test_materialize_claude_home_config_projects_macos_keychain_login_auth(
     ]
 
 
+def test_materialize_claude_home_config_projects_macos_keychain_preferences(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source_home = tmp_path / 'system-home'
+    target_home = tmp_path / 'managed-home'
+    source_plist = source_home / 'Library' / 'Preferences' / 'com.apple.security.plist'
+    source_plist.parent.mkdir(parents=True, exist_ok=True)
+    source_plist.write_text(
+        '<plist><dict><key>DefaultKeychain</key><array/></dict></plist>\n',
+        encoding='utf-8',
+    )
+
+    monkeypatch.setattr(claude_home_runtime.platform, 'system', lambda: 'Darwin')
+
+    materialize_claude_home_config(target_home, source_home=source_home)
+
+    target_plist = target_home / 'Library' / 'Preferences' / 'com.apple.security.plist'
+    assert target_plist.read_text(encoding='utf-8') == source_plist.read_text(encoding='utf-8')
+
+
+def test_materialize_claude_home_config_does_not_copy_keychain_preferences_on_non_darwin(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source_home = tmp_path / 'system-home'
+    target_home = tmp_path / 'managed-home'
+    source_plist = source_home / 'Library' / 'Preferences' / 'com.apple.security.plist'
+    source_plist.parent.mkdir(parents=True, exist_ok=True)
+    source_plist.write_text('<plist/>\n', encoding='utf-8')
+
+    monkeypatch.setattr(claude_home_runtime.platform, 'system', lambda: 'Linux')
+
+    materialize_claude_home_config(target_home, source_home=source_home)
+
+    target_plist = target_home / 'Library' / 'Preferences' / 'com.apple.security.plist'
+    assert not target_plist.exists()
+
+
+def test_materialize_claude_home_config_removes_keychain_preferences_when_auth_not_inherited(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source_home = tmp_path / 'system-home'
+    target_home = tmp_path / 'managed-home'
+    source_plist = source_home / 'Library' / 'Preferences' / 'com.apple.security.plist'
+    target_plist = target_home / 'Library' / 'Preferences' / 'com.apple.security.plist'
+    source_plist.parent.mkdir(parents=True, exist_ok=True)
+    target_plist.parent.mkdir(parents=True, exist_ok=True)
+    source_plist.write_text('<plist><dict><key>DefaultKeychain</key><array/></dict></plist>\n', encoding='utf-8')
+    target_plist.write_text('<plist><dict><key>OldKeychain</key><array/></dict></plist>\n', encoding='utf-8')
+
+    monkeypatch.setattr(claude_home_runtime.platform, 'system', lambda: 'Darwin')
+
+    materialize_claude_home_config(
+        target_home,
+        profile=ProviderProfileSpec(inherit_auth=False, inherit_api=False),
+        source_home=source_home,
+    )
+
+    assert not target_plist.exists()
+
+
 def test_materialize_claude_home_config_falls_back_to_legacy_macos_keychain_service(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## Summary

Managed Claude homes on macOS need the user's Security framework keychain preference plist in order for `security default-keychain` to resolve the login keychain from inside the isolated `HOME`.

This change projects `Library/Preferences/com.apple.security.plist` into Claude managed homes when auth inheritance is enabled, skips the projection on non-Darwin platforms, and removes stale plist state when `inherit_auth=False`.

## Root cause

CCB already inherited Claude auth material such as `.credentials.json`, and v6.1.6 added Keychain lookup for `Claude Code-credentials`, but the managed `HOME` did not receive the macOS Security preference plist that defines the default/search keychain. In a fresh managed Claude home, `security default-keychain` therefore failed with:

```text
security: SecKeychainCopyDefault: A default keychain could not be found.
```

## Tests

```text
pytest -q test/test_provider_profiles.py
53 passed in 0.87s
```

Also checked the patch with `git diff --check`.
