### PR TITLE
feat(agy): add pane_quiet execution adapter

### DIFF
--- a/docs/agy-adapter/PLAN.md
+++ b/docs/agy-adapter/PLAN.md
@@ -1,0 +1,250 @@
+# agy provider — execution adapter implementation plan
+
+Branch: `feat/agy-execution-adapter`
+Status cursor: see `## Progress cursor` near the bottom — update it after every milestone.
+
+## 1. 背景与根因
+
+### 现象
+
+把一个 agent 配为 `provider = "agy"`，跑 `ccb ask <agent> "..."`：
+
+1. `ccb ask` 立刻返回 `accepted job=...`
+2. `ccb pend <agent>` 显示 `status: running` `reply:` 空
+3. `ccb trace <job_id>` 显示 attempt 永远停在 `state=delivering`
+4. agy 自己的 tmux pane 里**完全没有**任何输入被注入，agy CLI 一直停在 `>` 提示符
+5. ccbd 重启时 `ccb ping <agent>` 报：
+   ```
+   restore_mode: resubmit_required
+   restore_reason: adapter_missing
+   restore_detail: provider agy has no registered execution adapter
+   ```
+
+### 根因
+
+`lib/provider_backends/agy/__init__.py`
+
+```python
+def build_backend() -> ProviderBackend:
+    return ProviderBackend(
+        manifest=build_manifest(),
+        execution_adapter=None,   # ← 缺
+        session_binding=build_session_binding(),
+        runtime_launcher=build_runtime_launcher(),
+    )
+```
+
+agy backend 显式把 `execution_adapter` 置 None，且 `provider_backends/agy/` 下根本没有
+`execution.py`。其他生产可用的 provider（claude / codex / gemini / opencode / droid）都形如：
+
+```python
+from .execution import build_execution_adapter
+...
+execution_adapter=build_execution_adapter(),
+```
+
+后果：
+- `ccb` 可以启动 agy 的 tmux pane（`runtime_launcher` 存在）
+- 但 `ccb ask` 没有「把 prompt 投递到 pane / 读 reply」的执行路径
+- ccbd 的 mailbox 把 attempt 停在 `delivering`，永不推进
+
+`OPTIONAL_PROVIDER_NAMES` 里包含 `agy`（`provider_core/registry_runtime/builtin_backends.py`），
+所以 agy backend 会被 `build_default_execution_adapters` 调用到，但因为
+`execution_adapter=None`，注册环节直接被 `ProviderBackendRegistry.execution_adapters()` 过滤掉了：
+
+```python
+def execution_adapters(self):
+    return [b.execution_adapter for b in self._backends.values()
+            if b.execution_adapter is not None]
+```
+
+→ 注册表里没有 agy → `adapter_missing`。
+
+## 2. agy 现状摸排
+
+`lib/provider_backends/agy/` 已有：
+- `__init__.py`  build_backend（待修）
+- `manifest.py`  声明 `CompletionFamily.TERMINAL_TEXT_QUIET`、`SelectorFamily.FINAL_MESSAGE`、`CompletionSourceKind.TERMINAL_TEXT`
+- `session.py`   基于 `provider_backends.pane_log_support`，把 `.agy-session` 文件读成 `AgyProjectSession`
+- `launcher.py`  `simple_tmux` 模式，pane 起 agy CLI，工作目录 = workspace_path
+
+→ 已经具备 pane 起得来的能力。缺的只是 execution 那一层。
+
+manifest 已经定调：completion 检测走 **terminal-text-quiet**，selector 走 **final-message** —
+意味着 adapter 不需要解析 agy 写出来的 JSONL（agy 也没有），只需要：
+
+1. 把 prompt 字符串通过 tmux send-keys 打进 pane
+2. 监听 pane 输出，等「画面安静 N 秒」或显式的 done marker
+3. 抓 pane 中模型回复段当 reply
+
+## 3. 设计与对照参考
+
+### 对照表
+
+| Provider | completion family | reply 来源 | 抓 reply 方式 |
+|---|---|---|---|
+| claude | session_event_log | 内置 JSONL session log | 解析 jsonl |
+| codex | session_event_log | codex JSONL log | 解析 jsonl |
+| droid | TERMINAL_TEXT_QUIET | pane / droid log | log + pane 抓取 |
+| opencode | session_event_log | `~/.local/share/opencode` storage | 读 storage |
+| **agy（目标）** | TERMINAL_TEXT_QUIET | **pane 输出** | pane 抓取 + done marker / 静默检测 |
+
+droid 是结构最接近的，但 droid 还有 `comm.py` + `comm_runtime/` 一整套抓 droid log 的支撑。
+agy 没有可用的 log 文件 → 只能纯靠 pane 抓取。
+
+### 可复用的现成工具
+
+`lib/provider_backends/pane_log_support/` 是给所有 pane-based provider 准备的共享层，已经被
+codex / gemini / opencode / droid session 复用：
+- `reader.py` / `reader_runtime/`  pane 输出读取
+- `communicator.py`                 send-keys 抽象
+- `parsing.py`                       文本解析助手
+- `lifecycle*.py`                    生命周期
+
+→ agy execution adapter **只在这套支撑上薄薄包一层**，不再自造轮子。
+
+## 4. 里程碑
+
+### M1 — Stub adapter（先脱离 delivering）
+
+**目的**：让 `ccb ask` 至少能把 prompt 真的打进 agy pane，
+且 ccbd 立刻把 attempt 标 terminal，job 状态从 `running/delivering` 走到 `completed`，
+reply 可以是空或者写「(stub mode, see agy pane)」。
+
+**交付物**：
+- 新增 `lib/provider_backends/agy/execution.py`
+  - 类 `AgyProviderAdapter` 实现 `provider = "agy"`、`start`、`poll`、`resume`
+  - `start(job, context, now)`：
+    - 通过 `agy.session.load_project_session(work_dir)` 拿 session
+    - `terminal_runtime.get_backend_for_session(session.data)` 拿 backend
+    - backend.send(prompt + Enter)
+    - 返回 `ProviderSubmission(status=INCOMPLETE, runtime_state={"prompt_sent": True, "sent_at": now, "pane_id": ...})`
+  - `poll(submission, now)`：直接返回 terminal `ProviderPollResult`，
+    `decision.terminal=True`，reply 用预置 stub 文字 / 空串
+  - `resume()`：照搬 droid 写法，返回 None（resubmit_required）
+  - `build_execution_adapter()` 工厂
+- 修改 `lib/provider_backends/agy/__init__.py`：
+  - `from .execution import build_execution_adapter`
+  - `execution_adapter=build_execution_adapter()`
+
+**验证**：
+1. `ccb kill && ccb`（重启 ccbd 让新 adapter 被加载）
+2. `ccb ask <agent> "M1 stub test"`
+3. `ccb pend <agent> 5` → status `completed`，不再卡 delivering
+4. `tmux ... capture-pane -p` → 能看到 `M1 stub test` 被键入 agy pane
+
+**回滚**：
+- `git checkout main`
+- 然后 `ccb kill && ccb` 重启
+
+### M2 — 完整 adapter（pane done marker + 静默检测兜底）
+
+**目的**：实现真正的「等 agy 答完 → 抓 reply → 上报」链路，能在 ccb 里直接看到 agy 回答内容。
+
+**交付物**：
+- `lib/provider_backends/agy/comm.py`     `AgyPaneReader`：pane snapshot + ANSI 剥离
+- `lib/provider_backends/agy/protocol.py` prompt 包装（`CCB_REQ_ID` / `CCB_DONE` 锚点）+ reply 抽取
+- `lib/provider_backends/agy/execution_runtime/`  辅助
+  - `start.py`    submission 流程、prompt 注入、runtime state 初始化
+  - `poll.py`     `pane_quiet` 状态机（hash 内容 + done marker + 静默窗口）
+  - `helpers.py`  共享工具：路径解析、hash、时间差
+- 更新 `execution.py` 由 stub 重构为 shim，委托给 `execution_runtime/`
+
+**完成检测策略**（按优先级）：
+
+1. **黄金路径**：done marker 命中（pane 里出现 `CCB_DONE: <id>` 至少 2 次，最后一个是模型的）
+   → `status=COMPLETED, reason=pane_done_marker, confidence=OBSERVED`
+2. **兜底**：reply 非空 + 观测时长 ≥ 2s + pane hash ≥ 4s 无变化
+   → `status=COMPLETED, reason=pane_text_quiet, confidence=DEGRADED`
+3. **硬超时**：总等待 ≥ 300s
+   → `status=FAILED, reason=pane_quiet_timeout`
+4. **送达失败**：start 阶段 send_text 抛错
+   → `status=FAILED, reason=send_failed:<err>`
+
+**为什么用 done marker 计数而非位置区分**：
+
+Antigravity TUI 把 prompt 回显和模型回答以**相同缩进**渲染，echo-DONE 和 model-DONE
+靠行前缀无法区分。协议靠**顺序**：prompt 指令模型「把 CCB_DONE 写在最后一行」，
+所以最后一个 DONE 是模型的，倒数第二个（若有）是 echo。0 个 → 还在写；1 个 → 只看到 echo；
+≥2 个 → 取最后两个之间的内容当 reply。
+
+**验证**：
+1. `ccb ask <agent> "回答 1+1 等于几"`
+2. `ccb pend <agent> 5` → status `completed`，reply 包含 `2`
+3. `ccb trace <job>` → terminal decision 中 `reason=pane_done_marker`, `confidence=observed`
+
+### M3 — 单元测试 + 边界覆盖
+
+**交付物**：
+- `pytest` 覆盖 `extract_reply_for_req` 关键场景：多 DONE 计数、banner 过滤、空快照
+- `poll_submission` 状态机的 happy path / quiet path / timeout path 测试
+- 长 reply（>10KB）与 carriage return 输出（pip 进度条等）的 hash 抖动测试
+
+## 5. 工程约束
+
+- 改动只能在 `lib/provider_backends/agy/` 范围内 + 改 1 个 import 在 `agy/__init__.py`。
+  不动 `provider_core/`、`provider_execution/`、`pane_log_support/` 任何代码。
+- 保持 manifest 已声明的 `TERMINAL_TEXT_QUIET` 不变；任何对 manifest 的调整需要写理由。
+- 不引入新外部 Python 依赖。
+- 注释为零是底线；只有非显然的「为什么」才写一行。
+- M1 stub 必须能独立通过验证项，不能为 M2 留接口债。
+
+## 6. 回滚预案
+
+任何时候出问题：
+
+```bash
+git checkout main
+ccb kill && ccb
+```
+
+ccb 装在 source 模式（doctor: `install_mode: source`）时，切回 main 即恢复改动前的版本。
+
+## 7. 已知踩坑
+
+- ccbd 重启会重建 namespace（lifecycle.jsonl 有记录），重启后跑的所有 agy job 都会重新走 adapter；
+  所以每次改完 execution.py 都必须 `ccb kill && ccb`，不能只重启 agy pane。
+- WSL 等长 namespace 场景下 ccb 的 socket 会走 runtime 短路径备选位置
+  （doctor `socket_fallback_reason: path_too_long`），改动不影响这条逻辑。
+- agy CLI 启动慢且界面带 ASCII logo / 输入框 banner，pane 抓取要跳过这些 banner。
+- agy CLI 与 ccb 不同宿主（例如 agy 在 Windows / ccb 在 WSL）时，agy pane 显示的工作目录
+  与 ccb 侧 `work_dir` 字符串形态不同。对 adapter 来说只需要把 `work_dir` 透传给 backend，
+  agy 那头自己处理路径。
+
+## 8. Progress cursor
+
+> 每完成一个 milestone 都要更新这里。续命用。
+
+- [x] M0 — Plan 文档
+- [x] M1 — Stub adapter（合并入本 PR 的 M2 commit）
+- [x] M2 — pane_quiet adapter（done marker + 静默兜底，运行时验证通过）
+- [ ] M3 — 单元测试 + 边界覆盖
+
+当前状态：**M1 + M2 合并为单个 commit 提交 PR；M3 留作后续 PR**
+
+### 验证记录
+
+环境：ccb v7.3.3（dev channel），agy 1.0.6（Antigravity CLI / Gemini 3.1 Pro 后端）
+
+**Smoke**：
+
+- `ccb ping ccbd` → healthy
+- `ccb ask <agent> "reply pong"` → `accepted`
+- `ccb pend <agent> 5` →
+  - `status: completed`
+  - `reply: pong`
+  - `completion_reason: pane_done_marker`
+  - `completion_confidence: observed`
+
+**多步任务**（10+ tool calls，~2 分钟）：
+
+- reply 2886 字节完整捕获
+- prompt 回显里的 banner 指令被 `_BANNER_INSTRUCTIONS` 过滤，无污染
+- 终止：`pane_done_marker` / OBSERVED（黄金路径）
+
+### 回滚
+
+```bash
+git checkout main
+ccb kill && ccb
+```

--- a/lib/provider_backends/agy/__init__.py
+++ b/lib/provider_backends/agy/__init__.py
@@ -1,5 +1,6 @@
 from provider_core.contracts import ProviderBackend
 
+from .execution import build_execution_adapter
 from .launcher import build_runtime_launcher
 from .manifest import build_manifest
 from .session import build_session_binding
@@ -8,7 +9,7 @@ from .session import build_session_binding
 def build_backend() -> ProviderBackend:
     return ProviderBackend(
         manifest=build_manifest(),
-        execution_adapter=None,
+        execution_adapter=build_execution_adapter(),
         session_binding=build_session_binding(),
         runtime_launcher=build_runtime_launcher(),
     )

--- a/lib/provider_backends/agy/comm.py
+++ b/lib/provider_backends/agy/comm.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+
+_ANSI_RE = re.compile(r'\x1b\[[0-9;?]*[ -/]*[@-~]')
+
+
+@dataclass
+class AgyPaneReader:
+    """Thin wrapper around a terminal backend that snapshots an agy tmux pane.
+
+    The underlying TmuxBackend.get_pane_content already strips ANSI, but other
+    backend types may not, so we strip defensively and tolerate failures by
+    returning an empty string instead of raising.
+    """
+
+    backend: object
+    pane_id: str
+    lines: int = 200
+
+    def snapshot(self) -> str:
+        getter = getattr(self.backend, 'get_pane_content', None)
+        if not callable(getter):
+            getter = getattr(self.backend, 'get_text', None)
+        if not callable(getter):
+            return ''
+        try:
+            content = getter(self.pane_id, lines=self.lines)
+        except Exception:
+            return ''
+        if not content:
+            return ''
+        return _ANSI_RE.sub('', content)
+
+
+__all__ = ['AgyPaneReader']

--- a/lib/provider_backends/agy/execution.py
+++ b/lib/provider_backends/agy/execution.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from ccbd.api_models import JobRecord
+from provider_execution.base import (
+    ProviderPollResult,
+    ProviderRuntimeContext,
+    ProviderSubmission,
+)
+
+from .execution_runtime import poll_submission as _poll_submission
+from .execution_runtime import start_submission as _start_submission
+
+
+class AgyProviderAdapter:
+    provider = 'agy'
+
+    def restore_diagnostics(self) -> dict[str, object]:
+        return {
+            'resume_supported': False,
+            'restore_mode': 'resubmit_required',
+            'restore_reason': 'provider_resume_unsupported',
+            'restore_detail': 'agy adapter does not implement restart-time resume; resubmit after ccbd restart',
+        }
+
+    def start(
+        self,
+        job: JobRecord,
+        *,
+        context: ProviderRuntimeContext | None,
+        now: str,
+    ) -> ProviderSubmission:
+        return _start_submission(job, context=context, now=now, provider=self.provider)
+
+    def poll(
+        self,
+        submission: ProviderSubmission,
+        *,
+        now: str,
+    ) -> ProviderPollResult | None:
+        return _poll_submission(submission, now=now)
+
+    def resume(
+        self,
+        job: JobRecord,
+        submission: ProviderSubmission,
+        *,
+        context: ProviderRuntimeContext | None,
+        persisted_state,
+        now: str,
+    ) -> ProviderSubmission | None:
+        del job, submission, context, persisted_state, now
+        return None
+
+
+def build_execution_adapter() -> AgyProviderAdapter:
+    return AgyProviderAdapter()
+
+
+__all__ = ['AgyProviderAdapter', 'build_execution_adapter']

--- a/lib/provider_backends/agy/execution_runtime/__init__.py
+++ b/lib/provider_backends/agy/execution_runtime/__init__.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from .poll import poll_submission
+from .start import start_submission
+
+__all__ = ['poll_submission', 'start_submission']

--- a/lib/provider_backends/agy/execution_runtime/helpers.py
+++ b/lib/provider_backends/agy/execution_runtime/helpers.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime
+from pathlib import Path
+
+from ccbd.api_models import JobRecord
+from provider_execution.base import ProviderRuntimeContext
+
+
+def resolve_work_dir(job: JobRecord, context: ProviderRuntimeContext | None) -> Path | None:
+    candidate = (context.workspace_path if context else None) or job.workspace_path
+    if not candidate:
+        return None
+    try:
+        return Path(candidate).expanduser()
+    except Exception:
+        return None
+
+
+def hash_text(text: str) -> str:
+    return hashlib.sha1((text or '').encode('utf-8', 'replace')).hexdigest()
+
+
+def parse_now(now: str) -> datetime | None:
+    if not now:
+        return None
+    try:
+        return datetime.fromisoformat(now.replace('Z', '+00:00'))
+    except Exception:
+        return None
+
+
+def seconds_between(start: str, end: str) -> float:
+    start_dt = parse_now(start)
+    end_dt = parse_now(end)
+    if start_dt is None or end_dt is None:
+        return 0.0
+    return max(0.0, (end_dt - start_dt).total_seconds())
+
+
+def state_int(state: dict[str, object], key: str, default: int) -> int:
+    value = state.get(key)
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def state_str(state: dict[str, object], key: str, default: str = '') -> str:
+    value = state.get(key)
+    if value is None:
+        return default
+    return str(value)
+
+
+__all__ = [
+    'hash_text',
+    'parse_now',
+    'resolve_work_dir',
+    'seconds_between',
+    'state_int',
+    'state_str',
+]

--- a/lib/provider_backends/agy/execution_runtime/poll.py
+++ b/lib/provider_backends/agy/execution_runtime/poll.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+from completion.models import (
+    CompletionConfidence,
+    CompletionCursor,
+    CompletionDecision,
+    CompletionStatus,
+)
+from provider_execution.base import ProviderPollResult, ProviderSubmission
+
+from ..comm import AgyPaneReader
+from ..protocol import extract_reply_for_req
+from .helpers import hash_text, seconds_between, state_int, state_str
+
+
+QUIET_SECS = 4.0
+MAX_WAIT_SECS = 300.0
+MIN_OBSERVED_SECS = 2.0
+
+
+def poll_submission(submission: ProviderSubmission, *, now: str) -> ProviderPollResult | None:
+    state = dict(submission.runtime_state)
+
+    send_error = state.get('send_error')
+    if send_error:
+        return _terminal(
+            submission,
+            state,
+            now,
+            status=CompletionStatus.FAILED,
+            reason=f'send_failed:{send_error}',
+            reply='',
+            confidence=CompletionConfidence.DEGRADED,
+        )
+
+    pane_id = state_str(state, 'pane_id')
+    req_id = state_str(state, 'req_id')
+    if not pane_id or not req_id:
+        return _terminal(
+            submission,
+            state,
+            now,
+            status=CompletionStatus.FAILED,
+            reason='runtime_state_invalid',
+            reply='',
+            confidence=CompletionConfidence.DEGRADED,
+        )
+
+    reader = _ensure_reader(state)
+    if reader is None:
+        return _terminal(
+            submission,
+            state,
+            now,
+            status=CompletionStatus.FAILED,
+            reason='runtime_handle_lost',
+            reply='',
+            confidence=CompletionConfidence.DEGRADED,
+        )
+
+    content = reader.snapshot()
+    if not content:
+        state['snapshot_errors'] = state_int(state, 'snapshot_errors', 0) + 1
+
+    current_hash = hash_text(content) if content else state_str(state, 'last_hash')
+    last_hash = state.get('last_hash')
+    started_at = state_str(state, 'started_at') or submission.accepted_at or now
+    last_change_at = state_str(state, 'last_change_at') or started_at
+
+    if content and current_hash != last_hash:
+        state['last_hash'] = current_hash
+        state['last_change_at'] = now
+        last_change_at = now
+
+    state['last_poll_at'] = now
+    state['next_seq'] = state_int(state, 'next_seq', 1) + 1
+
+    quiet_secs = seconds_between(last_change_at, now)
+    total_secs = seconds_between(started_at, now)
+
+    state['quiet_secs'] = quiet_secs
+    state['total_secs'] = total_secs
+
+    reply, done_seen = extract_reply_for_req(content, req_id)
+    state['done_seen'] = done_seen
+    state['reply_chars'] = len(reply)
+
+    if done_seen and reply:
+        return _terminal(
+            submission,
+            state,
+            now,
+            status=CompletionStatus.COMPLETED,
+            reason='pane_done_marker',
+            reply=reply,
+            confidence=CompletionConfidence.OBSERVED,
+        )
+
+    if total_secs >= MAX_WAIT_SECS:
+        return _terminal(
+            submission,
+            state,
+            now,
+            status=CompletionStatus.FAILED,
+            reason='pane_quiet_timeout',
+            reply=reply,
+            confidence=CompletionConfidence.DEGRADED,
+        )
+
+    if (
+        reply
+        and total_secs >= MIN_OBSERVED_SECS
+        and quiet_secs >= QUIET_SECS
+    ):
+        return _terminal(
+            submission,
+            state,
+            now,
+            status=CompletionStatus.COMPLETED,
+            reason='pane_text_quiet',
+            reply=reply,
+            confidence=CompletionConfidence.DEGRADED,
+        )
+
+    progress = replace(submission, runtime_state=state)
+    return ProviderPollResult(submission=progress, items=(), decision=None)
+
+
+def _ensure_reader(state: dict[str, object]) -> AgyPaneReader | None:
+    reader = state.get('reader')
+    if isinstance(reader, AgyPaneReader):
+        return reader
+    backend = state.get('backend')
+    pane_id = state_str(state, 'pane_id')
+    lines = state_int(state, 'pane_lines', 200)
+    if backend is None or not pane_id:
+        return None
+    rebuilt = AgyPaneReader(backend=backend, pane_id=pane_id, lines=lines)
+    state['reader'] = rebuilt
+    return rebuilt
+
+
+def _terminal(
+    submission: ProviderSubmission,
+    state: dict[str, object],
+    now: str,
+    *,
+    status: CompletionStatus,
+    reason: str,
+    reply: str,
+    confidence: CompletionConfidence,
+) -> ProviderPollResult:
+    cleaned_reply = reply or ''
+    progress = replace(
+        submission,
+        runtime_state=state,
+        status=status,
+        reason=reason,
+        reply=cleaned_reply,
+        confidence=confidence,
+    )
+    cursor = CompletionCursor(
+        source_kind=submission.source_kind,
+        event_seq=state_int(state, 'next_seq', 1),
+        updated_at=now,
+    )
+    decision = CompletionDecision(
+        terminal=True,
+        status=status,
+        reason=reason,
+        confidence=confidence,
+        reply=cleaned_reply,
+        anchor_seen=bool(state.get('done_seen')) or bool(cleaned_reply),
+        reply_started=bool(cleaned_reply),
+        reply_stable=bool(cleaned_reply) and status is CompletionStatus.COMPLETED,
+        provider_turn_ref=state_str(state, 'req_id') or None,
+        source_cursor=cursor,
+        finished_at=now,
+        diagnostics={
+            'mode': 'pane_quiet',
+            'quiet_secs': float(state.get('quiet_secs') or 0.0),
+            'total_secs': float(state.get('total_secs') or 0.0),
+            'done_seen': bool(state.get('done_seen')),
+            'snapshot_errors': state_int(state, 'snapshot_errors', 0),
+            'reply_chars': state_int(state, 'reply_chars', 0),
+        },
+    )
+    return ProviderPollResult(submission=progress, items=(), decision=decision)
+
+
+__all__ = ['poll_submission']

--- a/lib/provider_backends/agy/execution_runtime/start.py
+++ b/lib/provider_backends/agy/execution_runtime/start.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from ccbd.api_models import JobRecord
+from completion.models import CompletionSourceKind
+from provider_core.protocol import request_anchor_for_job
+from provider_execution.base import ProviderRuntimeContext, ProviderSubmission
+from provider_execution.common import error_submission, send_prompt_to_runtime_target
+
+from ..comm import AgyPaneReader
+from ..protocol import wrap_agy_prompt
+from ..session import load_project_session
+from .helpers import resolve_work_dir
+
+
+_PANE_LINES_DEFAULT = 200
+
+
+def start_submission(
+    job: JobRecord,
+    *,
+    context: ProviderRuntimeContext | None,
+    now: str,
+    provider: str,
+) -> ProviderSubmission:
+    work_dir = resolve_work_dir(job, context)
+    if work_dir is None:
+        return error_submission(
+            job,
+            provider=provider,
+            now=now,
+            source_kind=CompletionSourceKind.TERMINAL_TEXT,
+            reason='runtime_unavailable',
+            error='work_dir_missing',
+        )
+
+    instance = (job.agent_name or '').strip().lower() or None
+    session = None
+    load_error: str | None = None
+    try:
+        session = load_project_session(work_dir, instance=instance)
+        if session is None and instance is not None:
+            session = load_project_session(work_dir)
+    except Exception as exc:
+        load_error = f'load_session_failed:{exc!r}'
+
+    if session is None:
+        return error_submission(
+            job,
+            provider=provider,
+            now=now,
+            source_kind=CompletionSourceKind.TERMINAL_TEXT,
+            reason='runtime_unavailable',
+            error=load_error or 'agy_session_file_missing',
+        )
+
+    pane_id = session.pane_id
+    if not pane_id:
+        return error_submission(
+            job,
+            provider=provider,
+            now=now,
+            source_kind=CompletionSourceKind.TERMINAL_TEXT,
+            reason='pane_unavailable',
+            error='pane_id_missing_in_session',
+        )
+
+    try:
+        backend = session.backend()
+    except Exception as exc:
+        backend = None
+        backend_error = f'backend_resolve_failed:{exc!r}'
+    else:
+        backend_error = None
+
+    if backend is None:
+        return error_submission(
+            job,
+            provider=provider,
+            now=now,
+            source_kind=CompletionSourceKind.TERMINAL_TEXT,
+            reason='backend_unavailable',
+            error=backend_error or 'terminal_backend_unavailable',
+        )
+
+    req_id = request_anchor_for_job(job.job_id)
+    prompt = wrap_agy_prompt(job.request.body or '', req_id)
+
+    reader = AgyPaneReader(backend=backend, pane_id=pane_id, lines=_PANE_LINES_DEFAULT)
+
+    send_error: str | None = None
+    try:
+        send_prompt_to_runtime_target(backend, pane_id, prompt)
+    except Exception as exc:
+        send_error = f'send_text_failed:{exc!r}'
+
+    diagnostics: dict[str, object] = {
+        'provider': provider,
+        'mode': 'pane_quiet',
+        'pane_id': pane_id,
+        'req_id': req_id,
+        'task_id': job.request.task_id,
+        'workspace_path': str(work_dir),
+    }
+    if send_error:
+        diagnostics['send_error'] = send_error
+
+    return ProviderSubmission(
+        job_id=job.job_id,
+        agent_name=job.agent_name,
+        provider=provider,
+        accepted_at=now,
+        ready_at=now,
+        source_kind=CompletionSourceKind.TERMINAL_TEXT,
+        reply='',
+        diagnostics=diagnostics,
+        runtime_state={
+            'mode': 'pane_quiet',
+            'reader': reader,
+            'backend': backend,
+            'pane_id': pane_id,
+            'req_id': req_id,
+            'pane_lines': _PANE_LINES_DEFAULT,
+            'started_at': now,
+            'last_hash': None,
+            'last_change_at': now,
+            'last_poll_at': now,
+            'prompt_sent': send_error is None,
+            'send_error': send_error,
+            'snapshot_errors': 0,
+            'next_seq': 1,
+        },
+    )
+
+
+__all__ = ['start_submission']

--- a/lib/provider_backends/agy/protocol.py
+++ b/lib/provider_backends/agy/protocol.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import re
+
+from provider_core.protocol import (
+    ANY_DONE_LINE_RE,
+    DONE_PREFIX,
+    REQ_ID_PREFIX,
+    is_done_text,
+    make_req_id,
+    strip_done_text,
+)
+
+
+def wrap_agy_prompt(message: str, req_id: str) -> str:
+    rendered = (message or '').rstrip()
+    return (
+        f'{REQ_ID_PREFIX} {req_id}\n\n'
+        f'{rendered}\n\n'
+        'IMPORTANT: when you finish answering, write this exact line on its '
+        'own line as the final line of your reply (no quoting, no code fence):\n'
+        f'{DONE_PREFIX} {req_id}\n'
+    )
+
+
+_LINE_PREFIX_RE = re.compile(r'^[\s>$#❯]+')
+_BANNER_KEYWORDS = ('CCB_REQ_ID:', 'CCB_DONE:')
+_BANNER_INSTRUCTIONS = (
+    'IMPORTANT: when you finish',
+    'IMPORTANT:',
+    'on its own line as the final line',
+    'no quoting, no code fence',
+)
+
+
+def _req_anchor_re(req_id: str) -> re.Pattern[str]:
+    # Not line-anchored: pane TUIs often prefix echoed input with `> ` or similar.
+    return re.compile(rf'{re.escape(REQ_ID_PREFIX)}\s*{re.escape(req_id)}')
+
+
+def _done_anywhere_re(req_id: str) -> re.Pattern[str]:
+    return re.compile(rf'{re.escape(DONE_PREFIX)}\s*{re.escape(req_id)}')
+
+
+def extract_reply_for_req(text: str, req_id: str) -> tuple[str, bool]:
+    """Return (reply, done_seen) extracted from a pane snapshot.
+
+    Antigravity's TUI renders both the echoed prompt and the model response
+    with the same 2-space indentation, so echo-DONE and model-DONE are
+    indistinguishable by line prefix. We rely on order instead: the prompt
+    instructs the model to write CCB_DONE as the final line, so the LAST
+    CCB_DONE occurrence is the model's; the one before it (if any) is the
+    echoed prompt's tail.
+
+    Algorithm:
+    1. Find the LAST `CCB_REQ_ID: <id>` anchor.
+    2. In the after-anchor window, find all `CCB_DONE: <id>` occurrences.
+    3. Decide by count:
+       - 0 -> model still thinking; reply='', done_seen=False.
+       - 1 -> only the echoed prompt DONE is visible; reply='',
+              done_seen=False.
+       - >=2 -> last is model DONE, second-to-last is echo DONE.
+              reply slice = (end of echo-DONE line) -> (start of model-DONE
+              line). done_seen=True.
+    4. Clean: drop banner/echo lines, normalize whitespace.
+    5. Sentinel guard: if the cleaned reply still contains banner instruction
+       fragments, the slice landed in the echo region; drop it.
+    """
+    if not text or not req_id:
+        return '', False
+
+    text = text.replace('\r\n', '\n').replace('\r', '\n')
+
+    anchor_matches = list(_req_anchor_re(req_id).finditer(text))
+    if not anchor_matches:
+        return '', False
+
+    after_anchor = text[anchor_matches[-1].end():]
+
+    done_matches = list(_done_anywhere_re(req_id).finditer(after_anchor))
+    if len(done_matches) < 2:
+        return '', False
+
+    _, echo_line_end = _line_bounds(after_anchor, done_matches[-2].start())
+    model_line_start, _ = _line_bounds(after_anchor, done_matches[-1].start())
+
+    reply_start = echo_line_end + 1 if echo_line_end < len(after_anchor) else echo_line_end
+    body = after_anchor[reply_start:model_line_start]
+
+    cleaned = _clean_body(body, req_id)
+    if _contains_banner_fragment(cleaned):
+        return '', False
+
+    return cleaned, True
+
+
+def _line_bounds(text: str, pos: int) -> tuple[int, int]:
+    start = text.rfind('\n', 0, pos) + 1
+    end = text.find('\n', pos)
+    if end == -1:
+        end = len(text)
+    return start, end
+
+
+def _contains_banner_fragment(text: str) -> bool:
+    blob = text or ''
+    for marker in _BANNER_INSTRUCTIONS:
+        if marker in blob:
+            return True
+    for marker in _BANNER_KEYWORDS:
+        if marker in blob:
+            return True
+    return False
+
+
+def _clean_body(body: str, req_id: str) -> str:
+    text = (body or '').replace('\r\n', '\n').replace('\r', '\n')
+    try:
+        text = strip_done_text(text, req_id)
+    except Exception:
+        pass
+    text = ANY_DONE_LINE_RE.sub('', text)
+
+    cleaned_lines: list[str] = []
+    for raw in text.split('\n'):
+        stripped = _LINE_PREFIX_RE.sub('', raw).rstrip()
+        if _is_banner_line(stripped):
+            continue
+        cleaned_lines.append(stripped)
+
+    while cleaned_lines and not cleaned_lines[0].strip():
+        cleaned_lines.pop(0)
+    while cleaned_lines and not cleaned_lines[-1].strip():
+        cleaned_lines.pop()
+
+    return '\n'.join(cleaned_lines).strip()
+
+
+def _is_banner_line(line: str) -> bool:
+    text = (line or '').strip()
+    if not text:
+        return False
+    for marker in _BANNER_KEYWORDS:
+        if marker in text:
+            return True
+    for marker in _BANNER_INSTRUCTIONS:
+        if marker in text:
+            return True
+    return False
+
+
+__all__ = [
+    'ANY_DONE_LINE_RE',
+    'DONE_PREFIX',
+    'REQ_ID_PREFIX',
+    'extract_reply_for_req',
+    'is_done_text',
+    'make_req_id',
+    'strip_done_text',
+    'wrap_agy_prompt',
+]


### PR DESCRIPTION
> Bilingual description — English first, 中文版在下方 (English first, Chinese translation below).

---

## Summary

Add a complete execution adapter for the `agy` provider so that
`ccb ask` against an agy-backed agent actually delivers prompts and
captures replies, instead of stalling in `state=delivering` forever.

Before this change, `lib/provider_backends/agy/__init__.py` declared
`execution_adapter=None` and there was no `execution.py` under
`agy/`. As a result:

- `ccb ask <agy-agent> "..."` returned `accepted` but the job was
  stuck on `state=delivering` indefinitely.
- The pane never received the prompt (no `send_text` path).
- ccbd restart surfaced `restore_reason: adapter_missing` /
  `restore_detail: provider agy has no registered execution adapter`.

This PR wires up a `pane_quiet` execution adapter that follows the
same shape as the existing `TERMINAL_TEXT_QUIET` providers while
adapting to agy's specifics (no JSONL log file; reply lives purely in
pane output; Antigravity's TUI renders echo and model output with the
same indentation).

## Design

The manifest already declares `CompletionFamily.TERMINAL_TEXT_QUIET`,
`SelectorFamily.FINAL_MESSAGE`, and `CompletionSourceKind.TERMINAL_TEXT`
- no manifest changes are needed.

### Prompt injection

`start_submission` wraps the user's message with `CCB_REQ_ID: <id>` at
the top and an instruction asking the model to write `CCB_DONE: <id>`
as the final line of its reply, then injects the whole blob into the
agy pane via the existing `send_prompt_to_runtime_target` helper.

### Reply extraction

`extract_reply_for_req` reads a pane snapshot and locates the reply
by counting `CCB_DONE` occurrences after the last `CCB_REQ_ID` anchor:

- 0 occurrences -> model still composing.
- 1 occurrence  -> only the echoed prompt's DONE is visible (TUI
  re-renders the prompt with the same indentation as model output,
  so prefix-based disambiguation is unreliable).
- >=2 occurrences -> the last is the model's DONE, the second-to-last
  is the echo. The reply is the slice between them, after banner /
  instruction line filtering.

### Completion strategy

Priority order:

1. **pane_done_marker** -> `COMPLETED`, `confidence=OBSERVED`
   (golden path; reply non-empty AND `>=2` DONE markers seen)
2. **pane_text_quiet** -> `COMPLETED`, `confidence=DEGRADED`
   (fallback; reply non-empty AND observed `>= 2s` AND pane hash
   quiet `>= 4s`)
3. **pane_quiet_timeout** -> `FAILED` (total wait `>= 300s`)
4. **send_failed:`<err>`** -> `FAILED` (start-time `send_text` raised)

## Scope

Changes are limited to:

- `lib/provider_backends/agy/__init__.py` - wire `build_execution_adapter()`
- `lib/provider_backends/agy/execution.py` - thin adapter shim
- `lib/provider_backends/agy/comm.py` - pane snapshot helper (ANSI-strip)
- `lib/provider_backends/agy/protocol.py` - prompt wrapping + reply extraction
- `lib/provider_backends/agy/execution_runtime/` - start / poll logic
- `docs/agy-adapter/PLAN.md` - design doc, milestone breakdown, rollback

No changes to `provider_core/`, `provider_execution/`,
`pane_log_support/`, or other providers. No new external Python
dependencies.

## Verification

ccb v7.3.3, agy 1.0.6 (Antigravity CLI, Gemini 3.1 Pro backend).

### Smoke

- `ccb ping ccbd` -> healthy, generation increments cleanly
- `ccb ask <agy-agent> "reply pong"` -> `accepted`
- `ccb pend <agy-agent> 5` ->
  - `status: completed`
  - `reply: pong`
  - `completion_reason: pane_done_marker`
  - `completion_confidence: observed`

### Multi-step task

A real-world task (~2 minutes, 10+ tool calls including venv creation,
pip installs, multi-file write, script execution):

- Reply captured intact (2886 bytes)
- Banner / instruction lines (the `IMPORTANT:` / `no quoting, no code
  fence` text from the prompt template) correctly filtered out of the
  reply body by `_BANNER_INSTRUCTIONS`
- Termination via golden path: `pane_done_marker` / `OBSERVED`

## What's not in this PR

- Unit tests for `extract_reply_for_req` edge cases (multi-DONE counting,
  banner filtering, empty snapshot, CR / progress-bar churn)
- State-machine tests for `poll_submission` (happy path / quiet path /
  timeout path / send-error path)
- Long-reply (>10KB) pane-buffer truncation behaviour

These are tracked as M3 in `docs/agy-adapter/PLAN.md` and will land in
a follow-up PR.

## Rollback

```bash
git checkout main
ccb kill && ccb
```

Reverts the agy provider to its previous `execution_adapter=None`
state. ccb's source-install mode means no rebuild is needed.

---

# 中文说明

## 概述

为 `agy` provider 补一个完整的 execution adapter，让 `ccb ask
<agy-agent>` 真正能把 prompt 投递进 pane 并取回 reply，而不是永远卡在
`state=delivering`。

本次改动之前，`lib/provider_backends/agy/__init__.py` 把
`execution_adapter` 显式置为 `None`，且 `agy/` 下根本没有
`execution.py`。后果是：

- `ccb ask <agy-agent> "..."` 立刻返回 `accepted`，但 job 永远停在
  `state=delivering`。
- pane 完全收不到 prompt（缺 `send_text` 路径）。
- ccbd 重启日志里报 `restore_reason: adapter_missing` /
  `restore_detail: provider agy has no registered execution adapter`。

本 PR 接入了一个 `pane_quiet` 协议的 execution adapter，整体形状跟其他
`TERMINAL_TEXT_QUIET` 系列 provider 对齐，同时针对 agy 的两个特殊点做了
适配：没有 JSONL log 文件可读、Antigravity TUI 把 prompt 回显和模型回答
用同样缩进渲染。

## 设计

manifest 已经声明了 `CompletionFamily.TERMINAL_TEXT_QUIET`、
`SelectorFamily.FINAL_MESSAGE` 和 `CompletionSourceKind.TERMINAL_TEXT`，
所以 manifest 完全不动。

### Prompt 注入

`start_submission` 把用户消息包成：开头加 `CCB_REQ_ID: <id>`，结尾追加
一条指令要求模型把 `CCB_DONE: <id>` 写在 reply 的最后一行，然后通过
现成的 `send_prompt_to_runtime_target` 把整段打进 agy pane。

### Reply 抽取

`extract_reply_for_req` 抓 pane 快照，在最后一个 `CCB_REQ_ID` 锚点之后
统计 `CCB_DONE` 出现次数：

- 0 次 -> 模型还在写。
- 1 次 -> 只看到 prompt 回显里的那条 DONE（TUI 用跟模型输出相同的缩进
  把 prompt 重新渲染了一遍，所以靠行前缀区分 echo 和 model 不可靠）。
- ≥2 次 -> 最后一条是模型 DONE、倒数第二条是 echo DONE。reply 就是
  这两条之间的内容，经过 banner / 指令行过滤后返回。

### 完成判定策略

按优先级：

1. **pane_done_marker** -> `COMPLETED`、`confidence=OBSERVED`
   （黄金路径；reply 非空且看到 ≥2 个 DONE marker）
2. **pane_text_quiet** -> `COMPLETED`、`confidence=DEGRADED`
   （兜底；reply 非空且观测时长 ≥ 2s 且 pane hash 静默 ≥ 4s）
3. **pane_quiet_timeout** -> `FAILED`（总等待 ≥ 300s）
4. **send_failed:`<err>`** -> `FAILED`（start 阶段 `send_text` 抛错）

## 影响范围

改动严格限定在：

- `lib/provider_backends/agy/__init__.py` —— 接入
  `build_execution_adapter()`
- `lib/provider_backends/agy/execution.py` —— 薄薄的 adapter shim
- `lib/provider_backends/agy/comm.py` —— pane snapshot 工具（剥 ANSI）
- `lib/provider_backends/agy/protocol.py` —— prompt 包装 + reply 抽取
- `lib/provider_backends/agy/execution_runtime/` —— start / poll 实现
- `docs/agy-adapter/PLAN.md` —— 设计文档、里程碑分解、回滚预案

不动 `provider_core/`、`provider_execution/`、`pane_log_support/` 或
其他 provider。也不引入任何新的 Python 外部依赖。

## 验证

环境：ccb v7.3.3，agy 1.0.6（Antigravity CLI / Gemini 3.1 Pro 后端）。

### Smoke 测试

- `ccb ping ccbd` -> healthy，generation 正常递增
- `ccb ask <agy-agent> "reply pong"` -> `accepted`
- `ccb pend <agy-agent> 5` ->
  - `status: completed`
  - `reply: pong`
  - `completion_reason: pane_done_marker`
  - `completion_confidence: observed`

### 多步任务

跑了一个真实任务（约 2 分钟，10+ 个 tool call，包含 venv 创建、pip
安装、多文件写入、脚本执行）：

- Reply 2886 字节完整捕获
- prompt 模板里的 banner / 指令行（`IMPORTANT:` / `no quoting, no
  code fence` 那段）被 `_BANNER_INSTRUCTIONS` 正确过滤出 reply 主体
- 终止走黄金路径：`pane_done_marker` / `OBSERVED`

## 本 PR 未覆盖的内容

- `extract_reply_for_req` 边界用例的单元测试（多 DONE 计数、banner
  过滤、空快照、CR / 进度条抖动）
- `poll_submission` 状态机测试（happy path / quiet path / timeout
  path / send-error path）
- 超长 reply（>10KB）下 pane buffer 截断的行为

这些已在 `docs/agy-adapter/PLAN.md` 第 4 节作为 M3 列出，会在后续 PR
里补上。

## 回滚

```bash
git checkout main
ccb kill && ccb
```

agy provider 回到之前 `execution_adapter=None` 的状态。ccb 是 source
安装模式，不需要重新编译。
