### PR TITLE
加固源码安装和 provider 启动恢复逻辑

### DIFF
--- a/docs/install-runtime-environment-fix-analysis.md
+++ b/docs/install-runtime-environment-fix-analysis.md
@@ -1,0 +1,754 @@
+# CCB 安装与运行环境问题修复分析文档
+
+本文档说明 CCB 在 macOS、Volta、多 Python 环境下安装后出现启动失败、命令路径漂移、Claude/Codex agent 启动不一致等问题的前因后果，并给出可执行的修复方案和验收标准。
+
+本文档不依赖任何聊天上下文即可阅读。文中所有路径均来自一次真实排查环境，但结论适用于同类环境。
+
+## 1. 问题摘要
+
+在以下环境中安装 CCB：
+
+- 项目源码目录：`/Users/yuanfeijie/Desktop/project/claude_code_bridge`
+- 目标工作项目：`/Users/yuanfeijie/Desktop/procode/chat2image`
+- 系统：macOS
+- Python 环境：
+  - `/usr/bin/python3` 为 Python 3.9.6
+  - `/opt/homebrew/opt/python@3.12/libexec/bin/python` 为 Python 3.12.12
+- Node CLI 管理方式：Volta
+  - `codex` 期望走 `/Users/yuanfeijie/.volta/bin/codex`
+  - `claude` 期望走 `/Users/yuanfeijie/.volta/bin/claude`
+
+安装后出现过以下现象：
+
+- `ccb` 在 `chat2image` 中启动失败，报错为 `ccbd exited before ready with code 1`。
+- `ccbd.stderr.log` 中出现 Python 类型语法相关错误：
+
+```text
+TypeError: unsupported operand type(s) for |: '_SpecialForm' and 'NoneType'
+```
+
+- `codex` 在不同上下文中可能解析到不同安装路径，例如 Volta 路径或 Homebrew 路径。
+- `Claude Code` agent 重建后停在首次交互确认界面，导致 CCB 投递任务处于 `running` / `delivering` 状态但不返回。
+- 安装脚本中的 Droid MCP 自动注册可能卡住，使安装过程超时。
+- 新版 `ask` CLI 不再支持旧的 `--wait` 参数，旧测试命令会失败。
+
+这些问题不是单一故障，而是安装时环境检查、运行时解释器选择、PATH 继承、provider 首次确认、外部工具注册、CLI 版本迁移共同叠加导致的。
+
+## 2. 直接根因
+
+### 2.1 安装时检查的 Python 与运行时实际使用的 Python 不一致
+
+安装脚本会检查 Python 版本，真实安装日志显示：
+
+```text
+OK: Python 3.12.12 (python)
+```
+
+这表示安装脚本选中了命令名 `python`，并确认它是 Python 3.12。
+
+但是 source/dev 安装模式下，`~/.local/bin/ccb` 会作为符号链接指向源码仓库中的入口文件：
+
+```text
+~/.local/bin/ccb -> /Users/yuanfeijie/Desktop/project/claude_code_bridge/ccb
+~/.local/bin/ask -> /Users/yuanfeijie/Desktop/project/claude_code_bridge/bin/ask
+```
+
+源码入口文件使用 shebang：
+
+```python
+#!/usr/bin/env python3
+```
+
+因此用户执行 `ccb` 时，实际解释器不是安装脚本检查过的 `python`，而是重新由 `/usr/bin/env python3` 解析。
+
+在问题环境中：
+
+```text
+command -v python3 -> /usr/bin/python3
+python3 --version -> Python 3.9.6
+command -v python -> /opt/homebrew/opt/python@3.12/libexec/bin/python
+python --version -> Python 3.12.12
+```
+
+于是出现了以下断裂：
+
+```text
+安装时：python  = Python 3.12，检查通过
+运行时：python3 = Python 3.9，ccbd 崩溃
+```
+
+CCB 新版代码中使用了 Python 3.10+ 语法，例如 `A | None` 类型联合。Python 3.9 无法完整支持这些运行时类型表达式，因此 `ccbd` 在 import 阶段崩溃。
+
+### 2.2 `ccbd` 和 `keeper` 继承了错误解释器
+
+CCB 启动后会继续启动后台控制进程：
+
+- `keeper_main.py`
+- `ccbd/main.py`
+
+这两个进程不是独立选择 Python，而是通过当前 `ccb` 进程的 `sys.executable` 启动。
+
+因此如果 `ccb` 本身由 `/usr/bin/python3` 启动，那么后续 `keeper` 和 `ccbd` 也会使用 Python 3.9。
+
+这就是为什么只在安装脚本中检查 Python 不足以保证运行时正确。必须确保 `ccb` 入口本身、`keeper`、`ccbd` 三者使用同一个满足版本要求的 Python。
+
+### 2.3 source/dev 模式优先开发便利，不保证运行时闭环
+
+source/dev 模式的优点是全局命令直接链接当前源码，便于开发 CCB 本身。
+
+但它的风险是：
+
+- 入口 shebang 由源码决定。
+- 安装脚本选中的 `PYTHON_BIN` 不会写入全局 wrapper。
+- 用户 shell、tmux、后台 daemon 的 PATH 可能不同。
+- 运行时可能绕过安装时检查结果。
+
+因此 source/dev 模式适合 CCB 开发者，不适合作为多 Python macOS 用户的默认稳定安装方式。
+
+### 2.4 Volta 与 Homebrew 路径在不同进程中可能不一致
+
+用户期望：
+
+```text
+codex  -> /Users/yuanfeijie/.volta/bin/codex
+claude -> /Users/yuanfeijie/.volta/bin/claude
+```
+
+但 CCB 不只在当前交互式 shell 中执行。它还会创建：
+
+- 后台 daemon
+- tmux session
+- provider runtime
+- Claude/Codex 隔离 home
+- 多个 agent pane
+
+这些进程不一定读取用户交互式 zsh 的完整初始化文件，因此它们看到的 PATH 可能与用户手动执行 `codex` 时不同。
+
+如果某个后台上下文没有优先包含 `~/.volta/bin`，就可能解析到 Homebrew 的 `codex` 或其他旧版本 CLI。
+
+所以“安装时能查到 codex/claude”不等于“tmux agent pane 中也一定查到同一个 codex/claude”。
+
+### 2.5 Claude Code 首次确认会阻塞任务投递
+
+在重建 `.ccb` 运行态后，Claude Code 可能出现首次确认界面，例如：
+
+- 是否信任当前工作目录。
+- 是否使用当前 `ANTHROPIC_API_KEY`。
+
+如果 Claude pane 停在这些交互界面，CCB 仍可能认为 provider runtime 已经启动，但投递进去的任务不会被模型处理，表现为：
+
+```text
+job status: running
+mailbox state: delivering
+reply: empty
+```
+
+这不是 CCB 路由失败，而是 provider 处于交互确认状态。
+
+### 2.6 Droid MCP 自动注册不是核心路径，但会影响安装成功率
+
+安装脚本默认可能尝试 Droid MCP 自动注册。
+
+如果本机安装了相关命令但其注册过程卡住或不可用，安装脚本会被拖住甚至超时。
+
+对于只使用 Claude Code 和 Codex 的用户，Droid MCP 注册不是必要步骤，应当跳过或改为显式 opt-in。
+
+### 2.7 新版 `ask` CLI 已移除旧 `--wait`
+
+旧用法：
+
+```bash
+ask --wait --timeout 300 backend -- 'message'
+```
+
+新版 CLI 中 `ask` 只负责异步提交：
+
+```bash
+ask backend -- 'message'
+```
+
+等待结果应使用：
+
+```bash
+ccb wait-all --timeout 300 <job_id>
+```
+
+如果继续使用旧命令，会得到：
+
+```text
+unknown ask option: --wait
+```
+
+这是 CLI 版本迁移问题，不是安装失败。
+
+## 3. 已验证的当前稳定修复方式
+
+当前最稳的用户级修复是使用 release/managed 安装模式，而不是 source/dev symlink 安装模式。
+
+推荐安装命令：
+
+```bash
+cd /Users/yuanfeijie/Desktop/project/claude_code_bridge
+CCB_DROID_AUTOINSTALL=0 \
+CCB_SOURCE_KIND=release \
+CCB_BUILD_CHANNEL=stable \
+CCB_USE_MANAGED_VENV=1 \
+./install.sh install
+```
+
+该方式的效果：
+
+- 源码仓库保持干净，跟随 `origin/main`。
+- 全局命令安装到 `~/.local/bin`。
+- 实际代码复制到 `~/.local/share/codex-dual`。
+- 创建托管 Python venv：
+
+```text
+/Users/yuanfeijie/.local/share/codex-dual/.venv
+```
+
+- `ccb` 和 `ask` 不再是指向源码的 symlink，而是 wrapper：
+
+```bash
+exec "/Users/yuanfeijie/.local/share/codex-dual/.venv/bin/python" "/Users/yuanfeijie/.local/share/codex-dual/ccb" "$@"
+```
+
+这样即使系统默认 `python3` 仍是 Python 3.9，也不会影响 CCB 运行。
+
+### 3.1 验证安装结果
+
+执行：
+
+```bash
+command -v ccb
+command -v ask
+ccb version
+/Users/yuanfeijie/.local/share/codex-dual/.venv/bin/python --version
+```
+
+期望结果：
+
+```text
+/Users/yuanfeijie/.local/bin/ccb
+/Users/yuanfeijie/.local/bin/ask
+Install path: /Users/yuanfeijie/.local/share/codex-dual
+Install mode: release
+Install source: release
+Channel: stable
+Python 3.12.12
+```
+
+### 3.2 验证 provider CLI 路径
+
+在目标项目目录执行：
+
+```bash
+cd /Users/yuanfeijie/Desktop/procode/chat2image
+command -v codex
+codex --version
+command -v claude
+claude --version
+```
+
+期望结果：
+
+```text
+/Users/yuanfeijie/.volta/bin/codex
+codex-cli 0.130.0
+/Users/yuanfeijie/.volta/bin/claude
+2.1.120 (Claude Code)
+```
+
+### 3.3 重建项目运行态
+
+如果 `.ccb` 中存在旧运行态，先停止：
+
+```bash
+cd /Users/yuanfeijie/Desktop/procode/chat2image
+ccb kill -f
+```
+
+如需清理旧运行态并保留 `.ccb/ccb.config`，使用：
+
+```bash
+ccb -n
+```
+
+注意：`ccb -n` 会要求交互确认。它会清理 `.ccb` 下可重建运行态，但保留 `.ccb/ccb.config`。
+
+### 3.4 首次启动后处理 Claude Code 确认
+
+如果 Claude pane 停在安全确认界面，需要在 tmux 界面中确认：
+
+- 信任当前项目目录。
+- 使用预期的 API key。
+
+这一步完成后再测试任务投递。
+
+### 3.5 验证四 agent 投递
+
+新版测试方式：
+
+```bash
+job=$(ask backend -- 'CCB 自检：请只回复“backend 收到”，不要读取或修改任何文件。' | sed -n 's/^accepted job=\([^ ]*\).*/\1/p')
+ccb wait-all --timeout 300 "$job"
+ask get "$job"
+```
+
+对 `backend`、`review`、`lead`、`design` 分别执行。
+
+期望结果：
+
+```text
+backend -> backend 收到
+review  -> review 收到
+lead    -> lead 收到
+design  -> design 收到
+```
+
+最终队列应为空：
+
+```bash
+ccb pend --queue --detail all
+```
+
+期望结果：
+
+```text
+queued_agent_count: 0
+active_agent_count: 0
+total_queue_depth: 0
+total_pending_reply_count: 0
+```
+
+## 4. 不推荐的修复方式
+
+### 4.1 不推荐直接改源码 shebang
+
+例如将源码入口改成：
+
+```python
+#!/opt/homebrew/opt/python@3.12/libexec/bin/python3
+```
+
+这种方式虽然可以在单机上解决问题，但有明显缺点：
+
+- 会污染源码工作树。
+- 不适合提交给上游。
+- 绑定了本机 Homebrew 路径。
+- 其他机器可能没有该路径。
+- 用户要求“保留远端更新”时不应使用这种方式。
+
+### 4.2 不推荐只依赖修改 shell PATH
+
+修改 `~/.zshrc` 让 `python3` 指向 Python 3.12 只能解决交互式 shell 的一部分场景。
+
+CCB 还涉及 daemon、tmux、provider runtime，这些上下文未必读取同一份 shell 初始化文件。
+
+因此仅修改 shell PATH 不是完整修复。
+
+### 4.3 不推荐继续使用 source/dev 安装作为普通用户默认安装
+
+source/dev 模式适合开发 CCB 本身。
+
+普通使用更适合 managed release 模式，因为它能固定 Python 解释器和依赖环境。
+
+## 5. 上游应实施的永久修复方案
+
+以下方案面向 CCB 项目本身，目标是让安装器在多 Python、多 PATH、多 provider CLI 环境下具备闭环自检能力。
+
+### 5.1 修复 Python 解释器闭环
+
+安装器必须保证“安装时检查的 Python”和“运行时 `ccb` 使用的 Python”一致。
+
+推荐实现：
+
+1. source/dev 模式也生成 wrapper，不直接 symlink Python 入口。
+2. wrapper 中写死安装时通过检查的 `PYTHON_BIN` 绝对路径。
+3. `ask` 入口也使用同一个 Python wrapper。
+4. `keeper` 和 `ccbd` 继续使用 `sys.executable` 派生即可，因为 wrapper 已确保入口解释器正确。
+
+source/dev wrapper 示例：
+
+```bash
+#!/usr/bin/env bash
+if [[ "${TERM:-}" == "xterm-ghostty" ]]; then
+  export TERM=xterm-256color
+fi
+exec "/opt/homebrew/opt/python@3.12/libexec/bin/python" "/Users/yuanfeijie/Desktop/project/claude_code_bridge/ccb" "$@"
+```
+
+对于不同机器，路径应由安装脚本检测得到，而不是硬编码。
+
+必须避免以下行为：
+
+```text
+安装时检查 python=3.12
+运行时通过 /usr/bin/env python3 找到 python3=3.9
+```
+
+### 5.2 source/dev 模式下允许 managed venv
+
+当前逻辑中，source/dev 模式不使用 managed venv。
+
+建议新增一种模式：
+
+```text
+source code + managed Python wrapper
+```
+
+也就是：
+
+- 代码仍指向源码树，方便开发。
+- 解释器来自 `~/.local/share/codex-dual/.venv/bin/python`。
+- wrapper 调用源码入口。
+
+这样可同时满足：
+
+- 开发者修改源码立即生效。
+- Python 解释器稳定。
+- 不需要修改源码 shebang。
+
+### 5.3 安装后执行真实入口自检
+
+安装脚本不应只在安装进程中检查 Python。
+
+安装完成后必须执行：
+
+```bash
+"$BIN_DIR/ccb" version
+```
+
+并增加一个机器可读的 runtime 检查，例如：
+
+```bash
+"$BIN_DIR/ccb" doctor --runtime
+```
+
+输出必须包含：
+
+```text
+ccb_executable: /Users/.../.local/bin/ccb
+ccb_install_path: /Users/.../.local/share/codex-dual
+python_executable: /Users/.../.local/share/codex-dual/.venv/bin/python
+python_version: 3.12.12
+python_ok: true
+```
+
+如果 `python_version < 3.10`，安装必须失败。
+
+### 5.4 检查 provider CLI 在真实 tmux 环境中的解析结果
+
+安装时只执行 `command -v codex` 不够。
+
+必须在 CCB 实际启动 provider 的环境中检查：
+
+```bash
+command -v codex
+codex --version
+command -v claude
+claude --version
+```
+
+建议在 `ccb doctor` 中增加以下字段：
+
+```text
+caller_codex_path
+daemon_codex_path
+tmux_codex_path
+agent_backend_codex_path
+caller_claude_path
+daemon_claude_path
+tmux_claude_path
+agent_lead_claude_path
+```
+
+这些字段可以帮助判断是否出现以下问题：
+
+```text
+用户 shell 使用 Volta codex
+tmux pane 使用 Homebrew codex
+```
+
+如果解析结果不一致，应输出明确警告。
+
+### 5.5 明确 Volta PATH 策略
+
+如果检测到 `~/.volta/bin` 存在，并且用户当前 shell 的 `codex` 或 `claude` 来自 Volta，则 CCB 启动 provider 时应确保 `~/.volta/bin` 在 PATH 前部。
+
+推荐策略：
+
+1. 不全局覆盖 PATH。
+2. 只在 CCB provider runtime 环境中 prepend `~/.volta/bin`。
+3. 保留用户原 PATH 的其余部分。
+4. 在 `doctor` 中输出最终 provider PATH 的前几个关键段。
+
+示例：
+
+```text
+provider_path_prefix:
+  - /Users/yuanfeijie/.volta/bin
+  - /Users/yuanfeijie/.local/bin
+  - /opt/homebrew/bin
+```
+
+### 5.6 Droid MCP 自动注册应改为显式 opt-in 或短超时
+
+对于 Claude Code + Codex 用户，Droid MCP 注册不是核心路径。
+
+建议：
+
+- 默认不自动注册 Droid MCP。
+- 或者设置短超时，例如 5 到 10 秒。
+- 超时后只警告，不影响安装成功。
+- 文档中提供手动注册命令。
+
+推荐默认：
+
+```text
+CCB_DROID_AUTOINSTALL=0
+```
+
+如果用户明确需要 Droid，再运行：
+
+```bash
+CCB_DROID_AUTOINSTALL=1 ./install.sh install
+```
+
+### 5.7 检测 Claude Code 首次确认状态
+
+CCB 启动 Claude provider 后，不应只判断 pane 存活。
+
+它还应识别常见阻塞界面：
+
+- Trust folder prompt
+- Use API key prompt
+- Login prompt
+- Permission mode prompt
+
+如果检测到这些界面，应在 `ccb ps` 或 `ccb doctor` 中明确输出：
+
+```text
+agent: lead
+provider: claude
+runtime_health: blocked
+blocked_reason: claude_trust_folder_prompt
+action_required: focus pane lead and confirm trust prompt
+```
+
+这样用户可以区分：
+
+```text
+CCB 路由失败
+provider 正在确认
+模型正在处理
+```
+
+### 5.8 对新版 ask 语义提供兼容提示
+
+当用户执行：
+
+```bash
+ask --wait --timeout 300 backend -- 'message'
+```
+
+当前错误为：
+
+```text
+unknown ask option: --wait
+```
+
+建议改为更明确的迁移提示：
+
+```text
+--wait has been removed.
+Use:
+  job=$(ask backend -- 'message' | sed -n 's/^accepted job=\([^ ]*\).*/\1/p')
+  ccb wait-all --timeout 300 "$job"
+  ask get "$job"
+```
+
+这可以降低版本升级后的误判。
+
+## 6. 最小代码修改建议
+
+如果要在仓库中实现永久修复，建议按以下顺序进行，避免一次性大改。
+
+### 阶段 1：修复 source/dev Python wrapper
+
+目标：
+
+- source/dev 安装不再直接 symlink `ccb` 和 `ask`。
+- 使用安装时选中的 Python 写 wrapper。
+
+涉及位置：
+
+- `install.sh`
+
+关键改动：
+
+- 新增 `write_selected_python_wrapper`。
+- 在 `install_entrypoint_executable` 中，对 Python 入口文件始终生成 wrapper。
+- wrapper 中使用 `PYTHON_BIN` 的绝对路径。
+
+验收：
+
+```bash
+./install.sh install
+head -20 ~/.local/bin/ccb
+~/.local/bin/ccb version
+```
+
+必须看到 wrapper 使用 Python 3.10+。
+
+### 阶段 2：补 runtime doctor
+
+目标：
+
+- 明确输出 `sys.executable`、Python 版本、安装模式、provider 路径。
+
+涉及位置：
+
+- `lib/cli/services/doctor.py`
+- `lib/cli/services/doctor_runtime/*`
+
+验收：
+
+```bash
+ccb doctor
+```
+
+必须能看出：
+
+- CCB 使用哪个 Python。
+- Codex/Claude 在当前环境解析到哪里。
+- tmux/provider runtime 中解析到哪里。
+
+### 阶段 3：provider PATH 一致性
+
+目标：
+
+- Volta 用户在 tmux/provider runtime 中仍然使用 Volta CLI。
+
+涉及位置：
+
+- provider launcher runtime
+- control plane env
+- terminal/tmux runtime
+
+验收：
+
+```bash
+tmux -S .ccb/ccbd/tmux.sock list-panes ...
+```
+
+agent pane 中 `codex` 和 `claude` 应解析到预期路径。
+
+### 阶段 4：Claude prompt blocked 状态识别
+
+目标：
+
+- Claude 首次确认时，`ccb ps` 或 `doctor` 显示 blocked，而不是只显示 idle/healthy。
+
+验收：
+
+- 清理 Claude managed home。
+- 启动 CCB。
+- Claude 停在 trust/API key prompt 时，`ccb doctor` 明确提示人工确认。
+
+### 阶段 5：Droid 注册降级为非核心路径
+
+目标：
+
+- Droid 注册失败或卡住不影响 Claude/Codex 安装。
+
+验收：
+
+```bash
+./install.sh install
+```
+
+即使 Droid 不可用，安装也应完成，并输出警告。
+
+## 7. 推荐给普通用户的最终操作手册
+
+如果只是使用 CCB，不开发 CCB 本身，执行以下命令：
+
+```bash
+cd /Users/yuanfeijie/Desktop/project/claude_code_bridge
+git pull --ff-only
+CCB_DROID_AUTOINSTALL=0 \
+CCB_SOURCE_KIND=release \
+CCB_BUILD_CHANNEL=stable \
+CCB_USE_MANAGED_VENV=1 \
+./install.sh install
+```
+
+然后验证：
+
+```bash
+ccb version
+command -v codex
+codex --version
+command -v claude
+claude --version
+```
+
+启动项目：
+
+```bash
+cd /Users/yuanfeijie/Desktop/procode/chat2image
+ccb kill -f
+ccb
+```
+
+如果 Claude pane 出现信任目录或 API key 确认，先在 pane 中确认。
+
+测试 agent：
+
+```bash
+job=$(ask backend -- '请只回复“backend 收到”。' | sed -n 's/^accepted job=\([^ ]*\).*/\1/p')
+ccb wait-all --timeout 300 "$job"
+ask get "$job"
+```
+
+## 8. 明确结论
+
+本问题的本质不是 Python、Volta、Claude Code、Codex CLI 某一个工具单独损坏，而是 CCB 安装器在 source/dev 模式下没有形成完整运行时闭环。
+
+准确根因是：
+
+```text
+安装器检查到了 Python 3.12，但 source/dev 入口运行时通过 /usr/bin/env python3 使用了 Python 3.9。
+```
+
+进一步叠加：
+
+```text
+不同进程的 PATH 不一致，可能导致 codex/claude 解析路径不同。
+Claude Code 首次安全确认会阻塞 CCB 任务处理。
+Droid MCP 自动注册可能影响安装完成。
+ask CLI 新版移除了旧 --wait 参数。
+```
+
+对当前用户环境，已验证的稳定方案是：
+
+```text
+使用 release/managed 安装模式，让 ~/.local/bin/ccb 和 ~/.local/bin/ask 调用 managed Python 3.12 venv。
+保留源码仓库干净跟随 origin/main。
+跳过非核心 Droid MCP 自动注册。
+确认 Claude Code 首次 trust/API key prompt。
+使用新版 ask + ccb wait-all 测试方式。
+```
+
+对上游项目，推荐的永久修复是：
+
+```text
+source/dev 模式也应生成固定 Python wrapper，或允许 source + managed venv。
+安装后必须验证真实 ccb 入口使用的 sys.executable。
+doctor 必须报告 provider CLI 在 caller、daemon、tmux、agent runtime 中的实际解析路径。
+Droid MCP 注册应改为 opt-in 或短超时非阻塞。
+Claude 首次确认应被识别为 blocked 状态并给出明确操作提示。
+```
+
+只要完成这些改动，CCB 就能在多 Python、多 Node CLI 管理器、多后台运行层的 macOS 环境中稳定安装和运行。

--- a/docs/install-runtime-environment/01-background-and-incident.md
+++ b/docs/install-runtime-environment/01-background-and-incident.md
@@ -1,0 +1,334 @@
+# 背景与问题分析
+
+## 1. 文档目的
+
+本文档记录一次 CCB 安装和运行问题的完整背景、现象、环境、影响和因果链。本文档不依赖任何聊天记录或外部上下文即可理解。
+
+本文档中的 CCB 指当前仓库：
+
+```text
+/Users/yuanfeijie/Desktop/project/claude_code_bridge
+```
+
+目标工作项目为：
+
+```text
+/Users/yuanfeijie/Desktop/procode/chat2image
+```
+
+## 2. 用户目标
+
+用户希望在本机安装并使用 CCB，让一个项目内同时运行多个 AI agent：
+
+- Claude Code agent 负责调度。
+- Claude Code agent 负责页面实现或设计 review。
+- Codex agent 负责后端或实施任务。
+- Codex agent 负责代码 review。
+
+用户明确期望：
+
+- 可以直接执行裸命令 `ccb` 和 `ask`。
+- 不希望每次手写复杂的 `PATH=... ccb`。
+- 不希望使用错误的 Homebrew 版 `codex`。
+- `codex` 和 `claude` 应优先走 Volta 管理的 CLI。
+- 安装和修复不能破坏当前开发环境。
+- 需要能在 `~/Desktop/procode/chat2image` 中稳定启动。
+- `cmd` agent 不应出现在工作布局中。
+- 如果要修改上游，应通过 fork 提 PR。
+
+## 3. 真实环境事实
+
+### 3.1 操作系统与 shell
+
+已观察环境：
+
+```text
+OS: macOS
+shell: zsh
+timezone: Asia/Shanghai
+```
+
+### 3.2 Python 环境
+
+已观察到至少两个 Python：
+
+```text
+command -v python3 -> /usr/bin/python3
+python3 --version -> Python 3.9.6
+
+command -v python -> /opt/homebrew/opt/python@3.12/libexec/bin/python
+python --version -> Python 3.12.12
+```
+
+这意味着：
+
+```text
+python 和 python3 不是同一个解释器。
+python 满足 CCB 的 Python 3.10+ 要求。
+python3 不满足 CCB 的 Python 3.10+ 要求。
+```
+
+### 3.3 Node CLI 与 Volta
+
+用户期望 `codex` 和 `claude` 走 Volta：
+
+```text
+codex  -> /Users/yuanfeijie/.volta/bin/codex
+claude -> /Users/yuanfeijie/.volta/bin/claude
+```
+
+已观察版本：
+
+```text
+codex-cli 0.130.0
+Claude Code 2.1.120
+```
+
+同时系统中还存在 Homebrew 路径，且历史上出现过 Homebrew `codex` 被误用的情况。
+
+### 3.4 CCB 仓库与安装路径
+
+上游仓库：
+
+```text
+https://github.com/bfly123/claude_code_bridge.git
+```
+
+用户 fork：
+
+```text
+git@github.com:SeemSeam/claude_codex_bridge.git
+```
+
+本地 remote 目标状态：
+
+```text
+origin   git@github.com:SeemSeam/claude_codex_bridge.git
+upstream https://github.com/bfly123/claude_code_bridge.git
+```
+
+仓库当前跟随：
+
+```text
+upstream/main
+```
+
+已观察版本：
+
+```text
+CCB v6.2.2
+commit 39b4e92
+```
+
+## 4. 期望行为
+
+用户期望安装后：
+
+1. `ccb` 可以直接运行。
+2. `ask` 可以直接运行。
+3. `ccbd` daemon 能正常启动。
+4. tmux 工作窗口里只有 4 个 agent pane。
+5. `cmd` agent 不启用。
+6. `codex` 使用 Volta 的最新 CLI。
+7. `claude` 使用 Volta 的 Claude Code CLI。
+8. CCB 自己使用 Python 3.10+。
+9. 安装脚本如果发现环境问题，应明确报错或自动规避。
+10. 安装后能通过真实 `ask` 投递任务。
+
+## 5. 实际问题现象
+
+### 5.1 source/dev 安装后 `ccb` 启动失败
+
+在 `chat2image` 目录执行：
+
+```bash
+CCB_NO_ATTACH=1 ccb
+```
+
+曾出现：
+
+```text
+command_status: failed
+error: ccbd is unavailable: lease_unmounted; lifecycle_failure: ccbd exited before ready with code 1
+```
+
+### 5.2 `ccbd` 日志出现 Python 类型错误
+
+`ccbd.stderr.log` 中出现：
+
+```text
+TypeError: unsupported operand type(s) for |: '_SpecialForm' and 'NoneType'
+```
+
+错误发生在 import 阶段，说明 daemon 进程还没进入正常业务逻辑就崩溃了。
+
+### 5.3 安装脚本显示 Python 通过，但运行时仍失败
+
+安装脚本输出：
+
+```text
+OK: Python 3.12.12 (python)
+```
+
+但运行时实际通过 `#!/usr/bin/env python3` 解析到：
+
+```text
+/usr/bin/python3
+Python 3.9.6
+```
+
+这造成安装时和运行时解释器不一致。
+
+### 5.4 Claude Code 首次确认阻塞任务
+
+Claude agent pane 重建后可能停在以下交互确认：
+
+```text
+Do you trust this folder?
+Do you want to use this API key?
+```
+
+如果未确认，CCB 任务可能表现为：
+
+```text
+status: running
+mailbox_state: delivering
+reply: empty
+```
+
+### 5.5 Droid MCP 自动注册导致安装超时
+
+安装脚本默认可能尝试：
+
+```bash
+droid mcp add ...
+```
+
+如果 Droid 配置不可用或命令卡住，安装过程可能超时。对于只使用 Claude Code 和 Codex 的用户，这不是核心功能。
+
+### 5.6 新版 `ask` 不支持旧 `--wait`
+
+旧命令：
+
+```bash
+ask --wait --timeout 300 backend -- 'message'
+```
+
+新版报错：
+
+```text
+unknown ask option: --wait
+```
+
+新版正确流程：
+
+```bash
+job=$(ask backend -- 'message' | sed -n 's/^accepted job=\([^ ]*\).*/\1/p')
+ccb wait-all --timeout 300 "$job"
+ask get "$job"
+```
+
+## 6. 影响范围
+
+### 6.1 受影响用户
+
+受影响概率较高的环境：
+
+- macOS 用户。
+- 系统 `python3` 是 Apple 自带 Python 3.9。
+- Homebrew 安装了 Python 3.10+，但命令名主要是 `python`。
+- 使用 Volta 管理 Node CLI。
+- 同时存在 Homebrew CLI 和 Volta CLI。
+- 使用 CCB source/dev 安装模式。
+
+### 6.2 不一定受影响的用户
+
+以下用户可能不受影响：
+
+- `python3` 已经是 Python 3.10+。
+- 使用 release/managed 安装模式。
+- 不使用 Volta。
+- 没有多份 Codex/Claude CLI。
+- 不启用 Claude Code agent。
+
+## 7. 直接因果链
+
+完整因果链如下：
+
+```text
+用户运行 ./install.sh install
+install.sh 找到 python=3.12 并通过检查
+source/dev 模式安装 ~/.local/bin/ccb 为源码 symlink
+源码 ccb 第一行是 #!/usr/bin/env python3
+用户运行 ccb
+/usr/bin/env python3 找到 /usr/bin/python3
+/usr/bin/python3 是 Python 3.9.6
+ccb 进程 sys.executable 是 Python 3.9
+keeper 和 ccbd 通过 sys.executable 派生
+ccbd import Python 3.10+ 类型语法
+Python 3.9 import 崩溃
+ccb 启动失败
+```
+
+其中最关键的一步是：
+
+```text
+安装时检查的是 python，运行时入口使用的是 python3。
+```
+
+## 8. 非根因澄清
+
+以下不是根本原因：
+
+- 不是用户项目 `chat2image` 代码损坏。
+- 不是 tmux 本身损坏。
+- 不是 Codex CLI 本身必然损坏。
+- 不是 Claude Code 本身必然损坏。
+- 不是 Python 3.12 安装损坏。
+- 不是 Volta 本身损坏。
+
+这些工具只是让问题更容易显现。
+
+根本原因是 CCB 安装器没有保证“安装时通过检查的运行时”与“用户执行全局命令时实际使用的运行时”一致。
+
+## 9. 已验证的临时稳定方案
+
+已验证方案是改用 managed release 安装：
+
+```bash
+CCB_DROID_AUTOINSTALL=0 \
+CCB_SOURCE_KIND=release \
+CCB_BUILD_CHANNEL=stable \
+CCB_USE_MANAGED_VENV=1 \
+./install.sh install
+```
+
+此方案会：
+
+- 将 CCB 复制到 `~/.local/share/codex-dual`。
+- 创建 `~/.local/share/codex-dual/.venv`。
+- 让 `~/.local/bin/ccb` 和 `~/.local/bin/ask` 变成 wrapper。
+- wrapper 固定调用 managed Python 3.12。
+
+该方案解决的是 Python 解释器漂移，不解决所有长期诊断能力缺口。
+
+## 10. 上游需要修复的本质问题
+
+上游应修复：
+
+```text
+source/dev 安装模式不应裸 symlink Python entrypoint。
+```
+
+更准确地说：
+
+```text
+所有用户可执行 Python entrypoint 都应通过 wrapper 绑定安装时选中的 Python 3.10+ 解释器。
+```
+
+这样才能保证：
+
+```text
+install-time Python == run-time Python == daemon Python
+```
+

--- a/docs/install-runtime-environment/02-technical-root-cause.md
+++ b/docs/install-runtime-environment/02-technical-root-cause.md
@@ -1,0 +1,491 @@
+# 技术根因与代码链路
+
+## 1. 文档目的
+
+本文档从代码路径解释 CCB 安装与运行环境问题的技术根因。
+
+重点覆盖：
+
+- `install.sh` 如何选择 Python。
+- source/dev 安装为何绕过安装时 Python 选择。
+- managed release 安装为何稳定。
+- `keeper` 和 `ccbd` 如何继承 Python。
+- Volta / Homebrew CLI 为什么会在不同进程里解析不一致。
+- Droid MCP 注册为何会干扰安装。
+- Claude Code 首次确认为何会阻塞 CCB 任务。
+- `ask --wait` 为什么失效。
+
+## 2. Python 版本要求
+
+CCB 代码使用 Python 3.10+ 语法，例如：
+
+```python
+str | None
+dict[str, object]
+```
+
+因此运行 CCB 的 Python 必须满足：
+
+```text
+Python >= 3.10
+```
+
+如果运行时 Python 是 3.9，某些类型表达式可能在 import 阶段触发错误。
+
+真实错误示例：
+
+```text
+TypeError: unsupported operand type(s) for |: '_SpecialForm' and 'NoneType'
+```
+
+## 3. install.sh 的 Python 选择逻辑
+
+`install.sh` 中存在全局变量：
+
+```bash
+PYTHON_BIN="${CCB_PYTHON_BIN:-}"
+```
+
+安装脚本通过 `pick_python_bin` 选择 Python：
+
+```bash
+pick_python_bin() {
+  if [[ -n "${PYTHON_BIN}" ]] && _python_check_310 "${PYTHON_BIN}"; then
+    return 0
+  fi
+  for cmd in python3 python; do
+    if _python_check_310 "$cmd"; then
+      PYTHON_BIN="$cmd"
+      return 0
+    fi
+  done
+  return 1
+}
+```
+
+这段逻辑的含义：
+
+1. 如果用户设置了 `CCB_PYTHON_BIN`，优先使用它。
+2. 否则先试 `python3`。
+3. 再试 `python`。
+4. 找到 Python 3.10+ 就认为安装要求满足。
+
+在真实问题环境中：
+
+```text
+python3 = Python 3.9.6
+python  = Python 3.12.12
+```
+
+因此 `pick_python_bin` 会跳过 `python3`，选择 `python`。
+
+安装日志会显示：
+
+```text
+OK: Python 3.12.12 (python)
+```
+
+到这里为止，安装脚本行为本身是合理的。
+
+## 4. source/dev 安装模式
+
+安装模式由 `resolve_source_kind` 和 `resolve_install_mode` 决定。
+
+如果仓库存在 `.git`，默认认为是 source：
+
+```bash
+resolve_source_kind() {
+  if [[ -d "$REPO_ROOT/.git" ]]; then
+    echo "source"
+  else
+    echo "release"
+  fi
+}
+```
+
+source 对应：
+
+```bash
+resolve_install_mode() {
+  if [[ "$source_kind" == "source" ]]; then
+    echo "source"
+  else
+    echo "release"
+  fi
+}
+```
+
+source/dev 模式下：
+
+```bash
+install_uses_live_source() {
+  [[ "$(resolve_install_mode)" == "source" ]]
+}
+```
+
+这表示安装产物应直接使用当前源码树。
+
+## 5. source/dev 模式为何不使用 managed venv
+
+`use_managed_venv` 中有明确逻辑：
+
+```bash
+use_managed_venv() {
+  local requested="${CCB_USE_MANAGED_VENV:-auto}"
+  if install_uses_live_source; then
+    return 1
+  fi
+  ...
+}
+```
+
+这意味着：
+
+```text
+只要是 source/dev 安装，就永远不会使用 managed venv。
+```
+
+即使用户设置：
+
+```bash
+CCB_USE_MANAGED_VENV=1
+```
+
+在当前逻辑下 source/dev 模式仍不会使用 managed venv。
+
+这是问题的关键条件之一。
+
+## 6. source/dev entrypoint 安装逻辑
+
+入口列表：
+
+```bash
+SCRIPTS_TO_LINK=(
+  bin/ask
+  bin/autonew
+  bin/ctx-transfer
+  ccb
+)
+```
+
+这些文件当前 shebang 均为：
+
+```text
+#!/usr/bin/env python3
+```
+
+安装时调用：
+
+```bash
+install_bin_links
+```
+
+内部调用：
+
+```bash
+install_entrypoint_executable "$target_path" "$BIN_DIR/$name"
+```
+
+在 `install_entrypoint_executable` 中，仅当 managed venv 可用且 source 位于 install prefix 下时，才写 managed wrapper：
+
+```bash
+if use_managed_venv && [[ "$absolute_source" == "$INSTALL_PREFIX/"* ]]; then
+  write_managed_venv_python_wrapper "$absolute_source" "$destination_path"
+  return 0
+fi
+
+install_owned_executable "$source_path" "$destination_path"
+```
+
+但 source/dev 模式下 `use_managed_venv` 永远 false，所以进入 `install_owned_executable`。
+
+`install_owned_executable` 优先创建 symlink：
+
+```bash
+if ln -s "$source_path" "$destination_path" 2>/dev/null; then
+  return 0
+fi
+```
+
+因此 source/dev 安装结果通常是：
+
+```text
+~/.local/bin/ccb -> /path/to/repo/ccb
+~/.local/bin/ask -> /path/to/repo/bin/ask
+```
+
+这就是运行时绕过安装脚本 `PYTHON_BIN` 的原因。
+
+## 7. 当前 fallback wrapper 不能解决 Python 问题
+
+`install.sh` 中存在：
+
+```bash
+write_live_source_wrapper() {
+  local target="$1"
+  local wrapper_path="$2"
+  ...
+  cat > "$wrapper_path" <<EOF
+#!/usr/bin/env bash
+exec ${quoted_target} "\$@"
+EOF
+}
+```
+
+但这个 wrapper 只是执行目标文件：
+
+```bash
+exec /path/to/repo/ccb "$@"
+```
+
+目标文件仍然通过自身 shebang 启动：
+
+```text
+#!/usr/bin/env python3
+```
+
+因此即使 symlink 失败并 fallback 到 wrapper，也仍然可能使用错误的 `python3`。
+
+这个 fallback wrapper 只能解决文件系统不支持 symlink 的问题，不能解决 Python 解释器绑定问题。
+
+## 8. keeper 与 ccbd 的解释器继承
+
+`keeper` 启动逻辑位于：
+
+```text
+lib/cli/services/daemon_runtime/keeper.py
+```
+
+关键逻辑：
+
+```python
+subprocess.Popen(
+    [sys.executable, str(script), '--project', str(context.project.project_root)],
+    ...
+)
+```
+
+`ccbd` 启动逻辑位于：
+
+```text
+lib/ccbd/daemon_process.py
+```
+
+关键逻辑：
+
+```python
+process = subprocess.Popen(
+    [sys.executable, str(script), '--project', str(project_root)],
+    ...
+)
+```
+
+这说明：
+
+```text
+keeper 和 ccbd 使用当前 ccb 进程的 sys.executable。
+```
+
+因此只要全局 `ccb` 入口使用正确 Python，后台 daemon 就会跟随正确 Python。
+
+反过来：
+
+```text
+如果全局 ccb 入口使用 Python 3.9，keeper 和 ccbd 也会使用 Python 3.9。
+```
+
+所以修复点应放在入口 wrapper，而不是分别修改 keeper 或 ccbd。
+
+## 9. managed release 模式为何稳定
+
+release/managed 安装会复制项目到：
+
+```text
+~/.local/share/codex-dual
+```
+
+并创建 venv：
+
+```text
+~/.local/share/codex-dual/.venv
+```
+
+`write_managed_venv_python_wrapper` 会生成：
+
+```bash
+#!/usr/bin/env bash
+if [[ "${TERM:-}" == "xterm-ghostty" ]]; then
+  export TERM=xterm-256color
+fi
+exec "$venv_python" "$absolute_source" "$@"
+```
+
+实际效果：
+
+```text
+~/.local/bin/ccb -> bash wrapper -> managed venv python -> installed ccb
+```
+
+这样 `ccb` 不再依赖 `/usr/bin/env python3`，因此不会受到系统 Python 3.9 影响。
+
+## 10. PATH 与 Volta 问题
+
+`control_plane_env` 允许继承 `PATH`：
+
+```python
+_CONTROL_PLANE_ALLOWLIST = {
+    ...
+    'PATH',
+    ...
+}
+```
+
+理论上 daemon 和 provider 能继承调用者 PATH。
+
+但现实中存在多个上下文：
+
+```text
+用户交互式 shell
+安装脚本 shell
+ccb wrapper
+ccbd daemon
+tmux server
+tmux pane
+provider runtime
+Claude/Codex managed home
+```
+
+这些上下文不一定加载同一组 shell 初始化文件。
+
+Volta 通常依赖 PATH 前缀：
+
+```bash
+export PATH="$HOME/.volta/bin:$PATH"
+```
+
+如果某个上下文没有该前缀，就可能出现：
+
+```text
+用户 shell: codex -> ~/.volta/bin/codex
+tmux pane:  codex -> /opt/homebrew/bin/codex
+```
+
+这会导致 provider 版本漂移。
+
+当前 doctor 只报告当前 `ccb doctor` 进程中的：
+
+```python
+shutil.which(executable)
+```
+
+它不能证明 tmux pane 或 provider runtime 里解析到同一个 CLI。
+
+## 11. Droid MCP 注册问题
+
+当前 `install_droid_delegation` 中：
+
+```bash
+if [[ "${CCB_DROID_AUTOINSTALL:-1}" == "0" ]]; then
+  return
+fi
+
+if ! command -v droid >/dev/null 2>&1; then
+  return
+fi
+
+py="$(command -v python3 2>/dev/null || command -v python 2>/dev/null || true)"
+...
+droid mcp add ccb-delegation --type stdio "$py" "$server"
+```
+
+问题有三点：
+
+1. Droid 注册默认开启。
+2. `py` 优先选择 `python3`，可能绕过安装脚本已选中的 Python 3.10+。
+3. `droid mcp add` 没有超时。
+
+在只使用 Claude Code 和 Codex 的用户场景中，Droid 不是核心依赖。它不应阻塞 CCB 主安装流程。
+
+## 12. Claude Code 首次确认问题
+
+Claude Code 启动后可能要求确认：
+
+```text
+Do you trust this folder?
+Do you want to use this API key?
+```
+
+CCB 当前可能只能看到：
+
+```text
+pane alive
+runtime healthy
+```
+
+但 provider 实际没有进入可处理输入的状态。
+
+这会导致 CCB 任务被投递到 mailbox，但 Claude Code 没处理，表现为：
+
+```text
+job status: running
+event status: delivering
+reply: empty
+```
+
+这类问题不能通过重启 daemon 解决，必须确认 Claude Code prompt。
+
+## 13. ask CLI 迁移问题
+
+新版 `ask` 是异步提交工具。
+
+当前 `ask` usage：
+
+```text
+ask [--compact] [--silence] [--callback] <target> [--] <message...>
+ask get <job_id>
+ask cancel <job_id>
+```
+
+旧参数 `--wait` 不在支持列表中。
+
+当前 `parse_ask` 中仅对以下旧参数有明确提示：
+
+```python
+_REMOVED_ASK_FLAGS = {
+    '--sync': 'async submit is already the default',
+    '--async': 'omit the flag; async submit is already the default',
+}
+```
+
+因此 `--wait` 会落入普通未知参数错误：
+
+```text
+unknown ask option: --wait
+```
+
+这会让用户误以为安装或 agent 通讯失败。实际只是 CLI 语义迁移。
+
+## 14. 根本原因归纳
+
+根本原因分三层。
+
+第一层，直接根因：
+
+```text
+source/dev 安装的 Python entrypoint 没有绑定安装时检查通过的 Python。
+```
+
+第二层，诊断缺口：
+
+```text
+doctor 没有展示 daemon/tmux/provider runtime 的真实 Python 和 CLI 解析路径。
+```
+
+第三层，体验缺口：
+
+```text
+Droid 注册、Claude 首次确认、ask CLI 迁移都没有给用户足够明确的提示或隔离。
+```
+
+最优先需要修复第一层。
+

--- a/docs/install-runtime-environment/03-remediation-design.md
+++ b/docs/install-runtime-environment/03-remediation-design.md
@@ -1,0 +1,487 @@
+# 修复方案设计
+
+## 1. 文档目的
+
+本文档给出 CCB 安装与运行环境问题的工程修复方案。
+
+本文档将方案拆成多个 PR 级别的改动，避免一次性大改导致 review 困难。
+
+## 2. 修复目标
+
+必须达成的目标：
+
+1. 安装时检查通过的 Python 与运行时 `ccb` 使用的 Python 一致。
+2. `keeper` 和 `ccbd` 使用同一个 Python。
+3. source/dev 模式仍能使用 live source。
+4. 普通用户不再因系统 `/usr/bin/python3` 是 Python 3.9 而启动失败。
+5. 安装后能明确验证真实入口可运行。
+6. Droid MCP 注册不能阻塞 Claude/Codex 主安装流程。
+7. 旧 `ask --wait` 用户能看到明确迁移提示。
+8. doctor 能逐步暴露 provider CLI 路径漂移问题。
+9. Claude Code 首次确认应被诊断为 provider blocked，而不是误判成 CCB 路由失败。
+
+## 3. 非目标
+
+以下不作为第一阶段目标：
+
+- 不要求 CCB 自动修改用户全局 shell PATH。
+- 不要求删除用户已有 Homebrew `codex`。
+- 不要求删除用户已有 Volta 配置。
+- 不要求自动点击 Claude Code 安全确认。
+- 不要求改变 CCB 的 agent 调度语义。
+- 不要求恢复旧 `ask --wait` 的同步行为。
+
+## 4. PR 1：source/dev Python wrapper
+
+### 4.1 问题
+
+source/dev 安装当前通常创建 symlink：
+
+```text
+~/.local/bin/ccb -> /path/to/repo/ccb
+```
+
+而源码入口是：
+
+```text
+#!/usr/bin/env python3
+```
+
+这会绕过安装脚本选择的 `PYTHON_BIN`。
+
+### 4.2 目标
+
+source/dev 模式下，用户可执行入口必须是 wrapper。
+
+wrapper 必须显式调用安装时已验证的 Python 绝对路径。
+
+目标关系：
+
+```text
+~/.local/bin/ccb
+  -> bash wrapper
+  -> selected Python 3.10+
+  -> /path/to/repo/ccb
+```
+
+### 4.3 推荐实现
+
+在 `install.sh` 中新增函数：
+
+```bash
+resolved_python_executable() {
+  "$PYTHON_BIN" -c 'import sys; print(sys.executable)'
+}
+```
+
+新增 wrapper 生成函数：
+
+```bash
+write_selected_python_wrapper() {
+  local python_path="$1"
+  local source_path="$2"
+  local destination_path="$3"
+
+  local absolute_source="$source_path"
+  if [[ "$absolute_source" != /* ]]; then
+    absolute_source="$(cd "$(dirname "$source_path")" && pwd)/$(basename "$source_path")"
+  fi
+
+  mkdir -p "$(dirname "$destination_path")"
+  clear_installed_path "$destination_path"
+  cat > "$destination_path" <<EOF
+#!/usr/bin/env bash
+if [[ "\${TERM:-}" == "xterm-ghostty" ]]; then
+  export TERM=xterm-256color
+fi
+exec "$python_path" "$absolute_source" "\$@"
+EOF
+  chmod +x "$destination_path" 2>/dev/null || true
+}
+```
+
+调整 `install_entrypoint_executable`：
+
+```bash
+install_entrypoint_executable() {
+  ...
+  local python_path
+  python_path="$(resolved_python_executable)"
+
+  if use_managed_venv && [[ "$absolute_source" == "$INSTALL_PREFIX/"* ]]; then
+    write_managed_venv_python_wrapper "$absolute_source" "$destination_path"
+    return 0
+  fi
+
+  if install_uses_live_source; then
+    write_selected_python_wrapper "$python_path" "$absolute_source" "$destination_path"
+    return 0
+  fi
+
+  install_owned_executable "$source_path" "$destination_path"
+}
+```
+
+### 4.4 注意事项
+
+`SCRIPTS_TO_LINK` 当前全部是 Python entrypoint：
+
+```text
+bin/ask
+bin/autonew
+bin/ctx-transfer
+ccb
+```
+
+因此第一阶段可以对这些 entrypoint 全部生成 Python wrapper。
+
+如果未来 `SCRIPTS_TO_LINK` 中加入非 Python 脚本，需要增加 shebang 检测。
+
+### 4.5 测试
+
+更新：
+
+```text
+test/test_install_source_dev_mode.py
+```
+
+原测试允许 `ccb` 是 symlink。修复后应断言：
+
+```text
+bin/ccb 是普通文件
+bin/ccb 可执行
+bin/ccb 内容包含 REPO_ROOT/ccb
+bin/ccb 内容包含已选择 Python
+Codex skill 仍然 symlink 到源码 assets
+```
+
+应新增测试：
+
+```text
+当 python3 不可用或版本过低，但 python 满足 3.10+ 时，
+source/dev wrapper 使用 python 的真实绝对路径。
+```
+
+### 4.6 验收标准
+
+在 macOS 问题环境中：
+
+```bash
+./install.sh install
+head -20 ~/.local/bin/ccb
+~/.local/bin/ccb --print-version
+```
+
+期望：
+
+```text
+~/.local/bin/ccb 是 bash wrapper
+wrapper 调用 Python 3.10+
+ccb --print-version 成功
+```
+
+## 5. PR 2：安装后真实入口 smoke test
+
+### 5.1 问题
+
+当前安装脚本检查的是安装脚本进程中的 Python，不验证安装后的全局入口是否真的可运行。
+
+### 5.2 目标
+
+安装完成后验证：
+
+```text
+$BIN_DIR/ccb --print-version
+$BIN_DIR/ask --help
+```
+
+### 5.3 推荐实现
+
+新增：
+
+```bash
+verify_installed_entrypoints() {
+  if ! "$BIN_DIR/ccb" --print-version >/dev/null 2>&1; then
+    echo "ERROR: installed ccb entrypoint failed runtime smoke check"
+    echo "   Path: $BIN_DIR/ccb"
+    exit 1
+  fi
+  if ! "$BIN_DIR/ask" --help >/dev/null 2>&1; then
+    echo "ERROR: installed ask entrypoint failed runtime smoke check"
+    echo "   Path: $BIN_DIR/ask"
+    exit 1
+  fi
+}
+```
+
+在 `install_bin_links` 后调用。
+
+### 5.4 注意事项
+
+不要用：
+
+```bash
+ccb version
+```
+
+因为 `ccb version` 会检查远端更新，可能触发网络请求。
+
+应使用：
+
+```bash
+ccb --print-version
+```
+
+它更适合作为安装 smoke check。
+
+## 6. PR 3：Droid MCP 注册降级
+
+### 6.1 问题
+
+Droid MCP 注册当前存在三个问题：
+
+1. 默认启用。
+2. 重新用 `python3` 优先选择 Python。
+3. 无超时。
+
+### 6.2 目标
+
+Droid 注册失败、超时或不可用时，不影响 CCB 主安装。
+
+### 6.3 推荐实现
+
+保守方案：
+
+- 保持 `CCB_DROID_AUTOINSTALL` 默认值不变。
+- 增加短超时。
+- 使用安装脚本已选择的 Python。
+
+示例：
+
+```bash
+local timeout_s="${CCB_DROID_AUTOINSTALL_TIMEOUT_S:-10}"
+local py
+py="$(resolved_python_executable)"
+
+if command -v timeout >/dev/null 2>&1; then
+  timeout "$timeout_s" droid mcp add ...
+else
+  droid mcp add ...
+fi
+```
+
+macOS 默认没有 GNU `timeout`。更稳的跨平台方式是通过 Python 包一层：
+
+```bash
+"$PYTHON_BIN" - <<PY
+import subprocess, sys
+...
+subprocess.run([...], timeout=float("$timeout_s"))
+PY
+```
+
+### 6.4 验收标准
+
+场景：
+
+```text
+droid 不存在 -> 静默跳过
+droid add 成功 -> 输出 OK
+droid add 失败 -> 输出 WARN，安装继续
+droid add 卡住 -> 超时 WARN，安装继续
+```
+
+## 7. PR 4：ask --wait 迁移提示
+
+### 7.1 问题
+
+旧用户会执行：
+
+```bash
+ask --wait --timeout 300 backend -- 'message'
+```
+
+当前只输出：
+
+```text
+unknown ask option: --wait
+```
+
+这个提示不说明新版替代方式。
+
+### 7.2 推荐实现
+
+在 `lib/cli/parser_runtime/ask.py` 中扩展：
+
+```python
+_REMOVED_ASK_FLAGS = {
+    '--sync': 'async submit is already the default',
+    '--async': 'omit the flag; async submit is already the default',
+    '--wait': 'submit with `ask <agent> -- <message>`, then wait with `ccb wait-all --timeout <seconds> <job_id>`',
+    '-w': 'submit with `ask <agent> -- <message>`, then wait with `ccb wait-all --timeout <seconds> <job_id>`',
+}
+```
+
+### 7.3 测试
+
+新增 parser 测试：
+
+```text
+parser.parse(['ask', '--wait', 'backend', '--', 'hi'])
+```
+
+期望抛出 `CliUsageError`，错误中包含：
+
+```text
+wait-all
+```
+
+## 8. PR 5：doctor 路径诊断增强
+
+### 8.1 问题
+
+当前 doctor 报告：
+
+```python
+sys.executable
+shutil.which('codex')
+shutil.which('claude')
+```
+
+这只能说明当前 `doctor` 进程的环境，不说明：
+
+```text
+daemon 使用哪个 Python
+tmux pane 使用哪个 codex
+provider runtime 使用哪个 claude
+```
+
+### 8.2 第一阶段增强
+
+在 `requirements_summary` 中增加：
+
+```text
+path
+path_entries_first_n
+volta_bin_path
+volta_bin_exists
+volta_codex_exists
+volta_claude_exists
+python_ok
+python_min_version
+```
+
+这样可以立即看出：
+
+```text
+PATH 是否包含 ~/.volta/bin
+当前 doctor 是否使用 Python 3.10+
+```
+
+### 8.3 第二阶段增强
+
+在 provider launch 时记录 provider command resolution：
+
+```json
+{
+  "provider_command": "codex",
+  "provider_command_path": "/Users/.../.volta/bin/codex",
+  "provider_command_version": "codex-cli 0.130.0"
+}
+```
+
+doctor 只读 runtime json，不主动向 pane 注入命令。
+
+这样避免 doctor 对运行中的 agent 产生副作用。
+
+## 9. PR 6：Claude Code 首次确认 blocked 诊断
+
+### 9.1 问题
+
+Claude Code 可能停在安全确认界面，但 CCB 只能看到 pane alive。
+
+### 9.2 保守实现
+
+先只在 doctor 中做弱诊断，不改变调度状态。
+
+通过 tmux capture pane 或已保存 pane log 检测关键文本：
+
+```text
+Do you trust this folder
+Do you want to use this API key
+Quick safety check
+```
+
+输出：
+
+```text
+agent_blocker: name=lead provider=claude kind=interactive_prompt reason=trust_or_api_key_prompt action=confirm_in_pane
+```
+
+### 9.3 不建议第一阶段做的事
+
+不要自动发送 Enter 或选择项。
+
+原因：
+
+- 这是安全确认。
+- 自动确认可能违背用户意图。
+- 不同 Claude Code 版本 UI 文本可能不同。
+
+## 10. 推荐 PR 拆分
+
+建议顺序：
+
+1. `fix/source-install-python-wrapper`
+2. `fix/ask-wait-migration-message`
+3. `fix/droid-install-timeout`
+4. `feat/doctor-runtime-path-diagnostics`
+5. `feat/claude-prompt-blocker-diagnostics`
+
+不要把 1 到 5 全部塞进一个 PR。
+
+## 11. 当前用户可立即使用的稳定安装方案
+
+如果只是使用 CCB：
+
+```bash
+cd /Users/yuanfeijie/Desktop/project/claude_code_bridge
+git fetch upstream
+git switch main
+git merge --ff-only upstream/main
+CCB_DROID_AUTOINSTALL=0 \
+CCB_SOURCE_KIND=release \
+CCB_BUILD_CHANNEL=stable \
+CCB_USE_MANAGED_VENV=1 \
+./install.sh install
+```
+
+验证：
+
+```bash
+ccb version
+command -v ccb
+command -v ask
+command -v codex
+codex --version
+command -v claude
+claude --version
+```
+
+## 12. 明确建议
+
+如果目标是向上游提第一个 PR，首选：
+
+```text
+fix/source-install-python-wrapper
+```
+
+理由：
+
+- 根因明确。
+- 修改范围小。
+- 对 source/dev 安装用户直接有价值。
+- 不改变 CCB agent 调度语义。
+- 不依赖 Claude/Codex 外部行为。
+- 容易写自动化测试。
+

--- a/docs/install-runtime-environment/04-validation-runbook.md
+++ b/docs/install-runtime-environment/04-validation-runbook.md
@@ -1,0 +1,473 @@
+# 验证与操作手册
+
+## 1. 文档目的
+
+本文档给出安装问题的复现、验证、修复验收、回滚和提 PR 前检查流程。
+
+所有命令默认在仓库根目录或目标项目目录执行。命令前会明确标注工作目录。
+
+## 2. 安全原则
+
+执行验证时遵守以下原则：
+
+1. 不打印 API key。
+2. 不删除不能确认来源的文件。
+3. 不使用 `git reset --hard`。
+4. 不覆盖用户未提交改动。
+5. 先 `git status`，再修改。
+6. 对运行态清理只使用 CCB 自己的 `ccb kill -f` 或 `ccb -n`。
+
+## 3. 检查仓库状态
+
+工作目录：
+
+```bash
+cd /Users/yuanfeijie/Desktop/project/claude_code_bridge
+```
+
+命令：
+
+```bash
+git remote -v
+git status --short --branch
+git log --oneline --decorate -5
+```
+
+期望：
+
+```text
+origin   git@github.com:SeemSeam/claude_codex_bridge.git
+upstream https://github.com/bfly123/claude_code_bridge.git
+```
+
+本地 `main` 应跟踪 `upstream/main`。
+
+## 4. 复现 source/dev Python 漂移
+
+该复现只用于理解问题，不建议普通用户故意破坏当前稳定安装。
+
+### 4.1 复现条件
+
+满足：
+
+```text
+python3 < 3.10
+python >= 3.10
+CCB_SOURCE_KIND=source
+```
+
+检查：
+
+```bash
+command -v python3
+python3 --version
+command -v python
+python --version
+```
+
+问题环境示例：
+
+```text
+/usr/bin/python3
+Python 3.9.6
+/opt/homebrew/opt/python@3.12/libexec/bin/python
+Python 3.12.12
+```
+
+### 4.2 source/dev 安装
+
+```bash
+./install.sh install
+```
+
+检查：
+
+```bash
+ls -l ~/.local/bin/ccb ~/.local/bin/ask
+head -1 ~/.local/bin/ccb
+```
+
+问题状态可能是：
+
+```text
+~/.local/bin/ccb -> /path/to/repo/ccb
+#!/usr/bin/env python3
+```
+
+### 4.3 启动项目
+
+工作目录：
+
+```bash
+cd /Users/yuanfeijie/Desktop/procode/chat2image
+```
+
+命令：
+
+```bash
+ccb kill -f
+CCB_NO_ATTACH=1 ccb
+```
+
+问题结果：
+
+```text
+ccbd exited before ready with code 1
+```
+
+查看错误：
+
+```bash
+tail -200 .ccb/ccbd/ccbd.stderr.log
+```
+
+问题日志：
+
+```text
+TypeError: unsupported operand type(s) for |: '_SpecialForm' and 'NoneType'
+```
+
+## 5. 验证 managed release 规避方案
+
+工作目录：
+
+```bash
+cd /Users/yuanfeijie/Desktop/project/claude_code_bridge
+```
+
+安装：
+
+```bash
+CCB_DROID_AUTOINSTALL=0 \
+CCB_SOURCE_KIND=release \
+CCB_BUILD_CHANNEL=stable \
+CCB_USE_MANAGED_VENV=1 \
+./install.sh install
+```
+
+验证：
+
+```bash
+command -v ccb
+command -v ask
+ls -l ~/.local/bin/ccb ~/.local/bin/ask
+head -20 ~/.local/bin/ccb
+head -20 ~/.local/bin/ask
+ccb version
+~/.local/share/codex-dual/.venv/bin/python --version
+```
+
+期望：
+
+```text
+~/.local/bin/ccb 是普通 wrapper 文件
+~/.local/bin/ask 是普通 wrapper 文件
+wrapper 调用 ~/.local/share/codex-dual/.venv/bin/python
+Python 版本为 3.10+
+```
+
+## 6. 验证 Volta CLI
+
+工作目录：
+
+```bash
+cd /Users/yuanfeijie/Desktop/procode/chat2image
+```
+
+命令：
+
+```bash
+command -v codex
+codex --version
+command -v claude
+claude --version
+```
+
+期望：
+
+```text
+/Users/yuanfeijie/.volta/bin/codex
+codex-cli 0.130.0
+/Users/yuanfeijie/.volta/bin/claude
+2.1.120 (Claude Code)
+```
+
+如果不是 Volta 路径，应优先检查 PATH，而不是修改 CCB 代码。
+
+## 7. 启动 chat2image
+
+工作目录：
+
+```bash
+cd /Users/yuanfeijie/Desktop/procode/chat2image
+```
+
+先停止旧运行态：
+
+```bash
+ccb kill -f
+```
+
+启动：
+
+```bash
+CCB_NO_ATTACH=1 ccb
+```
+
+期望：
+
+```text
+start_status: ok
+agents: lead, backend, design, review
+```
+
+检查：
+
+```bash
+ccb ps
+ccb config validate
+```
+
+期望：
+
+```text
+ccbd_state: mounted
+config_status: valid
+cmd_enabled: false
+layout: lead:claude, backend:codex; design:claude, review:codex
+```
+
+## 8. 检查 tmux 布局
+
+工作目录：
+
+```bash
+cd /Users/yuanfeijie/Desktop/procode/chat2image
+```
+
+命令：
+
+```bash
+tmux -S .ccb/ccbd/tmux.sock list-windows -a -F '#{session_name}:#{window_index} id=#{window_id} name=#{window_name} panes=#{window_panes} active=#{window_active}'
+tmux -S .ccb/ccbd/tmux.sock list-panes -a -F '#{session_name}:#{window_index}.#{pane_index} #{pane_id} dead=#{pane_dead} title=#{pane_title} path=#{pane_current_path} cmd=#{pane_current_command}'
+```
+
+期望：
+
+```text
+window __ccb_ctl panes=1 active=0
+window ccb panes=4 active=1
+```
+
+解释：
+
+```text
+__ccb_ctl 是后台控制窗口，不是 cmd agent。
+工作窗口 ccb 中应有 4 个 pane。
+```
+
+如果配置中：
+
+```text
+cmd_enabled: false
+```
+
+则说明 cmd agent 未启用。
+
+## 9. 处理 Claude Code 首次确认
+
+如果 Claude pane 显示：
+
+```text
+Do you trust this folder?
+Do you want to use this API key?
+```
+
+需要人工在 pane 中确认。
+
+不要把这种状态误判为 CCB 通讯失败。
+
+确认后再执行 ask 测试。
+
+## 10. 新版 ask 测试方式
+
+旧方式已不适用：
+
+```bash
+ask --wait --timeout 300 backend -- 'message'
+```
+
+新版方式：
+
+```bash
+job=$(ask backend -- 'CCB 自检：请只回复“backend 收到”，不要读取或修改任何文件。' | sed -n 's/^accepted job=\([^ ]*\).*/\1/p')
+ccb wait-all --timeout 300 "$job"
+ask get "$job"
+```
+
+对四个 agent 分别测试：
+
+```bash
+for agent in backend review lead design; do
+  job=$(ask "$agent" -- "CCB 自检：请只回复“$agent 收到”，不要读取或修改任何文件。" | sed -n 's/^accepted job=\([^ ]*\).*/\1/p')
+  echo "$agent $job"
+  ccb wait-all --timeout 300 "$job"
+  ask get "$job"
+done
+```
+
+期望回复：
+
+```text
+backend 收到
+review 收到
+lead 收到
+design 收到
+```
+
+## 11. 验证队列清空
+
+命令：
+
+```bash
+ccb pend --queue --detail all
+```
+
+期望：
+
+```text
+queued_agent_count: 0
+active_agent_count: 0
+total_queue_depth: 0
+total_pending_reply_count: 0
+```
+
+## 12. PR 1 自动化测试建议
+
+如果实现 source/dev Python wrapper 修复，应运行：
+
+```bash
+pytest test/test_install_source_dev_mode.py
+pytest test/test_install_watchdog_optional.py
+```
+
+如果改了 `ask` parser，应运行：
+
+```bash
+pytest test/test_v2_cli_parser.py
+pytest test/test_ask_cli.py
+```
+
+如果改了 doctor 输出，应运行：
+
+```bash
+pytest test/test_v2_cli_render.py
+pytest test/test_v2_tmux_cleanup_history.py
+```
+
+## 13. 手工验收 checklist
+
+安装相关：
+
+```text
+[ ] install.sh 能找到 Python 3.10+
+[ ] source/dev 安装生成 wrapper，而不是裸 Python entrypoint symlink
+[ ] wrapper 调用安装时选中的 Python 绝对路径
+[ ] ~/.local/bin/ccb --print-version 成功
+[ ] ~/.local/bin/ask --help 成功
+```
+
+运行相关：
+
+```text
+[ ] ccb kill -f 成功
+[ ] CCB_NO_ATTACH=1 ccb 成功
+[ ] ccb ps 显示 mounted
+[ ] 四个 agent 均为 idle
+[ ] cmd_enabled=false
+[ ] 工作窗口 4 pane
+```
+
+provider 相关：
+
+```text
+[ ] codex 解析到 Volta
+[ ] claude 解析到 Volta
+[ ] Claude 首次确认完成
+[ ] ask backend 成功
+[ ] ask review 成功
+[ ] ask lead 成功
+[ ] ask design 成功
+```
+
+## 14. 回滚方案
+
+如果修复后安装失败，可以回到 managed release 规避方案：
+
+```bash
+cd /Users/yuanfeijie/Desktop/project/claude_code_bridge
+CCB_DROID_AUTOINSTALL=0 \
+CCB_SOURCE_KIND=release \
+CCB_BUILD_CHANNEL=stable \
+CCB_USE_MANAGED_VENV=1 \
+./install.sh install
+```
+
+如果项目运行态异常：
+
+```bash
+cd /Users/yuanfeijie/Desktop/procode/chat2image
+ccb kill -f
+CCB_NO_ATTACH=1 ccb
+```
+
+如果需要重建 `.ccb` 运行态并保留配置：
+
+```bash
+ccb -n
+```
+
+注意：`ccb -n` 需要交互确认。
+
+## 15. 提 PR 前检查
+
+推荐分支：
+
+```bash
+git switch -c fix/source-install-python-wrapper
+```
+
+检查 remote：
+
+```bash
+git remote -v
+```
+
+期望：
+
+```text
+origin   git@github.com:SeemSeam/claude_codex_bridge.git
+upstream https://github.com/bfly123/claude_code_bridge.git
+```
+
+提交前：
+
+```bash
+git status --short
+git diff
+pytest test/test_install_source_dev_mode.py
+```
+
+推送：
+
+```bash
+git push -u origin fix/source-install-python-wrapper
+```
+
+PR 目标：
+
+```text
+SeemSeam/claude_codex_bridge:fix/source-install-python-wrapper
+  -> bfly123/claude_code_bridge:main
+```
+

--- a/docs/install-runtime-environment/README.md
+++ b/docs/install-runtime-environment/README.md
@@ -1,0 +1,78 @@
+# CCB 安装与运行环境问题文档索引
+
+本文档集用于说明 CCB 在 macOS、多 Python、Volta、tmux、Claude Code、Codex CLI 同时存在的环境中，为什么会出现安装成功但运行失败、provider CLI 路径不一致、Claude agent 卡住、`ask --wait` 不可用等问题。
+
+文档目标：
+
+- 脱离任何聊天上下文也能完整理解问题。
+- 区分已确认事实、合理推断和建议方案。
+- 给出可拆分 PR 的修复路径。
+- 给出本地验证命令和期望结果。
+- 避免泄露 API key、token 或任何敏感凭据。
+
+## 文档结构
+
+1. [01-background-and-incident.md](./01-background-and-incident.md)
+
+   说明问题背景、真实环境、用户期望、实际现象、影响范围、已确认事实和因果链。
+
+2. [02-technical-root-cause.md](./02-technical-root-cause.md)
+
+   从代码路径解释根本原因，包括 `install.sh`、source/dev 安装模式、managed release 安装模式、Python 解释器继承、Volta PATH、Droid MCP、Claude Code 首次确认、`ask` CLI 迁移。
+
+3. [03-remediation-design.md](./03-remediation-design.md)
+
+   给出工程修复设计，包括 source/dev Python wrapper、安装后真实入口自检、Droid 注册降级、`ask --wait` 迁移提示、doctor 诊断增强、Claude prompt blocked 识别。
+
+4. [04-validation-runbook.md](./04-validation-runbook.md)
+
+   给出复现、验证、回归测试、手工验收、回滚和提 PR 前检查清单。
+
+## 一句话结论
+
+本问题的核心不是用户系统损坏，也不是 Python、Volta、Codex CLI、Claude Code 任意一个工具单独损坏。
+
+最核心的工程缺陷是：
+
+```text
+source/dev 安装模式下，install.sh 检查到了 Python 3.10+，
+但全局 ccb/ask 入口仍可能通过 /usr/bin/env python3 使用另一个更旧的 Python。
+```
+
+在真实问题环境中：
+
+```text
+install.sh 选中的 python = Python 3.12.12
+运行时 /usr/bin/env python3 = Python 3.9.6
+```
+
+于是安装时通过检查，运行时 `ccbd` 崩溃。
+
+## 最小稳定规避方案
+
+普通用户只使用 CCB，不开发 CCB 本身时，推荐使用 managed release 安装：
+
+```bash
+cd /Users/yuanfeijie/Desktop/project/claude_code_bridge
+CCB_DROID_AUTOINSTALL=0 \
+CCB_SOURCE_KIND=release \
+CCB_BUILD_CHANNEL=stable \
+CCB_USE_MANAGED_VENV=1 \
+./install.sh install
+```
+
+该方式会让全局 `ccb` / `ask` wrapper 固定调用 managed Python 3.12 venv，避免系统 `python3` 版本漂移。
+
+## 推荐上游修复优先级
+
+优先级从高到低：
+
+1. source/dev 安装的 Python 入口闭环。
+2. 安装后真实 `ccb` 入口 smoke test。
+3. `ask --wait` 迁移提示。
+4. Droid MCP 注册超时和非核心化。
+5. `ccb doctor` 增强 provider 路径诊断。
+6. Claude Code 首次确认 blocked 状态识别。
+
+这些修复建议拆成多个 PR，而不是一个大 PR。
+

--- a/install.sh
+++ b/install.sh
@@ -203,11 +203,13 @@ Optional environment variables:
   CODEX_CLAUDE_COMMAND_DIR Custom Claude commands directory (default: auto-detect)
   CCB_DROID_AUTOINSTALL    Auto-register Droid MCP tools if droid exists (default: 1)
   CCB_DROID_AUTOINSTALL_FORCE Re-register Droid MCP tools (default: 0)
+  CCB_DROID_AUTOINSTALL_TIMEOUT_S Timeout for Droid MCP registration (default: 10)
   CCB_BUILD_CHANNEL        Override build channel metadata (e.g. stable, preview, dev)
   CCB_BUILD_PLATFORM       Override build platform metadata (default: detected platform)
   CCB_BUILD_ARCH           Override build arch metadata (default: uname -m)
   CCB_BUILD_TIME           Override build timestamp metadata (default: current UTC time)
   CCB_SOURCE_KIND          Override source kind metadata (default: source if .git exists, else release)
+  CCB_PYTHON_BIN           Python 3.10+ executable to use for install-time checks and wrappers
   CCB_USE_MANAGED_VENV     Use install-local Python venv: auto (default), 1, or 0
                            auto = enabled for macOS release installs, disabled for source/dev installs
   CCB_INSTALL_WATCHDOG     Auto-install optional watchdog dependency (default: 1; set 0 to skip)
@@ -250,6 +252,15 @@ require_command() {
 }
 
 PYTHON_BIN="${CCB_PYTHON_BIN:-}"
+PYTHON_CANDIDATE_COMMANDS=(
+  python3
+  python3.14
+  python3.13
+  python3.12
+  python3.11
+  python3.10
+  python
+)
 
 _python_check_310() {
   local cmd="$1"
@@ -261,7 +272,7 @@ pick_python_bin() {
   if [[ -n "${PYTHON_BIN}" ]] && _python_check_310 "${PYTHON_BIN}"; then
     return 0
   fi
-  for cmd in python3 python; do
+  for cmd in "${PYTHON_CANDIDATE_COMMANDS[@]}"; do
     if _python_check_310 "$cmd"; then
       PYTHON_BIN="$cmd"
       return 0
@@ -274,7 +285,7 @@ pick_any_python_bin() {
   if [[ -n "${PYTHON_BIN}" ]] && command -v "${PYTHON_BIN}" >/dev/null 2>&1; then
     return 0
   fi
-  for cmd in python3 python; do
+  for cmd in "${PYTHON_CANDIDATE_COMMANDS[@]}"; do
     if command -v "$cmd" >/dev/null 2>&1; then
       PYTHON_BIN="$cmd"
       return 0
@@ -298,6 +309,14 @@ require_python_version() {
     exit 1
   fi
   echo "OK: Python $version ($PYTHON_BIN)"
+}
+
+selected_python_executable() {
+  if ! pick_python_bin; then
+    echo "ERROR: Missing dependency: python (3.10+ required)" >&2
+    return 1
+  fi
+  "$PYTHON_BIN" -c 'import sys; print(sys.executable)'
 }
 
 python_has_module() {
@@ -1222,15 +1241,14 @@ install_owned_executable() {
   chmod +x "$destination_path" 2>/dev/null || true
 }
 
-write_managed_venv_python_wrapper() {
-  local source_path="$1"
-  local destination_path="$2"
-  local venv_python
+write_python_entrypoint_wrapper() {
+  local python_path="$1"
+  local source_path="$2"
+  local destination_path="$3"
   local absolute_source="$source_path"
   if [[ "$absolute_source" != /* ]]; then
     absolute_source="$(cd "$(dirname "$source_path")" && pwd)/$(basename "$source_path")"
   fi
-  venv_python="$(managed_venv_python)"
   mkdir -p "$(dirname "$destination_path")"
   clear_installed_path "$destination_path"
   cat > "$destination_path" <<EOF
@@ -1238,9 +1256,15 @@ write_managed_venv_python_wrapper() {
 if [[ "\${TERM:-}" == "xterm-ghostty" ]]; then
   export TERM=xterm-256color
 fi
-exec "$venv_python" "$absolute_source" "\$@"
+exec "$python_path" "$absolute_source" "\$@"
 EOF
   chmod +x "$destination_path" 2>/dev/null || true
+}
+
+write_managed_venv_python_wrapper() {
+  local source_path="$1"
+  local destination_path="$2"
+  write_python_entrypoint_wrapper "$(managed_venv_python)" "$source_path" "$destination_path"
 }
 
 install_entrypoint_executable() {
@@ -1258,6 +1282,15 @@ install_entrypoint_executable() {
   fi
   if use_managed_venv && [[ "$absolute_source" == "$INSTALL_PREFIX/"* ]]; then
     write_managed_venv_python_wrapper "$absolute_source" "$destination_path"
+    return 0
+  fi
+
+  if install_uses_live_source; then
+    local python_path
+    if ! python_path="$(selected_python_executable)"; then
+      exit 1
+    fi
+    write_python_entrypoint_wrapper "$python_path" "$absolute_source" "$destination_path"
     return 0
   fi
 
@@ -1281,6 +1314,20 @@ install_bin_links() {
   done
 
   echo "Created executable links in $BIN_DIR"
+}
+
+verify_installed_entrypoints() {
+  if ! "$BIN_DIR/ccb" --print-version >/dev/null 2>&1; then
+    echo "ERROR: installed ccb entrypoint failed runtime smoke check"
+    echo "   Path: $BIN_DIR/ccb"
+    exit 1
+  fi
+  if ! "$BIN_DIR/ask" --help >/dev/null 2>&1; then
+    echo "ERROR: installed ask entrypoint failed runtime smoke check"
+    echo "   Path: $BIN_DIR/ask"
+    exit 1
+  fi
+  echo "OK: Installed entrypoints passed runtime smoke check"
 }
 
 ensure_path_configured() {
@@ -1500,6 +1547,36 @@ install_droid_skills() {
   echo "Updated Factory skills directory: $skills_dst"
 }
 
+droid_command_with_timeout() {
+  local python_runner="$1"
+  local timeout_s="$2"
+  shift 2
+  "$python_runner" - "$timeout_s" "$@" <<'PY' >/dev/null 2>&1
+from __future__ import annotations
+
+import subprocess
+import sys
+
+try:
+    timeout_s = float(sys.argv[1])
+except Exception:
+    timeout_s = 10.0
+cmd = sys.argv[2:]
+try:
+    result = subprocess.run(
+        cmd,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        timeout=max(timeout_s, 0.1),
+    )
+except subprocess.TimeoutExpired:
+    raise SystemExit(124)
+except FileNotFoundError:
+    raise SystemExit(127)
+raise SystemExit(result.returncode)
+PY
+}
+
 install_droid_delegation() {
   if [[ "${CCB_DROID_AUTOINSTALL:-1}" == "0" ]]; then
     return
@@ -1508,11 +1585,11 @@ install_droid_delegation() {
     return
   fi
   local py
-  py="$(command -v python3 2>/dev/null || command -v python 2>/dev/null || true)"
-  if [[ -z "$py" ]]; then
-    echo "WARN: python required for Droid MCP setup; skipping"
+  if ! py="$(selected_python_executable)"; then
+    echo "WARN: Python 3.10+ required for Droid MCP setup; skipping"
     return
   fi
+  local timeout_s="${CCB_DROID_AUTOINSTALL_TIMEOUT_S:-10}"
   local asset_root
   asset_root="$(resolve_install_asset_root)"
   local server="$asset_root/mcp/ccb-delegation/server.py"
@@ -1521,12 +1598,12 @@ install_droid_delegation() {
     return
   fi
   if [[ "${CCB_DROID_AUTOINSTALL_FORCE:-0}" == "1" ]]; then
-    droid mcp remove ccb-delegation >/dev/null 2>&1 || true
+    droid_command_with_timeout "$py" "$timeout_s" droid mcp remove ccb-delegation || true
   fi
-  if droid mcp add ccb-delegation --type stdio "$py" "$server" >/dev/null 2>&1; then
+  if droid_command_with_timeout "$py" "$timeout_s" droid mcp add ccb-delegation --type stdio "$py" "$server"; then
     echo "OK: Droid MCP delegation registered"
   else
-    echo "WARN: Failed to register Droid MCP delegation (already registered or droid config unavailable)"
+    echo "WARN: Failed to register Droid MCP delegation within ${timeout_s}s (already registered, unavailable, or timed out)"
   fi
 }
 
@@ -2204,6 +2281,7 @@ install_all() {
     write_install_metadata
   fi
   install_bin_links
+  verify_installed_entrypoints
   ensure_path_configured
   install_claude_commands
   install_claude_skills

--- a/lib/agents/policy.py
+++ b/lib/agents/policy.py
@@ -23,14 +23,18 @@ class AgentLaunchPolicy:
 
 
 def resolve_effective_restore_mode(default_mode: RestoreMode, *, cli_restore: bool) -> EffectiveRestoreMode:
-    if cli_restore:
-        return EffectiveRestoreMode.AUTO
+    if not cli_restore:
+        return EffectiveRestoreMode.FRESH
     mapping = {
         RestoreMode.FRESH: EffectiveRestoreMode.FRESH,
         RestoreMode.PROVIDER: EffectiveRestoreMode.PROVIDER,
         RestoreMode.AUTO: EffectiveRestoreMode.AUTO,
     }
     return mapping[default_mode]
+
+
+def should_restore_provider_history(default_mode: RestoreMode, *, cli_restore: bool) -> bool:
+    return resolve_effective_restore_mode(default_mode, cli_restore=cli_restore) is not EffectiveRestoreMode.FRESH
 
 
 def resolve_effective_permission_mode(

--- a/lib/cli/parser_runtime/ask.py
+++ b/lib/cli/parser_runtime/ask.py
@@ -8,6 +8,8 @@ from .constants import ASK_FLAG_OPTIONS, ASK_JOB_ACTIONS, ASK_OPTIONS_WITH_VALUE
 _REMOVED_ASK_FLAGS = {
     '--sync': 'async submit is already the default',
     '--async': 'omit the flag; async submit is already the default',
+    '--wait': 'submit with `ask <agent> -- <message>`, then wait with `ccb wait-all --timeout <seconds> <job_id>`',
+    '-w': 'submit with `ask <agent> -- <message>`, then wait with `ccb wait-all --timeout <seconds> <job_id>`',
 }
 
 

--- a/lib/provider_backends/claude/launcher_runtime/service.py
+++ b/lib/provider_backends/claude/launcher_runtime/service.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import json
 import shlex
 
+from agents.policy import should_restore_provider_history
 from provider_core.caller_env import (
     caller_context_env,
     export_env_clause,
@@ -59,7 +60,11 @@ def build_start_cmd(
     provider_start_parts_fn,
 ) -> str:
     profile = load_profile_fn(runtime_dir)
-    restore_target = resolve_restore_target_fn(spec=spec, runtime_dir=runtime_dir, restore=command.restore)
+    restore_target = resolve_restore_target_fn(
+        spec=spec,
+        runtime_dir=runtime_dir,
+        restore=should_restore_provider_history(spec.restore_default, cli_restore=command.restore),
+    )
     home_overrides = prepare_home_overrides_fn(
         runtime_dir,
         profile,
@@ -82,7 +87,7 @@ def build_start_cmd(
     if settings_path is not None:
         cmd_parts.extend(['--settings', str(settings_path)])
     if command.auto_permission:
-        cmd_parts.extend(['--permission-mode', 'bypassPermissions'])
+        cmd_parts.append('--dangerously-skip-permissions')
     if restore_target.has_history:
         cmd_parts.append('--continue')
     cmd_parts.extend(spec.startup_args)
@@ -107,7 +112,7 @@ def resolve_run_cwd(
         spec=spec,
         runtime_dir=runtime_dir,
         workspace_path=plan.workspace_path,
-        restore=command.restore,
+        restore=should_restore_provider_history(spec.restore_default, cli_restore=command.restore),
     ).run_cwd
 
 

--- a/lib/provider_backends/codex/launcher_runtime/command_runtime/service.py
+++ b/lib/provider_backends/codex/launcher_runtime/command_runtime/service.py
@@ -5,6 +5,7 @@ import shlex
 from pathlib import Path
 from typing import Callable
 
+from agents.policy import should_restore_provider_history
 from provider_core.caller_env import caller_context_env, provider_user_session_env
 from provider_backends.codex.runtime_artifacts import codex_runtime_artifact_layout
 from provider_backends.codex.session_authority import (
@@ -96,7 +97,7 @@ def _codex_args(command, spec, runtime_dir: Path, *, profile, provider_start_par
             ]
         )
     codex_args.extend(spec.startup_args)
-    if command.restore:
+    if should_restore_provider_history(spec.restore_default, cli_restore=command.restore):
         session_id = load_resume_session_id_fn(
             spec,
             runtime_dir,

--- a/lib/provider_hooks/settings_runtime/claude.py
+++ b/lib/provider_hooks/settings_runtime/claude.py
@@ -27,6 +27,15 @@ def trust_claude_workspace(*, home_root: Path, workspace_path: Path) -> Path:
         record = {}
     record['hasTrustDialogAccepted'] = True
     data[key] = record
+    projects = data.get('projects')
+    if not isinstance(projects, dict):
+        projects = {}
+    project_record = projects.get(key)
+    if not isinstance(project_record, dict):
+        project_record = {}
+    project_record['hasTrustDialogAccepted'] = True
+    projects[key] = project_record
+    data['projects'] = projects
     save_json(layout.trust_path, data)
     return layout.trust_path
 

--- a/test/test_install_droid_delegation.py
+++ b/test/test_install_droid_delegation.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INSTALL_SH = REPO_ROOT / "install.sh"
+
+
+def _python310_executable() -> str:
+    for candidate in (
+        sys.executable,
+        "python3.14",
+        "python3.13",
+        "python3.12",
+        "python3.11",
+        "python3.10",
+        "python3",
+        "python",
+    ):
+        try:
+            output = subprocess.check_output(
+                [
+                    candidate,
+                    "-c",
+                    "import sys\nif sys.version_info < (3, 10): raise SystemExit(1)\nprint(sys.executable)",
+                ],
+                stderr=subprocess.DEVNULL,
+                text=True,
+            ).strip()
+        except (OSError, subprocess.CalledProcessError):
+            continue
+        if output:
+            return output
+    raise AssertionError("Python 3.10+ is required to test Droid delegation install")
+
+
+def _run_install_snippet(
+    tmp_path: Path,
+    body: str,
+    *,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    home_dir = tmp_path / "home"
+    home_dir.mkdir(exist_ok=True)
+    python310 = _python310_executable()
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(home_dir),
+            "CODEX_INSTALL_PREFIX": str(tmp_path / "install"),
+            "CODEX_BIN_DIR": str(tmp_path / "bin"),
+            "CCB_LANG": "en",
+            "CCB_SOURCE_KIND": "source",
+            "CCB_SOURCE_ROOT": str(REPO_ROOT),
+            "CCB_PYTHON_BIN": python310,
+        }
+    )
+    if extra_env:
+        env.update(extra_env)
+    command = textwrap.dedent(
+        f"""
+        set -euo pipefail
+        source {shlex.quote(str(INSTALL_SH))}
+        {body}
+        """
+    )
+    return subprocess.run(
+        ["bash", "-lc", command],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=REPO_ROOT,
+    )
+
+
+def _write_fake_droid(bin_dir: Path, script: str) -> Path:
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    droid = bin_dir / "droid"
+    droid.write_text(script, encoding="utf-8")
+    droid.chmod(0o755)
+    return droid
+
+
+def test_install_droid_delegation_registers_with_selected_python(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "fake-bin"
+    args_marker = tmp_path / "droid-args.txt"
+    _write_fake_droid(
+        fake_bin,
+        (
+            "#!/usr/bin/env bash\n"
+            "printf '%s\\n' \"$@\" > \"$DROID_ARGS_MARKER\"\n"
+        ),
+    )
+
+    completed = _run_install_snippet(
+        tmp_path,
+        """
+        export PATH="$FAKE_DROID_BIN:$PATH"
+        install_droid_delegation
+        """,
+        extra_env={
+            "FAKE_DROID_BIN": str(fake_bin),
+            "DROID_ARGS_MARKER": str(args_marker),
+        },
+    )
+
+    assert completed.returncode == 0, completed.stderr or completed.stdout
+    assert "OK: Droid MCP delegation registered" in completed.stdout
+    args = args_marker.read_text(encoding="utf-8").splitlines()
+    assert args == [
+        "mcp",
+        "add",
+        "ccb-delegation",
+        "--type",
+        "stdio",
+        _python310_executable(),
+        str(REPO_ROOT / "mcp" / "ccb-delegation" / "server.py"),
+    ]
+
+
+def test_install_droid_delegation_timeout_warns_without_failing_install(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "fake-bin"
+    _write_fake_droid(
+        fake_bin,
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            sleep 5
+            """
+        ),
+    )
+
+    completed = _run_install_snippet(
+        tmp_path,
+        """
+        export PATH="$FAKE_DROID_BIN:$PATH"
+        CCB_DROID_AUTOINSTALL_TIMEOUT_S=0.2
+        install_droid_delegation
+        echo install-continued
+        """,
+        extra_env={"FAKE_DROID_BIN": str(fake_bin)},
+    )
+
+    assert completed.returncode == 0, completed.stderr or completed.stdout
+    assert "WARN: Failed to register Droid MCP delegation within 0.2s" in completed.stdout
+    assert "install-continued" in completed.stdout

--- a/test/test_install_source_dev_mode.py
+++ b/test/test_install_source_dev_mode.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import shlex
 import subprocess
+import sys
 import textwrap
 from pathlib import Path
 
@@ -11,9 +12,38 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 INSTALL_SH = REPO_ROOT / "install.sh"
 
 
+def _python310_executable() -> str:
+    for candidate in (
+        sys.executable,
+        "python3.14",
+        "python3.13",
+        "python3.12",
+        "python3.11",
+        "python3.10",
+        "python3",
+        "python",
+    ):
+        try:
+            output = subprocess.check_output(
+                [
+                    candidate,
+                    "-c",
+                    "import sys\nif sys.version_info < (3, 10): raise SystemExit(1)\nprint(sys.executable)",
+                ],
+                stderr=subprocess.DEVNULL,
+                text=True,
+            ).strip()
+        except (OSError, subprocess.CalledProcessError):
+            continue
+        if output:
+            return output
+    raise AssertionError("Python 3.10+ is required to test source/dev wrappers")
+
+
 def _run_source_dev_snippet(tmp_path: Path, shell_body: str) -> subprocess.CompletedProcess[str]:
     home_dir = tmp_path / "home"
     home_dir.mkdir()
+    python310 = _python310_executable()
     env = os.environ.copy()
     env.update(
         {
@@ -24,6 +54,7 @@ def _run_source_dev_snippet(tmp_path: Path, shell_body: str) -> subprocess.Compl
             "CCB_LANG": "en",
             "CCB_SOURCE_KIND": "source",
             "CCB_SOURCE_ROOT": str(REPO_ROOT),
+            "CCB_PYTHON_BIN": python310,
         }
     )
     command = textwrap.dedent(
@@ -47,19 +78,29 @@ def test_source_dev_install_links_live_bin_and_ask_skill_asset(tmp_path: Path) -
         tmp_path,
         """
         install_bin_links
+        verify_installed_entrypoints
         install_codex_skills
         """,
     )
 
     assert completed.returncode == 0, completed.stderr or completed.stdout
+    assert "OK: Installed entrypoints passed runtime smoke check" in completed.stdout
 
     bin_dir = tmp_path / "bin"
     ccb_path = bin_dir / "ccb"
     assert ccb_path.exists()
-    if ccb_path.is_symlink():
-        assert ccb_path.resolve() == REPO_ROOT / "ccb"
-    else:
-        assert str(REPO_ROOT / "ccb") in ccb_path.read_text(encoding="utf-8")
+    assert not ccb_path.is_symlink()
+    ccb_wrapper = ccb_path.read_text(encoding="utf-8")
+    assert ccb_wrapper.startswith("#!/usr/bin/env bash")
+    assert _python310_executable() in ccb_wrapper
+    assert str(REPO_ROOT / "ccb") in ccb_wrapper
+
+    ask_path = bin_dir / "ask"
+    assert ask_path.exists()
+    assert not ask_path.is_symlink()
+    ask_wrapper = ask_path.read_text(encoding="utf-8")
+    assert _python310_executable() in ask_wrapper
+    assert str(REPO_ROOT / "bin" / "ask") in ask_wrapper
 
     ask_skill_md = tmp_path / "codex-home" / "skills" / "ask" / "SKILL.md"
     assert ask_skill_md.is_symlink()
@@ -74,3 +115,53 @@ def test_source_dev_install_links_live_bin_and_ask_skill_asset(tmp_path: Path) -
     assert not (skills_dir / "ping").exists()
     assert not (skills_dir / "pend").exists()
     assert not (skills_dir / "file-op").exists()
+
+
+def test_python_selection_falls_back_to_versioned_python_command(tmp_path: Path) -> None:
+    home_dir = tmp_path / "home"
+    fake_bin = tmp_path / "fake-bin"
+    home_dir.mkdir()
+    fake_bin.mkdir()
+    for name in ("python3", "python3.14", "python3.13", "python3.11", "python3.10"):
+        (fake_bin / name).write_text("#!/usr/bin/env bash\nexit 1\n", encoding="utf-8")
+        (fake_bin / name).chmod(0o755)
+    (fake_bin / "python3.12").write_text(
+        (
+            "#!/usr/bin/env bash\n"
+            "if [[ \"${1:-}\" == \"-c\" && \"${2:-}\" == *sys.executable* ]]; then\n"
+            "  printf '%s\\n' \"$0\"\n"
+            "fi\n"
+            "exit 0\n"
+        ),
+        encoding="utf-8",
+    )
+    (fake_bin / "python3.12").chmod(0o755)
+    env = os.environ.copy()
+    env.pop("CCB_PYTHON_BIN", None)
+    env.update(
+        {
+            "HOME": str(home_dir),
+            "CODEX_INSTALL_PREFIX": str(tmp_path / "managed"),
+            "CODEX_BIN_DIR": str(tmp_path / "bin"),
+            "CCB_LANG": "en",
+        }
+    )
+    command = textwrap.dedent(
+        f"""
+        set -euo pipefail
+        source {shlex.quote(str(INSTALL_SH))}
+        export PATH={shlex.quote(str(fake_bin))}:$PATH
+        selected_python_executable
+        """
+    )
+
+    completed = subprocess.run(
+        ["bash", "-lc", command],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=REPO_ROOT,
+    )
+
+    assert completed.returncode == 0, completed.stderr or completed.stdout
+    assert completed.stdout.strip() == str(fake_bin / "python3.12")

--- a/test/test_provider_hook_settings.py
+++ b/test/test_provider_hook_settings.py
@@ -115,6 +115,7 @@ def test_install_claude_hooks_trusts_workspace_in_managed_home(tmp_path: Path) -
     trust_path = home_root / '.claude.json'
     trust_data = json.loads(trust_path.read_text(encoding='utf-8'))
     assert trust_data[str(workspace.resolve())]['hasTrustDialogAccepted'] is True
+    assert trust_data['projects'][str(workspace.resolve())]['hasTrustDialogAccepted'] is True
     assert not (workspace / '.claude').exists()
 
 

--- a/test/test_v2_cli_parser.py
+++ b/test/test_v2_cli_parser.py
@@ -202,6 +202,8 @@ def test_parse_ask_with_callback_flag(parser: CliParser) -> None:
     [
         (['ask', '--sync', 'agent1', 'ship', 'it'], '--sync is no longer supported'),
         (['ask', '--async', 'agent1', 'ship', 'it'], '--async is no longer supported'),
+        (['ask', '--wait', 'agent1', 'ship', 'it'], 'wait-all'),
+        (['ask', '-w', 'agent1', 'ship', 'it'], 'wait-all'),
     ],
 )
 def test_parse_ask_rejects_removed_alias_flags(parser: CliParser, argv: list[str], message: str) -> None:

--- a/test/test_v2_policy.py
+++ b/test/test_v2_policy.py
@@ -42,12 +42,12 @@ def test_launch_policy_matrix(
         queue_policy=QueuePolicy.SERIAL_PER_AGENT,
     )
 
-    policy = resolve_agent_launch_policy(spec, cli_restore=False, cli_auto_permission=False)
+    policy = resolve_agent_launch_policy(spec, cli_restore=True, cli_auto_permission=False)
     assert policy.permission_mode is expected_permission
     assert policy.restore_mode is expected_restore
 
 
-def test_cli_flags_override_launch_policy_defaults() -> None:
+def test_cli_new_context_forces_fresh_restore_policy() -> None:
     spec = AgentSpec(
         name='agent1',
         provider='claude',
@@ -55,13 +55,13 @@ def test_cli_flags_override_launch_policy_defaults() -> None:
         workspace_mode=WorkspaceMode.GIT_WORKTREE,
         workspace_root=None,
         runtime_mode='pane',
-        restore_default=RestoreMode.FRESH,
+        restore_default=RestoreMode.PROVIDER,
         permission_default=PermissionMode.MANUAL,
         queue_policy=QueuePolicy.REJECT_WHEN_BUSY,
     )
 
-    policy = resolve_agent_launch_policy(spec, cli_restore=True, cli_auto_permission=True)
+    policy = resolve_agent_launch_policy(spec, cli_restore=False, cli_auto_permission=True)
     assert policy.agent_name == 'agent1'
-    assert policy.restore_mode is EffectiveRestoreMode.AUTO
+    assert policy.restore_mode is EffectiveRestoreMode.FRESH
     assert policy.permission_mode is PermissionMode.AUTO
     assert policy.queue_policy == 'reject-when-busy'

--- a/test/test_v2_runtime_launch.py
+++ b/test/test_v2_runtime_launch.py
@@ -864,7 +864,7 @@ def test_ensure_agent_runtime_launches_named_claude_session(monkeypatch, tmp_pat
     assert payload['start_cmd'].endswith(
         f'claude --setting-sources user,project,local --settings '
         f'{shlex.quote(str(ctx.paths.agent_dir("reviewer") / "provider-runtime" / "claude" / "claude-settings.json"))} '
-        '--permission-mode bypassPermissions --continue'
+        '--dangerously-skip-permissions --continue'
     )
     settings_payload = json.loads(
         (ctx.paths.agent_dir('reviewer') / 'provider-runtime' / 'claude' / 'claude-settings.json').read_text(
@@ -1598,6 +1598,33 @@ def test_codex_launcher_build_start_cmd_uses_agent_scoped_resume_session(monkeyp
     assert 'agent2-session-id' not in cmd
 
 
+def test_codex_launcher_build_start_cmd_respects_agent_restore_fresh(monkeypatch, tmp_path: Path) -> None:
+    project_root = tmp_path / 'repo-codex-fresh'
+    runtime_dir = project_root / '.ccb' / 'agents' / 'agent1' / 'provider-runtime' / 'codex'
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    spec = AgentSpec(
+        name='agent1',
+        provider='codex',
+        target='.',
+        workspace_mode=WorkspaceMode.GIT_WORKTREE,
+        workspace_root=None,
+        runtime_mode=RuntimeMode.PANE_BACKED,
+        restore_default=RestoreMode.FRESH,
+        permission_default=PermissionMode.MANUAL,
+        queue_policy=QueuePolicy.SERIAL_PER_AGENT,
+    )
+    command = ParsedStartCommand(project=None, agent_names=('agent1',), restore=True, auto_permission=False)
+
+    monkeypatch.setattr(
+        'provider_backends.codex.launcher_runtime.command.load_resume_session_id',
+        lambda *args, **kwargs: pytest.fail('fresh restore must not inspect Codex resume sessions'),
+    )
+
+    cmd = _codex_start_cmd(command, spec, runtime_dir, 'sess-fresh')
+
+    assert ' resume ' not in f' {cmd} '
+
+
 def test_codex_launcher_build_start_cmd_reads_resume_cmd_from_agent_scoped_session_file(tmp_path: Path) -> None:
     project_root = tmp_path / 'repo-codex-agent'
     runtime_dir = project_root / '.ccb' / 'agents' / 'codex' / 'provider-runtime' / 'codex'
@@ -1674,10 +1701,50 @@ def test_claude_launcher_build_start_cmd_uses_overlay_and_drops_dead_local_user_
     )
     assert start_cmd.endswith(
         f'claude --setting-sources user,project,local --settings {shlex.quote(str(runtime_dir / "claude-settings.json"))} '
-        '--permission-mode bypassPermissions --continue'
+        '--dangerously-skip-permissions --continue'
     )
     settings_payload = json.loads((runtime_dir / 'claude-settings.json').read_text(encoding='utf-8'))
     assert settings_payload['skipDangerousModePermissionPrompt'] is True
+
+
+def test_claude_launcher_build_start_cmd_respects_agent_restore_fresh(monkeypatch, tmp_path: Path) -> None:
+    runtime_dir = tmp_path / 'runtime-claude-fresh'
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    spec = AgentSpec(
+        name='reviewer',
+        provider='claude',
+        target='.',
+        workspace_mode=WorkspaceMode.GIT_WORKTREE,
+        workspace_root=None,
+        runtime_mode=RuntimeMode.PANE_BACKED,
+        restore_default=RestoreMode.FRESH,
+        permission_default=PermissionMode.MANUAL,
+        queue_policy=QueuePolicy.SERIAL_PER_AGENT,
+    )
+    command = ParsedStartCommand(project=None, agent_names=('reviewer',), restore=True, auto_permission=True)
+    observed_restore_flags: list[bool] = []
+
+    def fake_restore_target(**kwargs):
+        observed_restore_flags.append(bool(kwargs['restore']))
+        return ProviderRestoreTarget(run_cwd=runtime_dir, has_history=bool(kwargs['restore']))
+
+    monkeypatch.setattr(claude_launcher, '_resolve_claude_restore_target', fake_restore_target)
+    monkeypatch.setattr(
+        'provider_backends.claude.launcher.write_claude_settings_overlay',
+        lambda runtime_dir, profile=None: runtime_dir / 'claude-settings.json',
+    )
+
+    start_cmd = claude_launcher.build_start_cmd(
+        command,
+        spec,
+        runtime_dir,
+        'claude-sess-fresh',
+        prepared_state=_claude_prepared_state(runtime_dir),
+    )
+
+    assert observed_restore_flags == [False]
+    assert '--dangerously-skip-permissions' in start_cmd
+    assert '--continue' not in start_cmd
 
 
 def test_claude_launcher_build_start_cmd_includes_agent_model_shortcut(tmp_path: Path) -> None:
@@ -2413,7 +2480,7 @@ def test_claude_launcher_build_start_cmd_uses_isolated_profile_api_env(monkeypat
     assert f'ANTHROPIC_AUTH_TOKEN={shlex.quote("profile-token")}' in start_cmd
     assert 'https://example.invalid/claude' not in start_cmd
     assert f'--settings {shlex.quote(str(runtime_dir / "claude-settings.json"))}' in start_cmd
-    assert '--permission-mode bypassPermissions' in start_cmd
+    assert '--dangerously-skip-permissions' in start_cmd
     settings_payload = json.loads((runtime_dir / 'claude-settings.json').read_text(encoding='utf-8'))
     assert settings_payload['skipDangerousModePermissionPrompt'] is True
 


### PR DESCRIPTION
## 摘要

这个 PR 加固了 CCB 的源码/开发模式安装流程，以及 Claude/Codex provider 启动恢复逻辑。

主要改动：

- 安装时解析并使用兼容的 Python 3.10+ 可执行文件，避免运行时落到错误 Python。
- 源码/开发模式安装改为生成 Python entrypoint wrapper，避免脆弱的 symlink、旧路径或 PATH 顺序问题。
- 安装后增加 `ccb --print-version` 和 `ask --help` smoke check，安装阶段即可发现不可用入口。
- 改进可选 `watchdog` 安装处理。
- Droid MCP delegation 注册使用安装阶段选定的 Python。
- `ask --wait` / `ask -w` 增加迁移提示，引导使用 `ccb wait-all`。
- 修正 restore 策略：普通 `ccb` 允许恢复 CCB runtime，但必须尊重每个 agent 的 `restore = "fresh"` 配置。
- Claude agent 配置为 fresh 时不再强制追加 `--continue`。
- Codex agent 配置为 fresh 时不再强制 `resume` 历史会话。
- Claude 自动放权启动参数更新为 `--dangerously-skip-permissions`。
- Claude trust 写入同时兼容旧格式和 Claude Code 2.1.120 当前格式，避免某些 managed Claude home 停在 workspace trust prompt。
- 补充安装/runtime 问题分析文档和针对性回归测试。

## 解决的问题

这个 PR 解决了以下问题：

- 源码安装可能使用错误 Python 或旧安装路径，导致 rich TOML 解析、hooks、entrypoint wrapper 在运行时失败。
- 用户机器上同时存在 Volta、Homebrew、多个 Python、多个 Claude/Codex 安装路径时，安装结果容易依赖当前 shell PATH，行为不可预测。
- 执行普通 `ccb` 时，agent 级别的 `restore = "fresh"` 可能被忽略，导致 Claude/Codex 继续恢复旧 provider 会话，用户看到历史测试消息残留。
- Claude Code 新版本下旧的 bypass permission 参数可能导致启动失败或 degraded。
- 同一项目下一个 Claude pane 能正常进入、另一个 Claude pane 卡在 trust prompt，是因为只写入了旧 trust 数据结构。

## 根本原因

之前的安装流程把源码 checkout 路径、安装产物路径、当前 shell PATH、Python 解释器选择、provider CLI 发现混在一起处理。只要用户环境里存在多个 Python/Node/Volta/Homebrew/Claude/Codex 来源，安装后的 wrapper 或 hook 就可能引用到错误路径。

provider 启动侧也把 CCB runtime 恢复和 provider 自身历史恢复混在了一起。普通 `ccb` 应该可以恢复 tmux/runtime，但不应该越过 agent 自己的 `restore = "fresh"` 策略去强制 Claude `--continue` 或 Codex `resume`。

Claude Code 2.1.120 对权限跳过参数和 workspace trust 文件结构也有变化，旧写法不足以覆盖新版本行为。

## 验证

已执行以下测试：

```bash
/tmp/ccb-py312-test/bin/python -m pytest   test/test_install_source_dev_mode.py   test/test_install_droid_delegation.py   test/test_install_watchdog_optional.py   test/test_v2_cli_parser.py   test/test_v2_policy.py   test/test_v2_runtime_launch.py   -k 'not real_tmux'
```

结果：

```text
123 passed
```

继续执行：

```bash
/tmp/ccb-py312-test/bin/python -m pytest   test/test_provider_hook_settings.py   test/test_v2_runtime_launch.py   test/test_v2_policy.py   -k 'claude or restore_fresh or launch_policy or trust'
```

结果：

```text
39 passed
```

另外执行：

```bash
git diff --check
```

并在 `~/Desktop/procode/chat2image` 做过手动 smoke test：

```bash
ccb kill -f
CCB_NO_ATTACH=1 ccb
ccb ping all
```

确认 `lead`、`design`、`backend`、`review` 四个 pane 能挂载，runtime 状态为 healthy/idle 或 restored。