### PR TITLE
test: include agy in OPTIONAL_EXECUTION_PROVIDERS assertion (hotfix #217 CI break)

### DIFF
--- a/test/test_v2_execution_registry.py
+++ b/test/test_v2_execution_registry.py
@@ -10,10 +10,11 @@ from provider_execution.registry import (
 def test_execution_registry_can_build_core_only_registry() -> None:
     registry = build_default_execution_registry(include_optional=False, include_test_doubles=False)
     assert set(CORE_EXECUTION_PROVIDERS) == {'codex', 'claude', 'gemini'}
-    assert set(OPTIONAL_EXECUTION_PROVIDERS) == {'opencode', 'droid'}
+    assert set(OPTIONAL_EXECUTION_PROVIDERS) == {'opencode', 'droid', 'agy'}
     assert registry.get('codex') is not None
     assert registry.get('claude') is not None
     assert registry.get('gemini') is not None
     assert registry.get('opencode') is None
     assert registry.get('droid') is None
+    assert registry.get('agy') is None
     assert registry.get('fake') is None


### PR DESCRIPTION
## Summary

Hotfix for the CI breakage on `main` after #217 merged. One test
expected the old `OPTIONAL_EXECUTION_PROVIDERS` set; #217 added `agy`
to `OPTIONAL_PROVIDER_NAMES` (which the execution registry aliases),
so the test needs to be updated.

**Broken CI run** (8/11 jobs failed, all with the same single
failure):
https://github.com/SeemSeam/claude_codex_bridge/actions/runs/26735236338

```
test/test_v2_execution_registry.py:13: in test_execution_registry_can_build_core_only_registry
    assert set(OPTIONAL_EXECUTION_PROVIDERS) == {'opencode', 'droid'}
E   AssertionError: assert {'agy', 'droid', 'opencode'} == {'droid', 'opencode'}
========== 1 failed, 2239 passed, 21 deselected in 1279.87s ==========
```

## Fix

`lib/provider_execution/registry.py:12`:

```python
OPTIONAL_EXECUTION_PROVIDERS = OPTIONAL_PROVIDER_NAMES
```

Pure alias — so the expected set must follow `OPTIONAL_PROVIDER_NAMES`
literally. Updates the assertion to `{'opencode', 'droid', 'agy'}` and
adds `assert registry.get('agy') is None` to maintain coverage
parity with opencode/droid in the `include_optional=False` path
(since agy has `execution_adapter=None` in #217 anyway).

## My mistake

I tested 12 agy-related test cases locally before opening #217 but
didn't run the **full** suite, so this test slipped through. PR #211
(the precursor I rebased) also did not catch it because they only ran
the 6 files listed in their PR description.

After this hotfix lands, the recommended verification command
becomes:

```bash
uvx --with pyyaml --with tomli pytest \
  test/test_v2_provider_catalog.py \
  test/test_v2_provider_core_registry.py \
  test/test_v2_execution_registry.py \
  test/test_v2_runtime_launch.py -q
```

Sorry for the breakage @SeemSeam — apologies for not catching this
in #217. 🙏