### PR TITLE
feat(provider): agy lifecycle glue on top of upstream backend

### DIFF
--- a/lib/cli/kill.py
+++ b/lib/cli/kill.py
@@ -47,7 +47,7 @@ def cmd_kill(
         yes = getattr(args, "yes", False)
         return kill_global_zombies(yes=yes, is_pid_alive=is_pid_alive)
 
-    providers = parse_providers(list(args.providers or ["codex", "gemini", "opencode", "claude", "droid"]))
+    providers = parse_providers(list(args.providers or ["codex", "gemini", "opencode", "claude", "droid", "agy"]))
     if not providers:
         return 2
 

--- a/lib/cli/kill_runtime/zombies.py
+++ b/lib/cli/kill_runtime/zombies.py
@@ -6,7 +6,7 @@ import shutil
 import subprocess
 from typing import Callable
 
-_ZOMBIE_SESSION_PATTERN = re.compile(r"^(codex|gemini|opencode|claude|droid)-(\d+)-")
+_ZOMBIE_SESSION_PATTERN = re.compile(r"^(codex|gemini|opencode|claude|droid|agy)-(\d+)-")
 
 
 def find_all_zombie_sessions(

--- a/test/test_cli_kill_runtime_zombies.py
+++ b/test/test_cli_kill_runtime_zombies.py
@@ -24,6 +24,7 @@ def test_find_all_zombie_sessions_filters_dead_parents() -> None:
         list_tmux_sessions_fn=lambda: [
             'codex-123-worker',
             'claude-456-run',
+            'agy-789-debugger',
             'demo-other',
         ],
     )
@@ -33,7 +34,12 @@ def test_find_all_zombie_sessions_filters_dead_parents() -> None:
             'session': 'codex-123-worker',
             'provider': 'codex',
             'parent_pid': 123,
-        }
+        },
+        {
+            'session': 'agy-789-debugger',
+            'provider': 'agy',
+            'parent_pid': 789,
+        },
     ]
 
 


### PR DESCRIPTION
Since `origin/main` already includes the main `agy` backend implementation (launcher, manifest, session), this PR contributes the remaining missing operational integrations to ensure complete stability:

1. **`lib/cli/kill.py`**: Includes `agy` in the default provider list for `ccb kill` commands.
2. **`lib/cli/kill_runtime/zombies.py`**: Adds regex support (`agy-*`) to recognize and clean up zombie tmux sessions for the `agy` provider, preventing orphan process leakage.
3. Test coverage for the zombie session recognition.

With this PR merged, the `agy` debugger integration runs robustly and cleanly on top of the upstream backend without any process leaks.