### PR TITLE
Fix stale terminal task request mailbox recovery

### DIFF
--- a/lib/message_bureau/control_queue_runtime/ack.py
+++ b/lib/message_bureau/control_queue_runtime/ack.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from mailbox_kernel import InboundEventType
+from mailbox_kernel import InboundEventStatus, InboundEventType
+from message_bureau.models import AttemptState
 from message_bureau.reply_metadata import (
     reply_heartbeat_silence_seconds,
     reply_last_progress_at,
@@ -13,10 +14,24 @@ from .common import require_mailbox_target
 from .events import pending_event_records, reply_for_event
 from .views import agent_queue
 
+TERMINAL_ATTEMPT_STATES = frozenset(
+    {
+        AttemptState.COMPLETED,
+        AttemptState.INCOMPLETE,
+        AttemptState.FAILED,
+        AttemptState.CANCELLED,
+        AttemptState.SUPERSEDED,
+        AttemptState.DEAD_LETTER,
+    }
+)
+
 
 def ack_reply(service, agent_name: str, inbound_event_id: str | None = None) -> dict[str, object]:
     normalized = require_mailbox_target(service, agent_name)
-    head = _head_reply_event(service, normalized, inbound_event_id=inbound_event_id)
+    head = _head_event(service, normalized, inbound_event_id=inbound_event_id)
+    if head.event_type is InboundEventType.TASK_REQUEST:
+        return _ack_terminal_task_request(service, normalized, head)
+
     reply = reply_for_event(service, head)
     if reply is None:
         raise ValueError(f'reply record missing for inbound event: {head.inbound_event_id}')
@@ -49,17 +64,31 @@ def ack_reply(service, agent_name: str, inbound_event_id: str | None = None) -> 
     )
 
 
-def _head_reply_event(service, agent_name: str, *, inbound_event_id: str | None):
+def _head_event(service, agent_name: str, *, inbound_event_id: str | None):
+    direct_head = service._mailbox_kernel.head_pending_event(agent_name)
+    requested_event_id = str(inbound_event_id or '').strip() or (
+        direct_head.inbound_event_id if direct_head is not None else ''
+    )
+    if direct_head is not None and direct_head.inbound_event_id == requested_event_id:
+        if direct_head.event_type is InboundEventType.TASK_REPLY:
+            return _validate_reply_head(direct_head)
+        if direct_head.event_type is InboundEventType.TASK_REQUEST:
+            return direct_head
+
     records = pending_event_records(service, agent_name)
     head = records[0] if records else None
     if head is None:
         raise ValueError(f'inbox is empty for agent: {agent_name}')
-    requested_event_id = str(inbound_event_id or '').strip() or head.inbound_event_id
+    requested_event_id = requested_event_id or head.inbound_event_id
     if head.inbound_event_id != requested_event_id:
         raise ValueError(f'ack requires head event: {head.inbound_event_id}')
+    return _validate_reply_head(head)
+
+
+def _validate_reply_head(head):
     if head.event_type is not InboundEventType.TASK_REPLY:
         raise ValueError(
-            f'ack only supports task_reply head events; found: {head.event_type.value}'
+            f'ack only supports task_reply or terminal task_request head events; found: {head.event_type.value}'
         )
     delivery_job_id = delivery_job_id_from_payload(head.payload_ref)
     if delivery_job_id:
@@ -68,6 +97,56 @@ def _head_reply_event(service, agent_name: str, *, inbound_event_id: str | None)
             f'{delivery_job_id}'
         )
     return head
+
+
+def _ack_terminal_task_request(service, agent_name: str, head) -> dict[str, object]:
+    attempt = service._attempt_store.get_latest(head.attempt_id) if head.attempt_id else None
+    if attempt is not None and attempt.attempt_state not in TERMINAL_ATTEMPT_STATES:
+        raise ValueError(
+            'ack only supports terminal task_request head events; '
+            f'found attempt_state={attempt.attempt_state.value}'
+        )
+
+    timestamp = service._clock()
+    if attempt is not None and attempt.attempt_state is AttemptState.CANCELLED and head.status in {
+        InboundEventStatus.CREATED,
+        InboundEventStatus.QUEUED,
+    }:
+        consumed = service._mailbox_kernel.abandon(
+            agent_name,
+            head.inbound_event_id,
+            finished_at=timestamp,
+        )
+    else:
+        consumed = service._mailbox_kernel.consume(
+            agent_name,
+            head.inbound_event_id,
+            finished_at=timestamp,
+        )
+    if consumed is None:
+        raise RuntimeError(f'failed to ack task_request event: {head.inbound_event_id}')
+
+    mailbox_payload = agent_queue(service, agent_name)
+    next_records = pending_event_records(service, agent_name)
+    next_head = service._mailbox_kernel.head_pending_event(agent_name)
+    if next_head is None or (
+        next_records and all(record.inbound_event_id != next_head.inbound_event_id for record in next_records)
+    ):
+        next_head = next_records[0] if next_records else None
+    return {
+        'target': agent_name,
+        'agent_name': agent_name,
+        'acknowledged_inbound_event_id': consumed.inbound_event_id,
+        'acknowledged_event_type': consumed.event_type.value,
+        'message_id': consumed.message_id,
+        'attempt_id': consumed.attempt_id,
+        'job_id': attempt.job_id if attempt is not None else None,
+        'attempt_state': attempt.attempt_state.value if attempt is not None else None,
+        'next_inbound_event_id': next_head.inbound_event_id if next_head is not None else None,
+        'next_event_type': next_head.event_type.value if next_head is not None else None,
+        'mailbox': mailbox_payload,
+        'reply': '',
+    }
 
 
 def _reply_attempt(service, head):

--- a/lib/message_bureau/control_queue_runtime/events.py
+++ b/lib/message_bureau/control_queue_runtime/events.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from mailbox_kernel import InboundEventStatus, InboundEventType
+from message_bureau.models import AttemptState
 from message_bureau.reply_metadata import (
     reply_heartbeat_silence_seconds,
     reply_last_progress_at,
@@ -16,6 +17,16 @@ TERMINAL_EVENT_STATES = frozenset(
         InboundEventStatus.CONSUMED,
         InboundEventStatus.SUPERSEDED,
         InboundEventStatus.ABANDONED,
+    }
+)
+TERMINAL_ATTEMPT_STATES = frozenset(
+    {
+        AttemptState.COMPLETED,
+        AttemptState.INCOMPLETE,
+        AttemptState.FAILED,
+        AttemptState.CANCELLED,
+        AttemptState.SUPERSEDED,
+        AttemptState.DEAD_LETTER,
     }
 )
 
@@ -60,8 +71,11 @@ def _event_is_live(service, event) -> bool:
     message = service._message_store.get_latest(event.message_id)
     if message is None:
         return False
-    if event.attempt_id and service._attempt_store.get_latest(event.attempt_id) is None:
+    attempt = service._attempt_store.get_latest(event.attempt_id) if event.attempt_id else None
+    if event.attempt_id and attempt is None:
         return False
+    if event.event_type is InboundEventType.TASK_REQUEST and attempt is not None:
+        return attempt.attempt_state not in TERMINAL_ATTEMPT_STATES
     if event.event_type is InboundEventType.TASK_REPLY and reply_for_event(service, event) is None:
         return False
     return True

--- a/test/test_v2_message_bureau_dispatcher_integration.py
+++ b/test/test_v2_message_bureau_dispatcher_integration.py
@@ -2055,6 +2055,88 @@ def test_dispatcher_ack_reply_unblocks_next_task_request_after_tick(tmp_path: Pa
     assert queue['agent']['active']['job_id'] == blocked_job_id
 
 
+def test_dispatcher_ack_clears_terminal_task_request_head(tmp_path: Path) -> None:
+    project_root = tmp_path / 'repo-ack-terminal-task-request'
+    ctx = _bootstrap_test_project(project_root)
+    layout = PathLayout(project_root)
+    config = _provider_config('codex', 'claude')
+    registry = AgentRegistry(layout, config)
+    registry.upsert(_runtime('claude', project_id=ctx.project_id, layout=layout, pid=102))
+    dispatcher = JobDispatcher(layout, config, registry, clock=lambda: '2026-03-30T00:00:00Z')
+
+    receipt = dispatcher.submit(
+        MessageEnvelope(
+            project_id=ctx.project_id,
+            to_agent='claude',
+            from_actor='user',
+            body='stale task request',
+            task_id='task-stale-request',
+            reply_to=None,
+            message_type='ask',
+            delivery_scope=DeliveryScope.SINGLE,
+        )
+    )
+    job_id = receipt.jobs[0].job_id
+    dispatcher.tick()
+    attempt = dispatcher._message_bureau._attempt_store.get_latest_by_job_id(job_id)
+    assert attempt is not None
+    dispatcher._message_bureau._attempt_store.append(
+        replace(attempt, attempt_state=AttemptState.INCOMPLETE, updated_at='2026-03-30T00:00:05Z')
+    )
+
+    acked = dispatcher.ack_reply('claude')
+
+    assert acked['acknowledged_event_type'] == 'task_request'
+    assert acked['attempt_state'] == 'incomplete'
+    assert acked['job_id'] == job_id
+    queue = dispatcher.queue('claude', detail=True)
+    assert queue['agent']['mailbox_state'] == 'idle'
+    assert queue['agent']['queue_depth'] == 0
+    assert queue['agent']['active_inbound_event_id'] is None
+    latest = InboundEventStore(layout).get_latest_for_attempt('claude', attempt.attempt_id)
+    assert latest is not None
+    assert latest.status is InboundEventStatus.CONSUMED
+
+
+def test_dispatcher_queue_summary_discards_stale_terminal_task_request_head(tmp_path: Path) -> None:
+    project_root = tmp_path / 'repo-discard-terminal-task-request'
+    ctx = _bootstrap_test_project(project_root)
+    layout = PathLayout(project_root)
+    config = _provider_config('codex', 'claude')
+    registry = AgentRegistry(layout, config)
+    registry.upsert(_runtime('claude', project_id=ctx.project_id, layout=layout, pid=102))
+    dispatcher = JobDispatcher(layout, config, registry, clock=lambda: '2026-03-30T00:00:00Z')
+
+    receipt = dispatcher.submit(
+        MessageEnvelope(
+            project_id=ctx.project_id,
+            to_agent='claude',
+            from_actor='user',
+            body='auto discard stale request',
+            task_id='task-auto-discard',
+            reply_to=None,
+            message_type='ask',
+            delivery_scope=DeliveryScope.SINGLE,
+        )
+    )
+    job_id = receipt.jobs[0].job_id
+    dispatcher.tick()
+    attempt = dispatcher._message_bureau._attempt_store.get_latest_by_job_id(job_id)
+    assert attempt is not None
+    dispatcher._message_bureau._attempt_store.append(
+        replace(attempt, attempt_state=AttemptState.INCOMPLETE, updated_at='2026-03-30T00:00:05Z')
+    )
+
+    queue = dispatcher.queue('claude', detail=True)
+
+    assert queue['agent']['mailbox_state'] == 'idle'
+    assert queue['agent']['queue_depth'] == 0
+    assert queue['agent']['active_inbound_event_id'] is None
+    latest = InboundEventStore(layout).get_latest_for_attempt('claude', attempt.attempt_id)
+    assert latest is not None
+    assert latest.status is InboundEventStatus.ABANDONED
+
+
 def test_dispatcher_pending_reply_on_one_agent_does_not_block_other_agent_start(tmp_path: Path) -> None:
     project_root = tmp_path / 'repo-multi-agent-mailbox-isolation'
     ctx = _bootstrap_test_project(project_root)


### PR DESCRIPTION
## Summary

- Treat task_request inbox events whose attempts are already terminal as stale, so queue views discard them instead of leaving the mailbox stuck in delivering.
- Extend ack/repair ack to clear terminal task_request heads while still rejecting active task_request events.
- Add dispatcher/mailbox regression coverage for manual recovery and automatic stale-head cleanup.

## Why

A pane-backed provider can stop or fail after a job/attempt has become terminal while the mailbox head still points at a delivering task_request. In that state the agent appears busy, the delivery lease remains held, and later messages cannot drain normally. Existing repair ack only handled task_reply heads, so there was no direct recovery command for this stale task_request state.

## Validation

- `python3 -m compileall -q lib/message_bureau/control_queue_runtime/ack.py lib/message_bureau/control_queue_runtime/events.py test/test_v2_message_bureau_dispatcher_integration.py`
- `.venv/bin/python -m pytest -q test/test_v2_message_bureau_dispatcher_integration.py -k 'ack_clears_terminal_task_request or queue_summary_discards_stale_terminal_task_request or inbox_exposes_head_reply_body or ack_reply_unblocks_next_task_request'`
  - `4 passed, 35 deselected`
- `.venv/bin/python -m pytest -q test/test_v2_message_bureau_dispatcher_integration.py`
  - `39 passed`
- Manual dispatcher/mailbox smoke script covering:
  - ack clears a terminal task_request head and returns mailbox to idle
  - queue summary discards a stale terminal task_request head as abandoned