### PR TITLE
fix(provider-hooks): prune stale ccb-managed claude hooks on reinstall

### DIFF
--- a/lib/provider_hooks/settings_runtime/claude.py
+++ b/lib/provider_hooks/settings_runtime/claude.py
@@ -15,6 +15,8 @@ _CLAUDE_ACTIVITY_EVENTS = (
     'PostToolUse',
     'Stop',
 )
+_CCB_FINISH_HOOK_NAME = 'ccb-provider-finish-hook'
+_CCB_ACTIVITY_HOOK_NAME = 'ccb-provider-activity-hook'
 
 
 def install_claude_hooks(*, home_root: Path, command: str) -> Path:
@@ -22,6 +24,11 @@ def install_claude_hooks(*, home_root: Path, command: str) -> Path:
     data = _load_settings(settings_path)
     hooks = _hooks_payload(data)
     groups = _event_groups(hooks, event_name='Stop')
+    groups = _prune_ccb_managed_hook_groups(
+        groups,
+        current_command=command,
+        managed_hook_name=_CCB_FINISH_HOOK_NAME,
+    )
     if not claude_event_has_command(groups, command):
         groups.append(_command_hook_group(command))
     hooks['Stop'] = groups
@@ -34,6 +41,11 @@ def install_claude_activity_hooks(*, home_root: Path, command: str) -> Path:
     hooks = _hooks_payload(data)
     for event_name in _CLAUDE_ACTIVITY_EVENTS:
         groups = _event_groups(hooks, event_name=event_name)
+        groups = _prune_ccb_managed_hook_groups(
+            groups,
+            current_command=command,
+            managed_hook_name=_CCB_ACTIVITY_HOOK_NAME,
+        )
         if not claude_event_has_command(groups, command):
             groups.append(_command_hook_group(command))
         hooks[event_name] = groups
@@ -81,6 +93,51 @@ def claude_event_has_command(groups: list[object], command: str) -> bool:
             if str(hook.get('command') or '').strip() == command:
                 return True
     return False
+
+
+def _prune_ccb_managed_hook_groups(
+    groups: list[object],
+    *,
+    current_command: str,
+    managed_hook_name: str,
+) -> list[object]:
+    pruned: list[object] = []
+    for group in groups:
+        if not isinstance(group, dict):
+            pruned.append(group)
+            continue
+        hooks = group.get('hooks')
+        if not isinstance(hooks, list):
+            pruned.append(group)
+            continue
+
+        kept_hooks: list[object] = []
+        for hook in hooks:
+            if not _is_stale_ccb_managed_hook(
+                hook,
+                current_command=current_command,
+                managed_hook_name=managed_hook_name,
+            ):
+                kept_hooks.append(hook)
+        if kept_hooks:
+            next_group = dict(group)
+            next_group['hooks'] = kept_hooks
+            pruned.append(next_group)
+    return pruned
+
+
+def _is_stale_ccb_managed_hook(
+    hook: object,
+    *,
+    current_command: str,
+    managed_hook_name: str,
+) -> bool:
+    if not isinstance(hook, dict):
+        return False
+    if str(hook.get('type') or '').strip().lower() != 'command':
+        return False
+    command = str(hook.get('command') or '').strip()
+    return managed_hook_name in command and command != current_command
 
 
 def _load_settings(path: Path) -> dict[str, object]:

--- a/test/test_provider_hook_settings.py
+++ b/test/test_provider_hook_settings.py
@@ -12,7 +12,7 @@ except ModuleNotFoundError:  # pragma: no cover - Python < 3.11
 from agents.models import AgentSpec, PermissionMode, ProviderProfileSpec, QueuePolicy, RestoreMode, RuntimeMode, WorkspaceMode
 from cli.services.provider_hooks import prepare_provider_workspace
 import provider_core.source_home as source_home_module
-from provider_hooks.settings import build_hook_command, install_workspace_completion_hooks
+from provider_hooks.settings import build_hook_command, install_workspace_activity_hooks, install_workspace_completion_hooks
 from storage.paths import PathLayout
 
 
@@ -103,6 +103,46 @@ def test_install_claude_hooks_preserves_existing_entries_without_duplication(tmp
     data = json.loads(settings_path.read_text(encoding='utf-8'))
     assert len(data['hooks']['Stop']) == 2
     assert not (workspace / '.claude').exists()
+
+
+def test_install_claude_hooks_prunes_stale_ccb_finish_hooks(tmp_path: Path) -> None:
+    workspace = tmp_path / 'workspace'
+    home_root = tmp_path / 'claude-home'
+    settings_path = home_root / '.claude' / 'settings.json'
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    command = '/usr/bin/python3 /current/bin/ccb-provider-finish-hook --provider claude'
+    stale_command = '/usr/bin/python3 /old/bin/ccb-provider-finish-hook --provider claude'
+    settings_path.write_text(
+        json.dumps(
+            {
+                'hooks': {
+                    'Stop': [
+                        {'hooks': [{'type': 'command', 'command': 'echo existing'}]},
+                        {'hooks': [{'type': 'command', 'command': stale_command}]},
+                    ]
+                }
+            },
+            ensure_ascii=False,
+            indent=2,
+        ),
+        encoding='utf-8',
+    )
+
+    install_workspace_completion_hooks(
+        provider='claude',
+        workspace_path=workspace,
+        home_root=home_root,
+        command=command,
+    )
+
+    data = json.loads(settings_path.read_text(encoding='utf-8'))
+    commands = [
+        hook['command']
+        for group in data['hooks']['Stop']
+        for hook in group.get('hooks', [])
+        if isinstance(hook, dict)
+    ]
+    assert commands == ['echo existing', command]
 
 
 def test_install_claude_hooks_trusts_workspace_in_managed_home(tmp_path: Path) -> None:
@@ -217,6 +257,60 @@ def test_prepare_provider_workspace_materializes_claude_activity_hooks(tmp_path:
     ]
     assert any('ccb-provider-finish-hook' in command for command in stop_commands)
     assert not (workspace / '.claude').exists()
+
+
+def test_install_claude_activity_hooks_prunes_stale_ccb_activity_hooks(tmp_path: Path) -> None:
+    workspace = tmp_path / 'workspace'
+    home_root = tmp_path / 'claude-home'
+    settings_path = home_root / '.claude' / 'settings.json'
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    activity_command = '/usr/bin/python3 /current/bin/ccb-provider-activity-hook --provider claude'
+    stale_activity_command = '/usr/bin/python3 /old/bin/ccb-provider-activity-hook --provider claude'
+    finish_command = '/usr/bin/python3 /old/bin/ccb-provider-finish-hook --provider claude'
+    settings_path.write_text(
+        json.dumps(
+            {
+                'hooks': {
+                    'Stop': [
+                        {'hooks': [{'type': 'command', 'command': finish_command}]},
+                        {'hooks': [{'type': 'command', 'command': stale_activity_command}]},
+                    ],
+                    'PostToolUse': [
+                        {'hooks': [{'type': 'command', 'command': 'echo existing'}]},
+                        {'hooks': [{'type': 'command', 'command': stale_activity_command}]},
+                    ],
+                }
+            },
+            ensure_ascii=False,
+            indent=2,
+        ),
+        encoding='utf-8',
+    )
+
+    install_workspace_activity_hooks(
+        provider='claude',
+        workspace_path=workspace,
+        home_root=home_root,
+        command=activity_command,
+    )
+
+    data = json.loads(settings_path.read_text(encoding='utf-8'))
+    stop_commands = [
+        hook['command']
+        for group in data['hooks']['Stop']
+        for hook in group.get('hooks', [])
+        if isinstance(hook, dict)
+    ]
+    post_tool_commands = [
+        hook['command']
+        for group in data['hooks']['PostToolUse']
+        for hook in group.get('hooks', [])
+        if isinstance(hook, dict)
+    ]
+    assert finish_command in stop_commands
+    assert activity_command in stop_commands
+    assert stale_activity_command not in stop_commands
+    assert post_tool_commands == ['echo existing', activity_command]
 
 
 def test_prepare_provider_workspace_materializes_claude_memory_bundle_before_hooks(


### PR DESCRIPTION
## Problem
When CCB's install path changes (e.g. reinstall to a new location), the absolute-path hook command stored in `~/.claude/settings.json` no longer matches the freshly built one. The stale finish/activity hook lingers and a duplicate gets appended, so the same hook fires twice.

## Fix
Match ccb-managed hook groups by the `ccb-provider-*-hook` marker and drop any group whose command differs from the current one before appending, leaving exactly one up-to-date hook.

## Tests
`test/test_provider_hook_settings.py` extended for the stale/duplicate prune path — 33 passed on top of v7.3.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)