### PR TITLE
Handle macOS Claude keychain fallback without security plist

### DIFF
--- a/lib/provider_backends/claude/launcher_runtime/home.py
+++ b/lib/provider_backends/claude/launcher_runtime/home.py
@@ -453,15 +453,44 @@ def _materialize_auth(source_home: Path, target_layout: ClaudeHomeLayout, *, pro
 
 def _materialize_macos_keychain_preferences(source_home: Path, target_layout: ClaudeHomeLayout, *, profile) -> None:
     target = target_layout.home_root / 'Library' / 'Preferences' / 'com.apple.security.plist'
+    target_keychains = target_layout.home_root / 'Library' / 'Keychains'
     if not _inherits_auth(profile):
         _remove_file(target)
+        _remove_keychains_link(target_keychains)
         return
     if platform.system() != 'Darwin':
         return
-    _sync_file(
-        source_home / 'Library' / 'Preferences' / 'com.apple.security.plist',
-        target,
-    )
+    source = source_home / 'Library' / 'Preferences' / 'com.apple.security.plist'
+    if source.is_file():
+        _sync_file(source, target)
+        return
+    _remove_file(target)
+    _materialize_macos_keychains_link(source_home / 'Library' / 'Keychains', target_keychains)
+
+
+def _materialize_macos_keychains_link(source: Path, target: Path) -> None:
+    if not source.is_dir():
+        _remove_keychains_link(target)
+        return
+    try:
+        if target.is_symlink():
+            if target.resolve() == source.resolve():
+                return
+            target.unlink()
+        elif target.exists():
+            return
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.symlink_to(source, target_is_directory=True)
+    except Exception:
+        pass
+
+
+def _remove_keychains_link(path: Path) -> None:
+    try:
+        if path.is_symlink():
+            path.unlink()
+    except Exception:
+        pass
 
 
 def _projected_claude_json_payload(

--- a/test/test_provider_profiles.py
+++ b/test/test_provider_profiles.py
@@ -1271,6 +1271,24 @@ def test_materialize_claude_home_config_projects_macos_keychain_preferences(
     assert target_plist.read_text(encoding='utf-8') == source_plist.read_text(encoding='utf-8')
 
 
+def test_materialize_claude_home_config_projects_macos_keychains_when_preferences_absent(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source_home = tmp_path / 'system-home'
+    target_home = tmp_path / 'managed-home'
+    source_keychains = source_home / 'Library' / 'Keychains'
+    source_keychains.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(claude_home_runtime.platform, 'system', lambda: 'Darwin')
+
+    materialize_claude_home_config(target_home, source_home=source_home)
+
+    target_keychains = target_home / 'Library' / 'Keychains'
+    assert target_keychains.is_symlink()
+    assert target_keychains.resolve() == source_keychains.resolve()
+
+
 def test_materialize_claude_home_config_does_not_copy_keychain_preferences_on_non_darwin(
     tmp_path: Path,
     monkeypatch,
@@ -1311,6 +1329,30 @@ def test_materialize_claude_home_config_removes_keychain_preferences_when_auth_n
     )
 
     assert not target_plist.exists()
+
+
+def test_materialize_claude_home_config_removes_macos_keychains_when_auth_not_inherited(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source_home = tmp_path / 'system-home'
+    target_home = tmp_path / 'managed-home'
+    source_keychains = source_home / 'Library' / 'Keychains'
+    target_keychains = target_home / 'Library' / 'Keychains'
+    source_keychains.mkdir(parents=True, exist_ok=True)
+    target_keychains.parent.mkdir(parents=True, exist_ok=True)
+    os.symlink(source_keychains, target_keychains)
+
+    monkeypatch.setattr(claude_home_runtime.platform, 'system', lambda: 'Darwin')
+
+    materialize_claude_home_config(
+        target_home,
+        profile=ProviderProfileSpec(inherit_auth=False, inherit_api=False),
+        source_home=source_home,
+    )
+
+    assert not target_keychains.exists()
+    assert not target_keychains.is_symlink()
 
 
 def test_materialize_claude_home_config_falls_back_to_legacy_macos_keychain_service(


### PR DESCRIPTION
This keeps the existing macOS `com.apple.security.plist` projection behavior when the file exists, but falls back to linking `~/Library/Keychains` into the managed Claude HOME when the plist is absent.

On some macOS setups, `~/Library/Preferences/com.apple.security.plist` does not exist, and `security default-keychain` inside the managed HOME cannot resolve the user's login keychain unless `Library/Keychains` is projected.

Also removes the projected Keychains symlink when `inherit_auth = false`.

Validation:
- Added coverage for macOS fallback to `Library/Keychains` when security plist is absent.
- Added cleanup coverage when auth inheritance is disabled.
- Ran provider profile tests and full test suite locally.