### PR TITLE
fix: support dict and list[dict] values in TOML renderers

### DIFF
--- a/lib/agents/config_loader_runtime/defaults_runtime/rendering_runtime/service.py
+++ b/lib/agents/config_loader_runtime/defaults_runtime/rendering_runtime/service.py
@@ -39,9 +39,11 @@ def _render_toml_mapping(
     mapping: dict[str, object],
     *,
     emit_header: bool,
+    is_array: bool = False,
 ) -> None:
     scalar_items: list[tuple[str, object]] = []
     table_items: list[tuple[str, dict[str, object]]] = []
+    array_items: list[tuple[str, list[dict[str, object]]]] = []
     for key, value in mapping.items():
         if value is None:
             continue
@@ -49,17 +51,23 @@ def _render_toml_mapping(
             if not value:
                 continue
             table_items.append((key, value))
+        elif isinstance(value, list) and value and all(isinstance(item, dict) for item in value):
+            array_items.append((key, value))
         else:
             scalar_items.append((key, value))
 
-    if emit_header and (scalar_items or not table_items):
+    if emit_header and (is_array or scalar_items or not table_items and not array_items):
         if lines:
             lines.append('')
-        lines.append(f'[{_render_toml_path(path)}]')
+        header = f'[[{_render_toml_path(path)}]]' if is_array else f'[{_render_toml_path(path)}]'
+        lines.append(header)
     for key, value in scalar_items:
         lines.append(f'{_render_toml_key(key)} = {_render_toml_value(value)}')
     for key, value in table_items:
         _render_toml_mapping(lines, (*path, key), value, emit_header=True)
+    for key, items in array_items:
+        for item in items:
+            _render_toml_mapping(lines, (*path, key), item, emit_header=True, is_array=True)
 
 
 def _render_toml_path(path: tuple[str, ...]) -> str:
@@ -79,6 +87,14 @@ def _render_toml_value(value: object) -> str:
         return json.dumps(value, ensure_ascii=False)
     if isinstance(value, list):
         return '[' + ', '.join(_render_toml_value(item) for item in value) + ']'
+    if isinstance(value, dict):
+        if not value:
+            return '{}'
+        pairs = ', '.join(
+            f'{_render_toml_key(k)} = {_render_toml_value(v)}'
+            for k, v in value.items()
+        )
+        return '{ ' + pairs + ' }'
     raise TypeError(f'unsupported TOML value type: {type(value).__name__}')
 
 

--- a/lib/provider_profiles/codex_home_config.py
+++ b/lib/provider_profiles/codex_home_config.py
@@ -791,10 +791,11 @@ def _render_toml_document(payload: dict[str, object]) -> str:
     return f'{rendered}\n' if rendered else ''
 
 
-def _render_toml_sections(payload: dict[str, object], *, path: tuple[str, ...]) -> list[str]:
+def _render_toml_sections(payload: dict[str, object], *, path: tuple[str, ...] = (), is_array: bool = False) -> list[str]:
     scalar_lines: list[str] = []
     child_sections: list[str] = []
     child_tables: list[tuple[str, dict[str, object]]] = []
+    array_tables: list[tuple[str, list[dict[str, object]]]] = []
     for raw_key, value in payload.items():
         key = str(raw_key)
         if value is None:
@@ -802,20 +803,26 @@ def _render_toml_sections(payload: dict[str, object], *, path: tuple[str, ...]) 
         if isinstance(value, dict):
             child_tables.append((key, value))
             continue
+        if isinstance(value, list) and value and all(isinstance(item, dict) for item in value):
+            array_tables.append((key, value))
+            continue
         scalar_lines.append(f'{_render_toml_key(key)} = {_render_toml_value(value)}')
 
     sections: list[str] = []
     if path:
-        header = f'[{_render_toml_path(path)}]'
-        if scalar_lines:
+        header = f'[[{_render_toml_path(path)}]]' if is_array else f'[{_render_toml_path(path)}]'
+        if is_array or scalar_lines:
             sections.append('\n'.join([header, *scalar_lines]))
-        elif not child_tables:
+        elif not child_tables and not array_tables:
             sections.append(header)
     elif scalar_lines:
         sections.append('\n'.join(scalar_lines))
 
     for key, child in child_tables:
         child_sections.extend(_render_toml_sections(child, path=(*path, key)))
+    for key, items in array_tables:
+        for item in items:
+            child_sections.extend(_render_toml_sections(item, path=(*path, key), is_array=True))
     sections.extend(child_sections)
     return sections
 
@@ -845,6 +852,14 @@ def _render_toml_value(value: object) -> str:
         return value.isoformat()
     if isinstance(value, (list, tuple)):
         return '[' + ', '.join(_render_toml_value(item) for item in value) + ']'
+    if isinstance(value, dict):
+        if not value:
+            return '{}'
+        pairs = ', '.join(
+            f'{_render_toml_key(k)} = {_render_toml_value(v)}'
+            for k, v in value.items()
+        )
+        return '{ ' + pairs + ' }'
     raise TypeError(f'unsupported TOML value type: {type(value).__name__}')
 
 

--- a/test/test_provider_profiles.py
+++ b/test/test_provider_profiles.py
@@ -4,6 +4,7 @@ import json
 import os
 from pathlib import Path
 import shutil
+import tomllib
 
 import pytest
 
@@ -2335,3 +2336,93 @@ def test_materialize_gemini_home_config_skips_memory_without_project_context(tmp
     layout = materialize_gemini_home_config(target_home, source_home=source_home)
 
     assert not (layout.gemini_dir / 'GEMINI.md').exists()
+
+
+def test_render_toml_value_handles_dict_inline_table() -> None:
+    from provider_profiles.codex_home_config import _render_toml_value
+    result = _render_toml_value({'name': 'test', 'enabled': False})
+    assert result == '{ name = "test", enabled = false }'
+
+
+def test_render_toml_value_handles_empty_dict() -> None:
+    from provider_profiles.codex_home_config import _render_toml_value
+    result = _render_toml_value({})
+    assert result == '{}'
+
+
+def test_render_toml_value_handles_dict_in_mixed_list() -> None:
+    from provider_profiles.codex_home_config import _render_toml_value
+    result = _render_toml_value(['literal', {'name': 'test'}])
+    assert result == '["literal", { name = "test" }]'
+
+
+def test_render_toml_sections_handles_array_of_tables() -> None:
+    from provider_profiles.codex_home_config import _render_toml_sections
+    payload = {
+        'skills': {
+            'config': [
+                {'path': '/a/skill.md', 'enabled': False},
+                {'name': 'plugin:skill', 'enabled': True},
+            ]
+        }
+    }
+    sections = _render_toml_sections(payload)
+    rendered = '\n\n'.join(sections)
+    assert '[[skills.config]]' in rendered
+    assert 'path = "/a/skill.md"' in rendered
+    assert 'enabled = false' in rendered
+    assert 'name = "plugin:skill"' in rendered
+    assert 'enabled = true' in rendered
+
+
+def test_render_toml_sections_handles_array_of_tables_with_only_child_tables() -> None:
+    from provider_profiles.codex_home_config import _render_toml_document
+    payload = {
+        'items': [
+            {'child': {'x': 1}},
+            {'child': {'x': 2}},
+        ]
+    }
+    rendered = _render_toml_document(payload)
+    assert tomllib.loads(rendered) == {
+        'items': [
+            {'child': {'x': 1}},
+            {'child': {'x': 2}},
+        ]
+    }
+
+
+def test_materialize_codex_home_config_with_skills_config_array(tmp_path: Path) -> None:
+    source_home = tmp_path / 'codex-home'
+    target_home = tmp_path / 'target-home'
+    source_home.mkdir(parents=True, exist_ok=True)
+    (source_home / 'config.toml').write_text(
+        'model = "gpt-5.5"\n'
+        '\n'
+        '[[skills.config]]\n'
+        'path = "/a/skill.md"\n'
+        'enabled = false\n'
+        '\n'
+        '[[skills.config]]\n'
+        'name = "plugin:other"\n'
+        'enabled = true\n'
+        '\n'
+        '[features]\n'
+        'unified_exec = true\n',
+        encoding='utf-8',
+    )
+
+    codex_home_config.materialize_codex_home_config(
+        target_home,
+        source_home=source_home,
+    )
+
+    text = (target_home / 'config.toml').read_text(encoding='utf-8')
+    assert '[[skills.config]]' in text
+    assert 'path = "/a/skill.md"' in text
+    assert 'name = "plugin:other"' in text
+    parsed = tomllib.loads(text)
+    assert parsed['skills']['config'] == [
+        {'path': '/a/skill.md', 'enabled': False},
+        {'name': 'plugin:other', 'enabled': True},
+    ]

--- a/test/test_v2_config_loader.py
+++ b/test/test_v2_config_loader.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import tomllib
 
 import pytest
 
@@ -1069,3 +1070,54 @@ def test_load_project_config_reports_actionable_error_when_hybrid_overlay_parser
 
     with pytest.raises(ConfigValidationError, match='rich TOML config requires Python 3.11\\+'):
         load_project_config(project_root)
+
+
+def test_render_toml_value_service_handles_dict_inline_table() -> None:
+    from agents.config_loader_runtime.defaults_runtime.rendering_runtime.service import _render_toml_value
+    result = _render_toml_value({'key': 'val', 'count': 3})
+    assert result == '{ key = "val", count = 3 }'
+
+
+def test_render_toml_value_service_handles_empty_dict() -> None:
+    from agents.config_loader_runtime.defaults_runtime.rendering_runtime.service import _render_toml_value
+    result = _render_toml_value({})
+    assert result == '{}'
+
+
+def test_render_toml_value_service_handles_dict_in_mixed_list() -> None:
+    from agents.config_loader_runtime.defaults_runtime.rendering_runtime.service import _render_toml_value
+    result = _render_toml_value(['literal', {'key': 'val'}])
+    assert result == '["literal", { key = "val" }]'
+
+
+def test_render_toml_mapping_handles_array_of_tables() -> None:
+    from agents.config_loader_runtime.defaults_runtime.rendering_runtime.service import _render_toml_document
+    payload = {
+        'items': [
+            {'name': 'first', 'value': 1},
+            {'name': 'second', 'value': 2},
+        ]
+    }
+    rendered = _render_toml_document(payload)
+    assert '[[items]]' in rendered
+    assert 'name = "first"' in rendered
+    assert 'value = 1' in rendered
+    assert 'name = "second"' in rendered
+    assert 'value = 2' in rendered
+
+
+def test_render_toml_mapping_handles_array_of_tables_with_only_child_tables() -> None:
+    from agents.config_loader_runtime.defaults_runtime.rendering_runtime.service import _render_toml_document
+    payload = {
+        'items': [
+            {'child': {'x': 1}},
+            {'child': {'x': 2}},
+        ]
+    }
+    rendered = _render_toml_document(payload)
+    assert tomllib.loads(rendered) == {
+        'items': [
+            {'child': {'x': 1}},
+            {'child': {'x': 2}},
+        ]
+    }


### PR DESCRIPTION
## Summary

Closes #207

- Fix `unsupported TOML value type: dict` crash when user's `~/.codex/config.toml` contains TOML array-of-tables (e.g. `[[skills.config]]`)
- Add `list[dict]` → `[[section]]` (TOML array-of-tables) support in both rendering paths
- Add `dict` → inline table `{ key = val }` fallback in `_render_toml_value`
- Affects `codex_home_config._render_toml_sections` and `config_loader._render_toml_mapping`

## Test plan

- [x] 136 tests passing (0 regressions)
- [x] New unit tests: dict inline table, empty dict, array-of-tables, mixed list
- [x] E2E test: `materialize_codex_home_config` with `[[skills.config]]` source config
- [ ] Manual: run `ccb` with `[[skills.config]]` entries in `~/.codex/config.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)