### PR TITLE
feat(provider): add agy backend (rebase + continue #211, closes #216)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ CCB is a project-level agent CLI workspace. It uses tmux to manage multiple real
 
 - **Real CLI sessions, not fake panels**: every agent pane runs the actual provider CLI.
 - **Visible collaboration**: the sidebar shows windows, agents, status, and communication; users can switch panes by mouse.
-- **Mixed providers**: one project can run Codex, Claude, Gemini, OpenCode, and Droid together.
+- **Mixed providers**: one project can run Codex, Claude, Gemini, OpenCode, Droid, and Antigravity (`agy`) together.
 - **Project config**: `.ccb/ccb.config` defines the team, layout, windows, worktrees, model, key, and url.
 - **Recoverable runtime**: CCB supervises agent panes and supports attach, restore, and project-scoped cleanup.
 - **Explicit collaboration channel**: agents can delegate through `/ask`, `$ask`, callback, and silence routes.

--- a/README_zh.md
+++ b/README_zh.md
@@ -73,7 +73,7 @@ CCB 是一个项目级 agent CLI 工作台。它用 tmux 管理多个真实 CLI 
 
 - **真实 CLI，不是模拟面板**：每个 agent pane 都运行对应 provider 的真实 CLI。
 - **可见协作**：sidebar 展示窗口、agent 状态和通信区；用户可以用鼠标直接切 pane。
-- **混合 provider**：一个项目里可以同时跑 Codex、Claude、Gemini、OpenCode、Droid。
+- **混合 provider**：一个项目里可以同时跑 Codex、Claude、Gemini、OpenCode、Droid 和 Antigravity（`agy`）。
 - **项目级配置**：`.ccb/ccb.config` 决定团队、布局、窗口、worktree、model、key、url。
 - **可恢复运行态**：CCB 后台守护 agent pane，支持 attach、恢复和项目级清理。
 - **显式协作通道**：agent 可以通过 `/ask`、`$ask`、callback 和 silence 进行委派与交接。

--- a/lib/provider_backends/agy/__init__.py
+++ b/lib/provider_backends/agy/__init__.py
@@ -1,0 +1,17 @@
+from provider_core.contracts import ProviderBackend
+
+from .launcher import build_runtime_launcher
+from .manifest import build_manifest
+from .session import build_session_binding
+
+
+def build_backend() -> ProviderBackend:
+    return ProviderBackend(
+        manifest=build_manifest(),
+        execution_adapter=None,
+        session_binding=build_session_binding(),
+        runtime_launcher=build_runtime_launcher(),
+    )
+
+
+__all__ = ['build_backend']

--- a/lib/provider_backends/agy/launcher.py
+++ b/lib/provider_backends/agy/launcher.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import shlex
+from pathlib import Path
+
+from agents.models import AgentSpec
+from cli.context import CliContext
+from cli.models import ParsedStartCommand
+from provider_core.caller_env import (
+    caller_context_env,
+    export_env_clause,
+    join_env_prefix,
+    provider_user_session_env,
+)
+from provider_core.contracts import ProviderRuntimeLauncher
+from provider_core.runtime_shared import provider_start_parts
+from workspace.models import WorkspacePlan
+
+
+_YOLO_FLAG = '--dangerously-skip-permissions'
+
+
+def build_runtime_launcher() -> ProviderRuntimeLauncher:
+    return ProviderRuntimeLauncher(
+        provider='agy',
+        launch_mode='simple_tmux',
+        prepare_launch_context=prepare_launch_context,
+        build_start_cmd=build_start_cmd,
+        build_session_payload=build_session_payload,
+    )
+
+
+def prepare_launch_context(
+    context: CliContext,
+    spec: AgentSpec,
+    plan: WorkspacePlan,
+    runtime_dir: Path,
+    prepared_state: dict[str, object],
+) -> dict[str, object]:
+    del runtime_dir
+    payload = dict(prepared_state or {})
+    payload['agent_name'] = spec.name
+    payload['project_root'] = str(context.project.project_root)
+    payload['workspace_path'] = str(prepared_state.get('run_cwd') or plan.workspace_path)
+    payload['agent_events_path'] = str(context.paths.agent_events_path(spec.name))
+    return payload
+
+
+def build_start_cmd(
+    command: ParsedStartCommand,
+    spec: AgentSpec,
+    runtime_dir,
+    launch_session_id: str,
+    *,
+    prepared_state: dict[str, object] | None = None,
+) -> str:
+    del prepared_state
+    cmd_parts = provider_start_parts('agy')
+    if command.auto_permission and _YOLO_FLAG not in cmd_parts and _YOLO_FLAG not in spec.startup_args:
+        cmd_parts.append(_YOLO_FLAG)
+    if command.restore and not _has_restore_arg(cmd_parts) and not _has_restore_arg(spec.startup_args):
+        cmd_parts.append('--continue')
+    cmd_parts.extend(spec.startup_args)
+    cmd = ' '.join(shlex.quote(str(part)) for part in cmd_parts)
+    runtime_dir = Path(runtime_dir)
+    env_prefix = join_env_prefix(
+        export_env_clause(provider_user_session_env()),
+        export_env_clause(spec.env),
+        export_env_clause(
+            caller_context_env(actor=spec.name, runtime_dir=runtime_dir, launch_session_id=launch_session_id)
+        ),
+    )
+    if env_prefix:
+        return f'{env_prefix}; {cmd}'
+    return cmd
+
+
+def build_session_payload(
+    context: CliContext,
+    spec: AgentSpec,
+    plan: WorkspacePlan,
+    runtime_dir,
+    run_cwd,
+    pane_id: str,
+    pane_title_marker: str,
+    start_cmd: str,
+    launch_session_id: str,
+    prepared_state: dict[str, object],
+) -> dict[str, object]:
+    del context, spec, prepared_state
+    return {
+        'ccb_session_id': launch_session_id,
+        'runtime_dir': str(runtime_dir),
+        'completion_artifact_dir': str(runtime_dir / 'completion'),
+        'terminal': 'tmux',
+        'tmux_session': pane_id,
+        'pane_id': pane_id,
+        'pane_title_marker': pane_title_marker,
+        'workspace_path': str(plan.workspace_path),
+        'work_dir': str(run_cwd),
+        'start_cmd': start_cmd,
+    }
+
+
+def _has_restore_arg(parts: tuple[str, ...] | list[str]) -> bool:
+    normalized = {str(part).strip() for part in parts}
+    return bool({'--continue', '-c', '--conversation'} & normalized)
+
+
+__all__ = ['build_runtime_launcher', 'build_start_cmd', 'prepare_launch_context']

--- a/lib/provider_backends/agy/manifest.py
+++ b/lib/provider_backends/agy/manifest.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from agents.models import RuntimeMode
+from completion.models import CompletionFamily, CompletionSourceKind, SelectorFamily
+from completion.profiles import CompletionManifest
+from provider_core.manifests import ProviderManifest
+
+
+def build_manifest() -> ProviderManifest:
+    return ProviderManifest(
+        provider='agy',
+        supports_resume=True,
+        supports_permission_auto=True,
+        supports_stream_watch=False,
+        supports_subagents=True,
+        supports_workspace_attach=True,
+        runtime_profiles={
+            RuntimeMode.PANE_BACKED: CompletionManifest(
+                provider='agy',
+                runtime_mode=RuntimeMode.PANE_BACKED.value,
+                completion_family=CompletionFamily.TERMINAL_TEXT_QUIET,
+                completion_source_kind=CompletionSourceKind.TERMINAL_TEXT,
+                supports_exact_completion=False,
+                supports_observed_completion=False,
+                supports_anchor_binding=False,
+                supports_reply_stability=False,
+                supports_terminal_reason=False,
+                selector_family=SelectorFamily.FINAL_MESSAGE,
+            ),
+        },
+    )
+
+
+__all__ = ['build_manifest']

--- a/lib/provider_backends/agy/session.py
+++ b/lib/provider_backends/agy/session.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from provider_backends.pane_log_support.session import (
+    PaneLogProjectSessionBase,
+    build_session_binding_for_provider,
+    compute_session_key_for_provider,
+    load_project_session_for_provider,
+)
+from provider_core.contracts import ProviderSessionBinding
+
+
+@dataclass
+class AgyProjectSession(PaneLogProjectSessionBase):
+    @property
+    def agy_session_id(self) -> str:
+        return str(self.data.get('agy_session_id') or self.data.get('ccb_session_id') or '').strip()
+
+    @property
+    def agy_session_path(self) -> str:
+        return str(self.session_file)
+
+    def backend(self):
+        from terminal_runtime import get_backend_for_session
+
+        return get_backend_for_session(self.data)
+
+
+def find_project_session_file(work_dir: Path, instance: Optional[str] = None) -> Optional[Path]:
+    from provider_backends.pane_log_support.session import find_project_session_file_for_provider
+
+    return find_project_session_file_for_provider(
+        work_dir,
+        session_filename='.agy-session',
+        instance=instance,
+    )
+
+
+def load_project_session(work_dir: Path, instance: Optional[str] = None) -> Optional[AgyProjectSession]:
+    return load_project_session_for_provider(
+        work_dir,
+        session_filename='.agy-session',
+        session_cls=AgyProjectSession,
+        instance=instance,
+    )
+
+
+def compute_session_key(session: AgyProjectSession, instance: Optional[str] = None) -> str:
+    return compute_session_key_for_provider(session, provider='agy', instance=instance)
+
+
+def build_session_binding() -> ProviderSessionBinding:
+    return build_session_binding_for_provider(provider='agy', load_session=load_project_session)
+
+
+__all__ = [
+    'AgyProjectSession',
+    'build_session_binding',
+    'compute_session_key',
+    'find_project_session_file',
+    'load_project_session',
+]

--- a/lib/provider_core/registry_runtime/builtin_backends.py
+++ b/lib/provider_core/registry_runtime/builtin_backends.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 from provider_core.contracts import ProviderBackend
 
 CORE_PROVIDER_NAMES = ("codex", "claude", "gemini")
-OPTIONAL_PROVIDER_NAMES = ("opencode", "droid")
+OPTIONAL_PROVIDER_NAMES = ("opencode", "droid", "agy")
 
 
 def build_builtin_backends(*, include_optional: bool = True) -> list[ProviderBackend]:
+    from provider_backends.agy import build_backend as build_agy_backend
     from provider_backends.claude import build_backend as build_claude_backend
     from provider_backends.codex import build_backend as build_codex_backend
     from provider_backends.droid import build_backend as build_droid_backend
@@ -22,6 +23,7 @@ def build_builtin_backends(*, include_optional: bool = True) -> list[ProviderBac
         backends.extend([
             build_opencode_backend(),
             build_droid_backend(),
+            build_agy_backend(),
         ])
     return backends
 

--- a/lib/provider_core/runtime_shared.py
+++ b/lib/provider_core/runtime_shared.py
@@ -10,6 +10,7 @@ _PROVIDER_START_ENV_VARS = {
     'gemini': 'GEMINI_START_CMD',
     'opencode': 'OPENCODE_START_CMD',
     'droid': 'DROID_START_CMD',
+    'agy': 'AGY_START_CMD',
 }
 
 _PROVIDER_DEFAULT_EXECUTABLES = {
@@ -18,6 +19,7 @@ _PROVIDER_DEFAULT_EXECUTABLES = {
     'gemini': 'gemini',
     'opencode': 'opencode',
     'droid': 'droid',
+    'agy': 'agy',
 }
 
 

--- a/test/test_v2_provider_catalog.py
+++ b/test/test_v2_provider_catalog.py
@@ -28,6 +28,7 @@ def test_default_provider_catalog_contains_expected_profiles() -> None:
         'gemini',
         'opencode',
         'droid',
+        'agy',
     }
     codex = catalog.resolve_completion_manifest('codex', RuntimeMode.PANE_BACKED)
     assert codex.completion_family is CompletionFamily.PROTOCOL_TURN
@@ -39,6 +40,9 @@ def test_default_provider_catalog_contains_expected_profiles() -> None:
     assert fake_codex.completion_family is CompletionFamily.PROTOCOL_TURN
     fake_gemini = catalog.resolve_completion_manifest('fake-gemini', RuntimeMode.PANE_BACKED)
     assert fake_gemini.completion_family is CompletionFamily.ANCHORED_SESSION_STABILITY
+    assert catalog.get('agy').supports_resume is True
+    agy = catalog.resolve_completion_manifest('agy', RuntimeMode.PANE_BACKED)
+    assert agy.completion_family is CompletionFamily.TERMINAL_TEXT_QUIET
     fake_legacy = catalog.resolve_completion_manifest('fake-legacy', RuntimeMode.PANE_BACKED)
     assert fake_legacy.completion_family is CompletionFamily.TERMINAL_TEXT_QUIET
 
@@ -81,4 +85,4 @@ def test_provider_catalog_can_build_core_only_catalog() -> None:
     catalog = build_default_provider_catalog(include_optional=False, include_test_doubles=False)
     assert set(catalog.providers()) == set(CORE_PROVIDER_NAMES)
     assert set(CORE_PROVIDER_NAMES) == {'codex', 'claude', 'gemini'}
-    assert set(OPTIONAL_PROVIDER_NAMES) == {'opencode', 'droid'}
+    assert set(OPTIONAL_PROVIDER_NAMES) == {'opencode', 'droid', 'agy'}

--- a/test/test_v2_provider_core_registry.py
+++ b/test/test_v2_provider_core_registry.py
@@ -31,17 +31,19 @@ def test_backend_registry_exposes_manifests_execution_and_session_bindings() -> 
 def test_default_session_binding_map_uses_backend_owned_entries() -> None:
     bindings = build_default_session_binding_map(include_optional=True)
 
-    assert set(bindings) == {'codex', 'claude', 'gemini', 'opencode', 'droid'}
+    assert set(bindings) == {'codex', 'claude', 'gemini', 'opencode', 'droid', 'agy'}
     assert bindings['codex'].session_id_attr == 'codex_session_id'
     assert bindings['opencode'].session_path_attr == 'session_file'
+    assert bindings['agy'].session_path_attr == 'agy_session_path'
 
 
 def test_default_runtime_launcher_map_uses_backend_owned_entries() -> None:
     launchers = build_default_runtime_launcher_map(include_optional=True)
 
-    assert set(launchers) == {'codex', 'claude', 'gemini', 'opencode', 'droid'}
+    assert set(launchers) == {'codex', 'claude', 'gemini', 'opencode', 'droid', 'agy'}
     assert launchers['codex'].launch_mode == 'codex_tmux'
     assert launchers['gemini'].launch_mode == 'simple_tmux'
+    assert launchers['agy'].launch_mode == 'simple_tmux'
 
 
 def test_session_filename_for_agent_follows_agent_first_naming() -> None:

--- a/test/test_v2_runtime_launch.py
+++ b/test/test_v2_runtime_launch.py
@@ -1442,10 +1442,12 @@ def test_provider_start_parts_respect_env_override(monkeypatch: pytest.MonkeyPat
     monkeypatch.setenv('GEMINI_START_CMD', '/tmp/stub-gemini --flag')
     monkeypatch.setenv('CLAUDE_START_CMD', '/tmp/stub-claude')
     monkeypatch.setenv('CODEX_START_CMD', '/tmp/stub-codex --profile test')
+    monkeypatch.setenv('AGY_START_CMD', '/tmp/stub-agy --sandbox')
 
     assert runtime_launch._provider_start_parts('gemini') == ['/tmp/stub-gemini', '--flag']
     assert runtime_launch._provider_start_parts('claude') == ['/tmp/stub-claude']
     assert runtime_launch._provider_start_parts('codex') == ['/tmp/stub-codex', '--profile', 'test']
+    assert runtime_launch._provider_start_parts('agy') == ['/tmp/stub-agy', '--sandbox']
     assert runtime_launch._provider_executable('codex') == '/tmp/stub-codex'
 
 
@@ -1453,10 +1455,40 @@ def test_provider_start_parts_fall_back_to_default_binary(monkeypatch: pytest.Mo
     monkeypatch.delenv('GEMINI_START_CMD', raising=False)
     monkeypatch.delenv('CLAUDE_START_CMD', raising=False)
     monkeypatch.delenv('CODEX_START_CMD', raising=False)
+    monkeypatch.delenv('AGY_START_CMD', raising=False)
 
     assert runtime_launch._provider_start_parts('gemini') == ['gemini']
     assert runtime_launch._provider_start_parts('claude') == ['claude']
     assert runtime_launch._provider_start_parts('codex') == ['codex']
+    assert runtime_launch._provider_start_parts('agy') == ['agy']
+
+
+def test_agy_start_cmd_defaults_to_yolo_permission(tmp_path: Path) -> None:
+    from provider_backends.agy import launcher as agy_launcher
+
+    spec = _spec('debugger', provider='agy')
+    cmd = agy_launcher.build_start_cmd(
+        ParsedStartCommand(project=None, agent_names=('debugger',), restore=False, auto_permission=True),
+        spec,
+        tmp_path / 'runtime',
+        'ccb-debugger-test',
+    )
+
+    assert 'agy --dangerously-skip-permissions' in cmd
+
+
+def test_agy_start_cmd_uses_continue_for_restore(tmp_path: Path) -> None:
+    from provider_backends.agy import launcher as agy_launcher
+
+    spec = _spec('debugger', provider='agy')
+    cmd = agy_launcher.build_start_cmd(
+        ParsedStartCommand(project=None, agent_names=('debugger',), restore=True, auto_permission=False),
+        spec,
+        tmp_path / 'runtime',
+        'ccb-debugger-test',
+    )
+
+    assert 'agy --continue' in cmd
 
 
 def test_ensure_agent_runtime_falls_back_when_created_pane_is_too_small(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Add `agy` (Google Antigravity CLI) as a CCB provider backend
  (pane-backed startup only; no execution adapter yet).
- Rebases @bookandlover's PR #211 onto v7.1.1, drops the mouse-default
  hunks (already merged via #212), re-aligns tests for current main.

Tracks #216.

## What's included

| | |
|---|---|
| `lib/provider_backends/agy/__init__.py` | `build_backend()` returns `ProviderBackend` with `execution_adapter=None` |
| `lib/provider_backends/agy/launcher.py` | `build_runtime_launcher()`, `prepare_launch_context`, `build_start_cmd` (yolo / continue), `build_session_payload` |
| `lib/provider_backends/agy/manifest.py` | provider manifest with `TERMINAL_TEXT_QUIET` completion family |
| `lib/provider_backends/agy/session.py` | pane-log-backed session binding |
| `lib/provider_core/runtime_shared.py` | register `AGY_START_CMD` env + `agy` default executable |
| `lib/provider_core/registry_runtime/builtin_backends.py` | add `build_agy_backend()` to OPTIONAL providers |
| `test/test_v2_provider_catalog.py` | catalog contains agy + `supports_resume=True` + `TERMINAL_TEXT_QUIET` |
| `test/test_v2_provider_core_registry.py` | bindings/launchers maps include agy |
| `test/test_v2_runtime_launch.py` | `AGY_START_CMD` env override + `--dangerously-skip-permissions` default + `--continue` for restore |
| `README.md` + `README_zh.md` | list `agy` / Antigravity in supported providers |

## What's NOT included (intentional)

`execution_adapter=None`. `ccb ask cc-agy "..."` routing requires a
full adapter mirroring `codex/execution.py` + `execution_runtime` +
`comm.py` log reader. That will land as a follow-up PR after this one
merges, to keep this diff reviewable.

## Validation

```bash
$ uvx --with pyyaml --with tomli pytest \
    test/test_v2_provider_catalog.py \
    test/test_v2_provider_core_registry.py \
    test/test_v2_runtime_launch.py::test_provider_start_parts_respect_env_override \
    test/test_v2_runtime_launch.py::test_provider_start_parts_fall_back_to_default_binary \
    test/test_v2_runtime_launch.py::test_agy_start_cmd_defaults_to_yolo_permission \
    test/test_v2_runtime_launch.py::test_agy_start_cmd_uses_continue_for_restore -q
# 12 passed in 0.12s
```

## Credits

Continues PR #211 by @bookandlover. Picks up the four `agy/` files
and the `agy`-relevant test changes; drops PR #211's mouse-default
hunks (now handled by #212) and the un-related `ccb_session_id` /
clipboard test edits that were from #211's older base.

## Use case

After this lands, `.ccb/ccb.config` accepts:

```toml
[windows]
work = "debugger:agy(worktree), worker:codex(worktree)"
```

Multi-agent fan-out workflows mixing Codex / Claude / Anthropic-
compatible CC 分身 / Antigravity gain sidebar visibility for the
agy pane (vs. running `agy -p "..."` out-of-band in a separate
terminal).

cc @SeemSeam @bookandlover