### PR TITLE
fix(namespace): fall back to default session size for sub-40x15 terminals

### DIFF
--- a/lib/ccbd/services/project_namespace_runtime/backend.py
+++ b/lib/ccbd/services/project_namespace_runtime/backend.py
@@ -214,7 +214,10 @@ def _resolved_session_size(terminal_size: tuple[int, int] | None) -> tuple[int, 
         height = int(terminal_size[1])
     except Exception:
         return default
-    if width <= 0 or height <= 0:
+    # 40x15 是四分屏可正常拆分的 sanity 下限：低于此宽高 tmux 无法materialize
+    # 两列四 pane 布局，且这类极小值通常来自尚未初始化/已 detached 的终端脏读，
+    # 一律回退到 default 而非硬塞，避免起出畸形 pane。
+    if width < 40 or height < 15:
         return default
     return width, height
 

--- a/test/test_v2_project_namespace_backend.py
+++ b/test/test_v2_project_namespace_backend.py
@@ -378,6 +378,39 @@ def test_create_session_uses_terminal_size_hint_when_provided(monkeypatch, tmp_p
     ]
 
 
+def test_create_session_falls_back_to_default_size_when_terminal_size_too_small(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv('CCB_TMUX_OBJECT_READY_POLL_INTERVAL_S', '0')
+    backend = _FlakyBackend()
+
+    create_session(
+        backend,
+        session_name='ccb-proj',
+        project_root=tmp_path,
+        window_name='cmd',
+        terminal_size=(10, 5),
+    )
+
+    assert backend.calls == [
+        (
+            'new-session',
+            '-d',
+            '-x',
+            '160',
+            '-y',
+            '48',
+            '-s',
+            'ccb-proj',
+            '-n',
+            'cmd',
+            '-c',
+            str(tmp_path),
+            'sh',
+            '-lc',
+            'while :; do sleep 3600; done',
+        )
+    ]
+
+
 def test_create_session_accepts_fast_probe_timeout(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setenv('CCB_TMUX_OBJECT_READY_POLL_INTERVAL_S', '0')
     backend = _FlakyBackend()


### PR DESCRIPTION
## Problem
`_resolved_session_size` only rejected dimensions `<= 0`. A tiny-but-positive size (a stale read from an initializing/detached terminal) was passed straight to tmux and produced a malformed 4-pane split.

## Fix
Treat `40x15` as the sanity floor for the two-column layout; fall back to the `(160, 48)` default when the resolved size is below it.

## Tests
`test/test_v2_project_namespace_backend.py` extended for the sub-floor fallback — 15 passed on top of v7.3.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)