### PR TITLE
fix(claude): pass --settings JSON inline to survive non-ASCII paths

### DIFF
--- a/lib/provider_backends/claude/launcher_runtime/service.py
+++ b/lib/provider_backends/claude/launcher_runtime/service.py
@@ -96,7 +96,14 @@ def build_start_cmd(
         cmd_parts.append(_ROOT_SKIP_PERMISSIONS_FLAG)
     cmd_parts.extend(['--setting-sources', 'user,project,local'])
     if settings_path is not None:
-        cmd_parts.extend(['--settings', str(settings_path)])
+        try:
+            settings_inline = json.dumps(
+                json.loads(settings_path.read_text(encoding='utf-8')),
+                ensure_ascii=False,
+            )
+            cmd_parts.extend(['--settings', settings_inline])
+        except Exception:
+            cmd_parts.extend(['--settings', str(settings_path)])
     if command.auto_permission:
         cmd_parts.extend(['--permission-mode', 'bypassPermissions'])
     if restore_target.has_history:


### PR DESCRIPTION
> Bilingual description — English first, 中文版在下方.

---

## Summary

Survive non-ASCII workspace / settings paths when launching the Claude
CLI by passing the settings JSON content inline (`--settings '{...}'`)
instead of the file path (`--settings /some/path.json`).

## The bug

When the workspace path or the settings file path contains non-ASCII
characters (Chinese, Japanese, Korean, etc.), launching Claude via
`claude --settings <path>` can fail at startup because the Claude CLI
may not open the file under the same encoding the shell used to pass
the path. Observed symptom (Windows + WSL with a CJK workspace path):

- Claude CLI exits immediately on launch.
- ccb's claude provider cannot bring up the pane.
- No crash log surfaced on ccb's side - the failure is opaque from
  ccbd's perspective.

The ASCII-only path is unaffected.

## The fix

In `build_start_cmd`, when `settings_path` is set, read the file in
Python with explicit `utf-8`, then pass the re-serialized JSON content
inline as the `--settings` argument value. `ensure_ascii=False`
preserves any non-ASCII content inside the settings file verbatim.

On any failure (file missing, permission error, invalid JSON, etc.)
we fall back to the original path-based behavior, so:

- ASCII-only paths: behavior unchanged (slightly slower because we
  parse + re-serialize, but in practice the settings file is tiny).
- CJK / non-ASCII paths: Claude CLI never has to open the path - it
  gets the content directly on its command line.
- Edge cases (bad file, bad JSON): we silently degrade to the old
  form rather than break startup.

## Scope

- `lib/provider_backends/claude/launcher_runtime/service.py` only.
- 8 inserts, 1 delete.
- `json` is already imported at module level - no new imports.
- No new external dependencies.
- No changes to other providers, ccbd, or the agy adapter work
  (tracked separately in PR #221).

## Caveats / what the reviewer should double-check

- The inline form on Windows passes a JSON blob through the shell
  command line. For typical settings files (small JSON, no embedded
  shell metacharacters) this is fine; for unusual settings content
  the path-based form will kick in via the `except` branch.
- Verified locally on Windows + WSL with a CJK workspace path: the
  pane comes up cleanly with this change applied and fails without.

## Rollback

Revert this commit. No state migration needed; ccb source-install
mode means no rebuild.

---

# 中文说明

## 概述

当 workspace 路径或 settings 文件路径里含有非 ASCII 字符
（中文 / 日文 / 韩文等）时，让 Claude CLI 的启动不再崩。做法：把
settings 的 JSON 内容**内联**作为 `--settings` 的参数值传给 Claude CLI
（`--settings '{...}'`），不再传文件路径（`--settings /some/path.json`）。

## Bug 现象

当 workspace 路径或 settings 文件路径包含非 ASCII 字符时，通过
`claude --settings <path>` 启动 Claude CLI 可能在启动阶段直接挂掉——
Claude CLI 用的文件打开编码跟 shell 传路径用的编码不一致。在 Windows + WSL
+ 中文 workspace 路径下复现到的症状：

- Claude CLI 启动后立刻退出
- ccb 的 claude provider 拉不起 pane
- ccb 侧拿不到具体崩溃日志——从 ccbd 视角看是个黑盒失败

纯 ASCII 路径不受影响。

## 修复方案

在 `build_start_cmd` 中，当 `settings_path` 非空时，用 Python 以
`utf-8` 显式读出文件内容，然后把重新序列化的 JSON 字符串作为
`--settings` 的参数值内联传给 Claude CLI。`ensure_ascii=False` 用于
保留 settings 文件里的非 ASCII 内容原貌。

任何失败（文件不存在、权限不够、JSON 无效等）都走 `except` 分支退回
到原来的「传路径」形式，所以：

- 纯 ASCII 路径：行为没有任何变化（只是多了一次 parse + re-serialize，
  实际开销可忽略，settings 文件本来就很小）
- 中文 / 非 ASCII 路径：Claude CLI 不再需要打开那个文件，直接从命令行
  拿到 JSON 内容
- 边缘场景（文件坏 / JSON 坏）：静默降级到原来的形式，不会破坏启动

## 影响范围

- 仅 `lib/provider_backends/claude/launcher_runtime/service.py`
- 8 行新增、1 行删除
- `json` 模块已在文件顶部 import，**不需要新增 import**
- 没有新增外部依赖
- 不动其他 provider / ccbd / agy adapter（agy 的工作在另一个 PR
  #221 单独跟踪）

## 评审请重点确认

- 在 Windows 下内联形式会把 JSON 串走 shell 命令行。对常见的 settings
  文件（小、不含 shell 元字符）没问题；如果 settings 内容非常规，
  `except` 分支会兜底回原路径形式。
- 本地在 Windows + WSL + 中文路径下验证：应用本改动后 pane 正常起来；
  不应用本改动则启动失败。

## 回滚

revert 本 commit 即可。无状态迁移；ccb 是 source 安装模式，不需要重新编译。
