### PR TITLE
feat(layout): @percent pane split token

### DIFF
--- a/lib/agents/models_runtime/config_runtime/validation.py
+++ b/lib/agents/models_runtime/config_runtime/validation.py
@@ -75,6 +75,7 @@ def _normalize_layout_tree(node: LayoutNode) -> LayoutNode:
                 name=_normalize_layout_leaf_name(node.leaf.name),
                 provider=node.leaf.provider,
                 workspace_mode=node.leaf.workspace_mode,
+                percent=node.leaf.percent,
             ),
         )
     assert node.left is not None

--- a/lib/agents/models_runtime/layout_runtime/nodes.py
+++ b/lib/agents/models_runtime/layout_runtime/nodes.py
@@ -8,6 +8,7 @@ class LayoutLeaf:
     name: str
     provider: str | None = None
     workspace_mode: str | None = None
+    percent: int | None = None
 
 
 @dataclass(frozen=True)
@@ -48,11 +49,17 @@ class LayoutNode:
     def render(self) -> str:
         if self.kind == 'leaf':
             assert self.leaf is not None
+            parts = []
             if self.leaf.provider:
                 if str(self.leaf.workspace_mode or '').strip() == 'worktree':
-                    return f'{self.leaf.name}:{self.leaf.provider}(worktree)'
-                return f'{self.leaf.name}:{self.leaf.provider}'
-            return self.leaf.name
+                    parts.append(f'{self.leaf.name}:{self.leaf.provider}(worktree)')
+                else:
+                    parts.append(f'{self.leaf.name}:{self.leaf.provider}')
+            else:
+                parts.append(self.leaf.name)
+            if self.leaf.percent is not None:
+                parts.append(f'@{self.leaf.percent}')
+            return ''.join(parts)
         assert self.left is not None
         assert self.right is not None
         sep = ';' if self.kind == 'horizontal' else ','

--- a/lib/agents/models_runtime/layout_runtime/parser.py
+++ b/lib/agents/models_runtime/layout_runtime/parser.py
@@ -8,7 +8,8 @@ _LEAF_TOKEN_RE = re.compile(
     r'(?P<name>[A-Za-z][A-Za-z0-9_.-]{0,63})'
     r'(?:\s*:\s*(?P<provider>[A-Za-z0-9_-]+)'
     r'(?:\s*\(\s*(?P<workspace_mode>worktree)\s*\))?'
-    r')?$'
+    r')?'
+    r'(?:\s*@\s*(?P<percent>\d+))?$'
 )
 
 
@@ -64,12 +65,15 @@ class _LayoutParser:
             raise LayoutParseError(
                 f"invalid layout token {token!r}; expected 'cmd', 'agent', 'agent:provider', or 'agent:provider(worktree)'"
             )
+        pct_str = match.group('percent')
+        pct = int(pct_str) if pct_str is not None else None
         return LayoutNode(
             kind='leaf',
             leaf=LayoutLeaf(
                 name=match.group('name').strip(),
                 provider=(match.group('provider') or None),
                 workspace_mode=(match.group('workspace_mode') or None),
+                percent=pct,
             ),
         )
 

--- a/lib/ccbd/services/project_namespace_runtime/materialize_topology.py
+++ b/lib/ccbd/services/project_namespace_runtime/materialize_topology.py
@@ -382,6 +382,16 @@ def _materialize_tool_window(
     )
 
 
+def _get_specified_percent(node: Any) -> int | None:
+    if node.kind == 'leaf':
+        assert node.leaf is not None
+        return node.leaf.percent
+    for leaf in node.iter_leaves():
+        if getattr(leaf, 'percent', None) is not None:
+            return leaf.percent
+    return None
+
+
 def _materialize_layout(
     controller,
     context,
@@ -398,9 +408,18 @@ def _materialize_layout(
 
     assert node.left is not None
     assert node.right is not None
-    total = max(1, node.leaf_count)
-    right_count = max(1, node.right.leaf_count)
-    percent = max(1, min(99, round((right_count * 100) / total)))
+
+    right_pct = _get_specified_percent(node.right)
+    left_pct = _get_specified_percent(node.left)
+    if right_pct is not None:
+        percent = max(1, min(99, right_pct))
+    elif left_pct is not None:
+        percent = max(1, min(99, 100 - left_pct))
+    else:
+        total = max(1, node.leaf_count)
+        right_count = max(1, node.right.leaf_count)
+        percent = max(1, min(99, round((right_count * 100) / total)))
+
     direction = 'right' if node.kind == 'horizontal' else 'bottom'
     new_pane_id = split_pane(
         context.backend,

--- a/lib/cli/services/tmux_start_layout.py
+++ b/lib/cli/services/tmux_start_layout.py
@@ -76,6 +76,16 @@ def prepare_tmux_start_layout(
     )
 
 
+def _get_specified_percent(node: Any) -> int | None:
+    if node.kind == 'leaf':
+        assert node.leaf is not None
+        return node.leaf.percent
+    for leaf in node.iter_leaves():
+        if getattr(leaf, 'percent', None) is not None:
+            return leaf.percent
+    return None
+
+
 def _materialize_layout(
     backend,
     *,
@@ -91,9 +101,18 @@ def _materialize_layout(
 
     assert node.left is not None
     assert node.right is not None
-    total = max(1, node.leaf_count)
-    right_count = max(1, node.right.leaf_count)
-    percent = max(1, min(99, round((right_count * 100) / total)))
+
+    right_pct = _get_specified_percent(node.right)
+    left_pct = _get_specified_percent(node.left)
+    if right_pct is not None:
+        percent = max(1, min(99, right_pct))
+    elif left_pct is not None:
+        percent = max(1, min(99, 100 - left_pct))
+    else:
+        total = max(1, node.leaf_count)
+        right_count = max(1, node.right.leaf_count)
+        percent = max(1, min(99, round((right_count * 100) / total)))
+
     direction = 'right' if node.kind == 'horizontal' else 'bottom'
     new_pane_id = backend.split_pane(
         parent_pane_id,

--- a/test/test_agents_layout_runtime.py
+++ b/test/test_agents_layout_runtime.py
@@ -28,6 +28,23 @@ def test_parse_layout_spec_accepts_role_id_leaf_token() -> None:
     assert layout.render() == 'agent1:codex, agentroles.archi:codex'
 
 
+@pytest.mark.parametrize(
+    'spec, expected_percent',
+    [
+        ('debugger:agy@30', 30),
+        ('reviewer:claude@50', 50),
+        ('debugger:agy', None),
+    ],
+)
+def test_parse_layout_spec_percent_token(spec: str, expected_percent: int | None) -> None:
+    # @percent 令牌:显式指定 pane 分屏百分比,渲染往返保持
+    layout = parse_layout_spec(spec)
+    assert layout.kind == 'leaf'
+    assert layout.leaf is not None
+    assert layout.leaf.percent == expected_percent
+    assert layout.render() == spec
+
+
 def test_prune_layout_preserves_branch_shape_when_possible() -> None:
     layout = parse_layout_spec('cmd; (agent1:codex, agent2:claude)')
 


### PR DESCRIPTION
## What

Adds an optional `@N` suffix to layout leaf tokens to explicitly set a pane's
split percentage, e.g. `agent1:codex@30` or `reviewer:claude@50`. Without the
suffix, panes keep the current behaviour of dividing evenly by leaf count, so
this is fully backward compatible.

## Why

Sibling panes are currently always split evenly. There is no way to express an
asymmetric split (e.g. a wide review pane next to a narrow tool pane) from the
layout spec. The `@N` token makes the split ratio explicit and round-trips
through render.

## How

- `layout_runtime/nodes.py`: `LayoutLeaf` gains a `percent` field; parse/render
  round-trip the `@N` token
- `layout_runtime/parser.py`: parse the `@N` suffix into `percent`
- `config_runtime/validation.py`: preserve `percent` during normalization
- both materialize paths honour an explicit `percent` over even division via a
  shared `_get_specified_percent` helper:
  - daemon: `materialize_topology._materialize_layout`
  - cli: `tmux_start_layout`

## Tests

- `test_agents_layout_runtime.py`: parametrized round-trip test covering `@30`,
  `@50`, and the no-suffix (`None`) case
- `test/test_agents_layout_runtime.py` — 9 passed on top of current `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
