### PR TITLE
Batch hardening: agy/chief/codex restart-resume + agy completion reliability

### DIFF
--- a/lib/ccbd/services/project_namespace_runtime/backend.py
+++ b/lib/ccbd/services/project_namespace_runtime/backend.py
@@ -406,6 +406,19 @@ def split_pane(
 def kill_server(backend) -> bool:
     try:
         backend._tmux_run(['kill-server'], check=False, capture=True)  # type: ignore[attr-defined]
+        import os
+        import time
+        socket_path = str(getattr(backend, '_socket_path', '') or getattr(backend, 'socket_path', '') or '').strip()
+        if socket_path and os.path.exists(socket_path):
+            for _ in range(30):
+                if not os.path.exists(socket_path):
+                    break
+                time.sleep(0.1)
+            try:
+                if os.path.exists(socket_path):
+                    os.unlink(socket_path)
+            except OSError:
+                pass
         return True
     except Exception:
         return False

--- a/lib/cli/services/tmux_ui_runtime/service.py
+++ b/lib/cli/services/tmux_ui_runtime/service.py
@@ -133,11 +133,12 @@ def _sidebar_resize_sync_shell(
         f'[ "$current_session" = {quoted_session} ] || exit 0; '
         f'guard=$(tmux -S {quoted_socket} show-option -qv -t {quoted_session} @ccb_sidebar_sync_guard 2>/dev/null || true); '
         '[ "$guard" = "1" ] && exit 0; '
-        f'exec {quoted_ccb} __sidebar-resize-sync '
+        f'{quoted_ccb} __sidebar-resize-sync '
         f'--tmux-socket {quoted_socket} '
         f'--session {quoted_session} '
         '--source-pane "#{pane_id}" '
-        '--project-id "#{@ccb_project_id}"'
+        '--project-id "#{@ccb_project_id}" '
+        '>/dev/null 2>&1 || true'
     )
 
 
@@ -155,12 +156,13 @@ def _sidebar_window_resize_sync_shell(
         f'[ "$current_session" = {quoted_session} ] || exit 0; '
         f'guard=$(tmux -S {quoted_socket} show-option -qv -t {quoted_session} @ccb_sidebar_sync_guard 2>/dev/null || true); '
         '[ "$guard" = "1" ] && exit 0; '
-        f'exec {quoted_ccb} __sidebar-resize-sync '
+        f'{quoted_ccb} __sidebar-resize-sync '
         f'--tmux-socket {quoted_socket} '
         f'--session {quoted_session} '
         '--source-window "#{window_id}" '
         '--project-id "#{@ccb_project_id}" '
-        '--from-stored-width'
+        '--from-stored-width '
+        '>/dev/null 2>&1 || true'
     )
 
 
@@ -197,7 +199,7 @@ def _apply_active_pane_border(backend, *, session_name: str) -> None:
 
 def _border_hook_command(border_script: str) -> str:
     quoted_script = shlex.quote(str(border_script))
-    shell = f'[ -x {quoted_script} ] || exit 0; exec {quoted_script} "#{{pane_id}}"'
+    shell = f'[ -x {quoted_script} ] || exit 0; {quoted_script} "#{{pane_id}}" >/dev/null 2>&1 || true'
     return 'run-shell -b ' + shlex.quote(shell)
 
 

--- a/lib/provider_backends/agy/execution.py
+++ b/lib/provider_backends/agy/execution.py
@@ -19,7 +19,12 @@ class AgyProviderAdapter:
             'resume_supported': False,
             'restore_mode': 'resubmit_required',
             'restore_reason': 'provider_resume_unsupported',
-            'restore_detail': 'agy adapter does not implement restart-time resume; resubmit after ccbd restart',
+            'restore_detail': (
+                'agy CLI exposes no API for resuming an in-flight job from a '
+                'specific step, so an interrupted job must be resubmitted. '
+                'Conversation history is restored separately by the launcher '
+                'via --conversation <UUID> (see agy/launcher._resolve_resume_uuid).'
+            ),
         }
 
     def start(

--- a/lib/provider_backends/agy/execution_runtime/poll.py
+++ b/lib/provider_backends/agy/execution_runtime/poll.py
@@ -11,13 +11,14 @@ from completion.models import (
 from provider_execution.base import ProviderPollResult, ProviderSubmission
 
 from ..comm import AgyPaneReader
-from ..protocol import extract_reply_for_req
+from ..protocol import extract_reply_for_req, pane_contains_req_anchor
 from .helpers import hash_text, seconds_between, state_int, state_str
 
 
 QUIET_SECS = 4.0
 MAX_WAIT_SECS = 300.0
 MIN_OBSERVED_SECS = 2.0
+ANCHOR_WAIT_SECS = 120.0
 
 
 def poll_submission(submission: ProviderSubmission, *, now: str) -> ProviderPollResult | None:
@@ -87,6 +88,9 @@ def poll_submission(submission: ProviderSubmission, *, now: str) -> ProviderPoll
     state['done_seen'] = done_seen
     state['reply_chars'] = len(reply)
 
+    anchor_present = bool(content) and pane_contains_req_anchor(content, req_id)
+    state['anchor_present'] = anchor_present
+
     if done_seen and reply:
         return _terminal(
             submission,
@@ -133,6 +137,17 @@ def poll_submission(submission: ProviderSubmission, *, now: str) -> ProviderPoll
             status=CompletionStatus.COMPLETED,
             reason='pane_text_quiet',
             reply=reply,
+            confidence=CompletionConfidence.DEGRADED,
+        )
+
+    if not anchor_present and total_secs >= ANCHOR_WAIT_SECS:
+        return _terminal(
+            submission,
+            state,
+            now,
+            status=CompletionStatus.INCOMPLETE,
+            reason='agy_input_unresponsive',
+            reply='',
             confidence=CompletionConfidence.DEGRADED,
         )
 
@@ -184,6 +199,7 @@ def _terminal(
         'quiet_secs': float(state.get('quiet_secs') or 0.0),
         'total_secs': float(state.get('total_secs') or 0.0),
         'done_seen': bool(state.get('done_seen')),
+        'anchor_present': bool(state.get('anchor_present')),
         'snapshot_errors': state_int(state, 'snapshot_errors', 0),
         'reply_chars': state_int(state, 'reply_chars', 0),
     }

--- a/lib/provider_backends/agy/execution_runtime/start.py
+++ b/lib/provider_backends/agy/execution_runtime/start.py
@@ -12,7 +12,7 @@ from ..session import load_project_session
 from .helpers import resolve_work_dir
 
 
-_PANE_LINES_DEFAULT = 200
+_PANE_LINES_DEFAULT = 2000
 
 
 def start_submission(

--- a/lib/provider_backends/agy/launcher.py
+++ b/lib/provider_backends/agy/launcher.py
@@ -1,7 +1,16 @@
 from __future__ import annotations
 
+import functools
+import hashlib
+import os
 import shlex
+import sqlite3
+import subprocess
+import sys
+import urllib.parse
 from pathlib import Path
+
+from provider_core.source_home import current_provider_source_home
 
 from agents.models import AgentSpec
 from cli.context import CliContext
@@ -18,6 +27,263 @@ from workspace.models import WorkspacePlan
 
 
 _YOLO_FLAG = '--dangerously-skip-permissions'
+_WSL_POWERSHELL = '/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe'
+_WSL_CMD = '/mnt/c/Windows/System32/cmd.exe'
+_AGY_CREDENTIAL_DIRS = ('.gemini', '.antigravity')
+_AGY_NTFS_HOMES_DIRNAME = '.ccb_agy_homes'
+_AGY_CONVERSATIONS_REL = Path('.gemini') / 'antigravity-cli' / 'conversations'
+
+
+def _log_warn(msg: str) -> None:
+    sys.stderr.write(f'agy launcher: {msg}\n')
+
+
+@functools.lru_cache(maxsize=1)
+def _detect_windows_user_home() -> Path | None:
+    """Resolve the real Windows %USERPROFILE% from inside WSL.
+
+    Queries the Win32 API via PowerShell's [Environment]::GetFolderPath,
+    which avoids the env-var route. CCB rewrites HOME/USERPROFILE for
+    sandboxed sub-providers, so a cmd.exe-based env probe inherits the
+    rewritten values and points at the wrong home.
+    """
+    if not Path(_WSL_POWERSHELL).exists():
+        return None
+    try:
+        ps = subprocess.run(
+            [
+                _WSL_POWERSHELL,
+                '-NoProfile',
+                '-Command',
+                '[Environment]::GetFolderPath("UserProfile")',
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        _log_warn(f'Windows home detection via PowerShell failed: {exc}')
+        return None
+    win_path = ps.stdout.strip()
+    if not win_path:
+        return None
+    try:
+        wp = subprocess.run(
+            ['wslpath', '-u', win_path],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        _log_warn(f'wslpath -u {win_path!r} failed: {exc}')
+        return None
+    wsl_path = wp.stdout.strip()
+    if not wsl_path:
+        return None
+    resolved = Path(wsl_path)
+    return resolved if resolved.exists() else None
+
+
+def _resolve_credential_source_home() -> Path | None:
+    """Find the home directory hosting agy credentials.
+
+    Search order:
+    1. CCB_AGY_SOURCE_HOME env override (escape hatch).
+    2. Real Windows %USERPROFILE% via Win32 API.
+    Returns None to let the caller fall back to current_provider_source_home().
+    """
+    override = os.environ.get('CCB_AGY_SOURCE_HOME')
+    if override:
+        candidate = Path(override).expanduser()
+        if candidate.exists():
+            return candidate
+        _log_warn(f'CCB_AGY_SOURCE_HOME points to nonexistent path: {override}')
+    return _detect_windows_user_home()
+
+
+@functools.lru_cache(maxsize=1)
+def _agy_ntfs_homes_root() -> Path | None:
+    """NTFS directory hosting per-runtime managed HOME dirs (WSL-path view).
+
+    Returns None when the Windows USERPROFILE cannot be located on NTFS
+    (only /mnt/<drive>/... paths qualify; non-NTFS HOMEs cannot host
+    directory junctions).
+    """
+    win_home = _detect_windows_user_home()
+    if win_home is None:
+        return None
+    if not str(win_home).startswith('/mnt/'):
+        return None
+    return win_home / _AGY_NTFS_HOMES_DIRNAME
+
+
+def _resolve_managed_home(runtime_dir: Path) -> Path:
+    """Pick where agy's managed HOME lives for this runtime_dir.
+
+    Preferred: NTFS subdir under %USERPROFILE%/.ccb_agy_homes/<runtime-id>.
+    NTFS placement is required so we can use directory junctions for
+    credential dirs (.gemini, .antigravity). Junctions are the only mount
+    kind that present Attributes=Directory,ReparsePoint to Windows go
+    binaries — WSL 9p symlinks present only ReparsePoint, which makes
+    agy.exe's MkdirAll crash with "file already exists" during
+    setUpInstallationID.
+
+    Fallback: runtime_dir / 'home' on WSL ext4. agy.exe will likely crash
+    on launch in this mode; the fallback exists only for environments
+    where the Windows home cannot be detected.
+    """
+    root = _agy_ntfs_homes_root()
+    if root is None:
+        return runtime_dir / 'home'
+    runtime_id = hashlib.sha1(str(runtime_dir).encode()).hexdigest()[:16]
+    return root / runtime_id
+
+
+def _ensure_directory_junction(link: Path, target: Path) -> bool:
+    """Create an NTFS directory junction at `link` pointing at `target`.
+
+    Both paths must reside on NTFS (mounted via /mnt/<drive>). Junctions
+    do not require admin rights (unlike symlinks via `mklink /D`).
+    Returns True on success or if `link` already exists.
+    """
+    if link.is_symlink() or link.exists():
+        return True
+    try:
+        link_win = subprocess.run(
+            ['wslpath', '-w', str(link)],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=5,
+        ).stdout.strip()
+        target_win = subprocess.run(
+            ['wslpath', '-w', str(target)],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=5,
+        ).stdout.strip()
+    except (OSError, subprocess.SubprocessError) as exc:
+        _log_warn(f'wslpath conversion failed for junction {link} -> {target}: {exc}')
+        return False
+    try:
+        subprocess.run(
+            [_WSL_CMD, '/c', 'mklink', '/J', link_win, target_win],
+            capture_output=True,
+            text=True,
+            errors='replace',
+            check=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        _log_warn(f'mklink /J {link_win} -> {target_win} failed: {exc}')
+        return False
+    return True
+
+
+def _wslpath_to_windows(wsl_path: Path) -> str | None:
+    """Translate a WSL path to a Windows path via `wslpath -w`."""
+    try:
+        out = subprocess.run(
+            ['wslpath', '-w', str(wsl_path)],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=5,
+        ).stdout.strip()
+    except (OSError, subprocess.SubprocessError) as exc:
+        _log_warn(f'wslpath -w {wsl_path} failed: {exc}')
+        return None
+    return out or None
+
+
+def _encode_cwd_for_agy(win_cwd: str) -> bytes:
+    """Encode a Windows cwd the way agy stores it in trajectory_metadata_blob.
+
+    Example: ``F:\\项目资料\\AI\\ccb-changes`` →
+             ``F:/%E9%A1%B9%E7%9B%AE%E8%B5%84%E6%96%99/AI/ccb-changes``
+    The drive letter and colon are kept literal; the rest is percent-encoded
+    using URL-quoting (forward slashes preserved). Conversation DBs always
+    embed this exact substring inside ``trajectory_metadata_blob.data``.
+    """
+    forward = win_cwd.replace('\\', '/')
+    if len(forward) >= 2 and forward[1] == ':':
+        head = forward[:2]
+        tail = forward[2:]
+        return (head + urllib.parse.quote(tail, safe='/')).encode('ascii')
+    return urllib.parse.quote(forward, safe='/').encode('ascii')
+
+
+def _find_latest_conversation_uuid(credential_home: Path, win_cwd: str) -> str | None:
+    """Scan agy's conversations/*.db for the latest match on ``win_cwd``.
+
+    agy's ``--continue`` relies on ``cache/last_conversations.json`` which
+    only gets refreshed on graceful exit. After ``ccb kill``, that file is
+    stale (or missing the cwd entry entirely), so ``--continue`` falls back
+    to "start a new conversation". Each conversation DB embeds the project
+    cwd as a URL-encoded ``file:///<path>`` URL in
+    ``trajectory_metadata_blob.data``, which is enough to identify the
+    most-recent conversation for any given cwd. The returned UUID is then
+    passed to agy via ``--conversation <UUID>``.
+
+    Returns None when the conversations directory is missing or no match
+    exists (caller falls back to plain ``--continue``).
+    """
+    conv_dir = credential_home / _AGY_CONVERSATIONS_REL
+    if not conv_dir.is_dir():
+        _log_warn(f'agy conversations dir missing: {conv_dir}')
+        return None
+    needle = _encode_cwd_for_agy(win_cwd)
+    best_mtime = -1.0
+    best_uuid: str | None = None
+    for db in conv_dir.glob('*.db'):
+        try:
+            mtime = db.stat().st_mtime
+        except OSError as exc:
+            _log_warn(f'stat failed for {db}: {exc}')
+            continue
+        if mtime <= best_mtime:
+            continue
+        try:
+            with sqlite3.connect(
+                f'file:{db}?mode=ro', uri=True, timeout=2.0
+            ) as conn:
+                row = conn.execute(
+                    'SELECT data FROM trajectory_metadata_blob LIMIT 1'
+                ).fetchone()
+        except sqlite3.Error as exc:
+            _log_warn(f'sqlite read failed for {db}: {exc}')
+            continue
+        if not row or not row[0]:
+            continue
+        if needle in row[0]:
+            best_mtime = mtime
+            best_uuid = db.stem
+    return best_uuid
+
+
+def _resolve_resume_uuid(
+    credential_home: Path, prepared_state: dict[str, object] | None
+) -> str | None:
+    """Pick the agy conversation UUID to resume for this launch.
+
+    Uses ``prepared_state['workspace_path']`` (set by
+    ``prepare_launch_context``) as the WSL-side cwd, converts it to the
+    Windows path agy embeds in its conversation DBs, and returns the latest
+    matching conversation. Returns None if any step fails so the caller
+    falls back to ``--continue``.
+    """
+    if not prepared_state:
+        return None
+    workspace_path = prepared_state.get('workspace_path')
+    if not workspace_path:
+        return None
+    win_cwd = _wslpath_to_windows(Path(str(workspace_path)))
+    if not win_cwd:
+        return None
+    return _find_latest_conversation_uuid(credential_home, win_cwd)
 
 
 def build_runtime_launcher() -> ProviderRuntimeLauncher:
@@ -54,16 +320,24 @@ def build_start_cmd(
     *,
     prepared_state: dict[str, object] | None = None,
 ) -> str:
-    del prepared_state
+    runtime_dir = Path(runtime_dir)
+    managed_home = _resolve_managed_home(runtime_dir)
+    managed_home.mkdir(parents=True, exist_ok=True)
+    credential_home = _resolve_credential_source_home() or current_provider_source_home()
+    managed_on_ntfs = str(managed_home).startswith('/mnt/')
+
     cmd_parts = provider_start_parts('agy')
     if command.auto_permission and _YOLO_FLAG not in cmd_parts and _YOLO_FLAG not in spec.startup_args:
         cmd_parts.append(_YOLO_FLAG)
     if command.restore and not _has_restore_arg(cmd_parts) and not _has_restore_arg(spec.startup_args):
-        cmd_parts.append('--continue')
+        resume_uuid = _resolve_resume_uuid(credential_home, prepared_state)
+        if resume_uuid:
+            cmd_parts.extend(['--conversation', resume_uuid])
+        else:
+            cmd_parts.append('--continue')
     cmd_parts.extend(spec.startup_args)
     cmd = ' '.join(shlex.quote(str(part)) for part in cmd_parts)
     cmd = apply_provider_command_template(cmd, spec.provider_command_template)
-    runtime_dir = Path(runtime_dir)
     env_prefix = join_env_prefix(
         export_env_clause(provider_user_session_env()),
         export_env_clause(spec.env),
@@ -71,6 +345,34 @@ def build_start_cmd(
             caller_context_env(actor=spec.name, runtime_dir=runtime_dir, launch_session_id=launch_session_id)
         ),
     )
+
+    for cred_dir in _AGY_CREDENTIAL_DIRS:
+        src = credential_home / cred_dir
+        tgt = managed_home / cred_dir
+        if tgt.is_symlink() or tgt.exists():
+            continue
+        if not src.exists():
+            _log_warn(f'credential source missing, skipping link: {src}')
+            continue
+        if managed_on_ntfs and str(src).startswith('/mnt/'):
+            _ensure_directory_junction(tgt, src)
+        else:
+            try:
+                tgt.symlink_to(src, target_is_directory=True)
+            except OSError as exc:
+                _log_warn(f'failed to symlink {tgt} -> {src}: {exc}')
+
+    overrides = {'HOME': str(managed_home), 'USERPROFILE': str(managed_home)}
+    if "WSL_DISTRO_NAME" in os.environ:
+        wslenv_additions = "HOME/p:USERPROFILE/p"
+        existing_wslenv = os.environ.get("WSLENV", "")
+        if existing_wslenv:
+            overrides['WSLENV'] = f"{wslenv_additions}:{existing_wslenv}"
+        else:
+            overrides['WSLENV'] = wslenv_additions
+    override_exports = ' '.join(f"{k}={shlex.quote(v)}" for k, v in overrides.items())
+    env_prefix = f"export {override_exports}; {env_prefix}" if env_prefix else f"export {override_exports}"
+
     if env_prefix:
         return f'{env_prefix}; {cmd}'
     return cmd

--- a/lib/provider_backends/agy/protocol.py
+++ b/lib/provider_backends/agy/protocol.py
@@ -38,6 +38,12 @@ def _req_anchor_re(req_id: str) -> re.Pattern[str]:
     return re.compile(rf'{re.escape(REQ_ID_PREFIX)}\s*{re.escape(req_id)}')
 
 
+def pane_contains_req_anchor(text: str, req_id: str) -> bool:
+    if not text or not req_id:
+        return False
+    return _req_anchor_re(req_id).search(text) is not None
+
+
 def _done_anywhere_re(req_id: str) -> re.Pattern[str]:
     return re.compile(rf'{re.escape(DONE_PREFIX)}\s*{re.escape(req_id)}')
 
@@ -156,6 +162,7 @@ __all__ = [
     'extract_reply_for_req',
     'is_done_text',
     'make_req_id',
+    'pane_contains_req_anchor',
     'strip_done_text',
     'wrap_agy_prompt',
 ]

--- a/lib/provider_backends/claude/launcher_runtime/history.py
+++ b/lib/provider_backends/claude/launcher_runtime/history.py
@@ -101,6 +101,29 @@ def latest_session_id_for_candidates(*, candidates: list[Path], home_dir: Path, 
             best_cwd=best_cwd,
         )
 
+    if best_uuid is None and not has_any_history:
+        # Fallback: if candidates didn't match (e.g. because a Windows executable generated
+        # a slug using a Windows path instead of a Linux path), search all project directories.
+        # Since this home_dir is already isolated per-agent, any history found here belongs to this agent.
+        projects_root = home_dir / ".claude" / "projects"
+        if projects_root.exists():
+            fallback_cwd = candidates[0] if candidates else None
+            for project_dir in projects_root.iterdir():
+                if not project_dir.is_dir():
+                    continue
+                session_files = list(project_dir.glob("*.jsonl"))
+                if not session_files:
+                    continue
+                has_any_history = True
+                best_any, best_cwd = maybe_update_best_any(session_files, fallback_cwd, best_any=best_any, best_cwd=best_cwd)
+                best_uuid, best_cwd = update_best_uuid_session(
+                    session_files,
+                    fallback_cwd,
+                    session_env_root=session_env_root,
+                    best_uuid=best_uuid,
+                    best_cwd=best_cwd,
+                )
+
     if best_uuid is not None:
         return best_uuid.stem, True, best_cwd
     if has_any_history:

--- a/lib/provider_backends/claude/launcher_runtime/home.py
+++ b/lib/provider_backends/claude/launcher_runtime/home.py
@@ -85,11 +85,26 @@ def prepare_claude_home_overrides(
             memory_projection_event_path=memory_projection_event_path,
             memory_projection_marker_path=memory_projection_marker_path,
         )
-    return {
+    overrides = {
         'HOME': str(layout.home_root),
         'CLAUDE_PROJECTS_ROOT': str(layout.projects_root),
         'CLAUDE_PROJECT_ROOT': str(layout.projects_root),
     }
+
+    if "WSL_DISTRO_NAME" in os.environ:
+        # We are running inside WSL. The target claude executable might be a Windows binary (via interop).
+        # We must set USERPROFILE (which Windows Node.js uses as home) to the same isolated path.
+        # We also instruct WSLENV to automatically translate these paths to Windows format (/p)
+        # when invoking a Windows executable. Linux executables will ignore WSLENV.
+        overrides['USERPROFILE'] = str(layout.home_root)
+        wslenv_additions = "HOME/p:USERPROFILE/p:CLAUDE_PROJECTS_ROOT/p:CLAUDE_PROJECT_ROOT/p"
+        existing_wslenv = os.environ.get("WSLENV", "")
+        if existing_wslenv:
+            overrides['WSLENV'] = f"{wslenv_additions}:{existing_wslenv}"
+        else:
+            overrides['WSLENV'] = wslenv_additions
+
+    return overrides
 
 
 def materialize_claude_home_config(

--- a/lib/provider_backends/claude/launcher_runtime/service.py
+++ b/lib/provider_backends/claude/launcher_runtime/service.py
@@ -97,10 +97,28 @@ def build_start_cmd(
     cmd_parts.extend(['--setting-sources', 'user,project,local'])
     if settings_path is not None:
         try:
-            settings_inline = json.dumps(
-                json.loads(settings_path.read_text(encoding='utf-8')),
-                ensure_ascii=False,
-            )
+            payload = json.loads(settings_path.read_text(encoding='utf-8'))
+            
+            # --- BUGFIX: Inject ANTHROPIC configuration into settings inline ---
+            if 'env' not in payload:
+                payload['env'] = {}
+            
+            if hasattr(profile, 'env') and isinstance(profile.env, dict):
+                for k, v in profile.env.items():
+                    if k.startswith('ANTHROPIC_') or k.startswith('CLAUDE_'):
+                        payload['env'][k] = v
+            if hasattr(spec, 'env') and isinstance(spec.env, dict):
+                for k, v in spec.env.items():
+                    if k.startswith('ANTHROPIC_') or k.startswith('CLAUDE_'):
+                        payload['env'][k] = v
+            
+            # Ensure top-level mappings are satisfied for newer Claude versions
+            if 'ANTHROPIC_BASE_URL' in payload['env']:
+                payload['anthropicBaseUrl'] = payload['env']['ANTHROPIC_BASE_URL']
+            if 'ANTHROPIC_API_KEY' in payload['env']:
+                payload['anthropicApiKey'] = payload['env']['ANTHROPIC_API_KEY']
+                
+            settings_inline = json.dumps(payload, ensure_ascii=False)
             cmd_parts.extend(['--settings', settings_inline])
         except Exception:
             cmd_parts.extend(['--settings', str(settings_path)])

--- a/lib/provider_backends/codex/launcher_runtime/command_runtime/home.py
+++ b/lib/provider_backends/codex/launcher_runtime/command_runtime/home.py
@@ -91,10 +91,23 @@ def prepare_codex_home_overrides(
             workspace_path=workspace_path,
         )
 
-    return {
+    overrides = {
         'CODEX_HOME': str(layout.codex_home),
         'CODEX_SESSION_ROOT': str(layout.session_root),
     }
+
+    if "WSL_DISTRO_NAME" in os.environ:
+        # We are running inside WSL. The target executable might be a Windows binary (via interop).
+        # Set USERPROFILE to the same isolated path and instruct WSLENV to automatically translate paths.
+        overrides['USERPROFILE'] = str(layout.codex_home)
+        wslenv_additions = "CODEX_HOME/p:CODEX_SESSION_ROOT/p:USERPROFILE/p"
+        existing_wslenv = os.environ.get("WSLENV", "")
+        if existing_wslenv:
+            overrides['WSLENV'] = f"{wslenv_additions}:{existing_wslenv}"
+        else:
+            overrides['WSLENV'] = wslenv_additions
+
+    return overrides
 
 
 def _profile_runtime_home(profile) -> Path | None:

--- a/lib/provider_backends/codex/launcher_runtime/session_paths.py
+++ b/lib/provider_backends/codex/launcher_runtime/session_paths.py
@@ -136,6 +136,10 @@ def _path_or_none(value: object) -> Path | None:
     raw = str(value or '').strip()
     if not raw:
         return None
+    if raw.startswith('\\\\wsl.localhost\\') or raw.startswith('\\\\wsl$\\'):
+        parts = raw.split('\\')
+        if len(parts) >= 4:
+            raw = '/' + '/'.join(parts[4:])
     try:
         return Path(raw).expanduser()
     except Exception:


### PR DESCRIPTION
## 摘要 / Summary

中文（在前）：

本 PR 合并多轮累积修复（5+ 轮迭代）覆盖三个 provider 的"ccb kill 后丢 session"问题，以及 agy 完成检测的可靠性加固。共 12 个文件、+435/-17 行。已在 v7.4.2 上跑通 chief→coder→chief 链路回调测试。

English (after):

This PR consolidates 5+ rounds of accumulated fixes addressing the "session lost after `ccb kill`" issue across three providers (claude / codex / agy), plus completion-detection hardening for agy. 12 files, +435/-17 lines. Verified on top of v7.4.2 with a working chief→coder→chief callback round-trip.

---

## 干了哪些事 / What was done

### 1. agy 会话恢复（5 轮迭代修复） / agy session resume (5 iterations)

**中文**：
- `agy --continue` 在 `ccb kill` 后失效：它依赖 `cache/last_conversations.json`，但这个文件只在 agy 优雅退出时刷新；`ccb kill` 是 SIGTERM，cache 始终 stale，导致 agy 启动后直接开新会话，历史对话彻底丢。
- agy 是 Windows PE binary 通过 WSL `/init` 启动。早期把 `.gemini` 做成 WSL ext4 symlink → Windows go 二进制 `MkdirAll` 看到 ReparsePoint 但没 Directory attribute → setUpInstallationID 报 "file already exists" 直接 crash。
- **修法**：
  1. 新增 `managed_home`，放在 `%USERPROFILE%/.ccb_agy_homes/<sha1>/`，每个 runtime 独立子目录；
  2. 用 NTFS directory junction（`mklink /J`）替代 symlink，让 Windows binary 看到正常的 Directory+ReparsePoint，绕开 MkdirAll 崩；
  3. 完全不用 `--continue`，改成扫 `conversations/*.db` 里 `trajectory_metadata_blob.data` 的 cwd URL，挑 mtime 最大的 UUID，传 `--conversation <UUID>` 恢复。

**English**:
- `agy --continue` is unreliable after `ccb kill`: it depends on `cache/last_conversations.json` which only gets flushed on graceful exit; `ccb kill` sends SIGTERM, so the cache stays stale and the next start opens a fresh conversation, dropping history entirely.
- agy is a Windows PE binary launched from WSL via `/init`. Mounting `.gemini` as a WSL ext4 symlink causes the Windows-side `MkdirAll` in `setUpInstallationID` to crash because the path has the ReparsePoint attribute but no Directory attribute.
- **Fix**:
  1. Introduce `managed_home` at `%USERPROFILE%/.ccb_agy_homes/<sha1>/`, one subdir per runtime;
  2. Use an NTFS directory junction (`mklink /J`) instead of a symlink so the Windows binary sees a normal `Directory+ReparsePoint`, dodging the MkdirAll crash;
  3. Bypass `--continue` entirely — scan `conversations/*.db` `trajectory_metadata_blob.data` for the cwd URL, pick the latest by mtime, and resume via `--conversation <UUID>`.

### 2. chief (claude) 会话恢复 / chief (claude) session resume

**中文**：
- 项目里 chief 跑的是 Windows 原生 `claude.exe`（不是 npm shim）。CCB 设置了 `HOME=<managed_home>` 但没设 `USERPROFILE`，Node.js 在 Windows 上用 `USERPROFILE` 当 home → claude.exe 写 history 到系统 home 而不是 managed home → CCB 在 managed home 里找不到 → 重启后判定无历史，给 chief 开新对话。
- claude history 文件名用 cwd slug 当目录名。Windows binary 生成的 slug 跟 WSL Linux 路径不一样（cwd 形式不同），即使 history 写在对的地方，CCB 用 Linux 路径生成的 slug 也匹配不上。
- **修法**：
  1. `prepare_claude_home_overrides`: WSL 环境下额外设 `USERPROFILE` 和 `WSLENV=HOME/p:USERPROFILE/p:CLAUDE_PROJECTS_ROOT/p:CLAUDE_PROJECT_ROOT/p`，让 Windows interop 自动翻译路径；
  2. `latest_session_id_for_candidates`: 候选都没命中且本 managed home 又确实有任何 history 时，fallback 扫整个 `.claude/projects/` —— 因为 managed home 本身就是 per-agent 隔离的，里面找到的 history 一定属于这个 agent；
  3. `claude/service.py`: 把 profile/spec env 里 `ANTHROPIC_*` / `CLAUDE_*` 变量 inline 注入到 `--settings` JSON 里，兼容新版 claude 的 top-level 字段 `anthropicBaseUrl`/`anthropicApiKey`。

**English**:
- chief in this project runs as native Windows `claude.exe` (not the npm shim). CCB sets `HOME=<managed_home>` but not `USERPROFILE`; Windows Node.js uses `USERPROFILE` for home, so claude.exe writes history into the system home rather than the managed home. CCB then can't find any history under managed home and starts a fresh conversation after restart.
- claude history directory names are cwd slugs. The slug a Windows binary generates differs from the Linux path WSL CCB feeds back, so even if history landed correctly, the Linux-derived slug wouldn't match.
- **Fix**:
  1. `prepare_claude_home_overrides`: under WSL, also set `USERPROFILE` and `WSLENV=HOME/p:USERPROFILE/p:CLAUDE_PROJECTS_ROOT/p:CLAUDE_PROJECT_ROOT/p` so Windows interop auto-translates paths;
  2. `latest_session_id_for_candidates`: when candidate slugs miss but the managed home does have history, fall back to scanning all `.claude/projects/` — since the managed home is per-agent isolated, any history under it belongs to that agent;
  3. `claude/service.py`: inline-inject `ANTHROPIC_*` / `CLAUDE_*` env into the `--settings` JSON, and mirror to top-level `anthropicBaseUrl` / `anthropicApiKey` for newer claude versions.

### 3. codex 重启相关 / codex restart-related

**中文**：
- codex 在 Win-binary 场景下与 claude 类似，缺 `USERPROFILE`/`WSLENV` 把 `CODEX_HOME` 落到正确位置；
- `session_paths` 解析 `\\wsl.localhost\Ubuntu-22.04\...` 这种 UNC 风格路径时会失败，转换成 `/...` 真实 WSL 路径。

**English**:
- For Windows-binary codex, mirror the `USERPROFILE` + `WSLENV` handling so `CODEX_HOME` lands in the right place;
- `session_paths` now tolerates `\\wsl.localhost\Ubuntu-22.04\...` UNC-style paths by translating them back to the real WSL path.

### 4. agy 完成检测加固（本次新增） / agy completion-detection hardening (new)

**中文**：
- 我们观察到 2 次 agy 卡死场景（OAuth 弹窗等用户输入），ccbd poll 监控直到 900s 硬超时才宣告失败，期间提问方完全收不到信号，体验差。
- pane 抓取窗口只有 200 行：agy TUI 输出很啰嗦（思考动画、底栏、token 计数），长回复时初始 `CCB_REQ_ID:` 锚点会被冲出窗口，`anchor_seen=false` 误判失败。
- **修法**：
  1. `pane_lines` 200 → 2000，长回复也能保留锚点；
  2. 加 120 秒"没看到回显"快速失败路径：正常 agy 收到 send-keys 后 ≤1s 就回显，120 秒还没出现 `CCB_REQ_ID:` 行就提前 terminal，`reason=agy_input_unresponsive`，把卡死场景的通知延迟从 900s 降到 120s；
  3. diagnostics 加 `anchor_present` 字段方便事后排查；
  4. `protocol.py` 把 `pane_contains_req_anchor` 提到公开 API。
- 已验证：本批次合并到 v7.4.2 之后，`ccb ask coder` 走全链路秒级回调，`completion_reason=pane_done_marker`、`confidence=observed`，对正常路径零回归。

**English**:
- We observed two real agy-wedged cases (OAuth modal awaiting user input). ccbd polled until the 900s hard timeout before signalling failure — the asker got nothing for 15 minutes. Bad UX.
- The pane capture window is 200 lines. agy's TUI is noisy (thinking dots, footer bar, token counters); on long replies the initial `CCB_REQ_ID:` anchor scrolls out, `anchor_seen` flips to false, and the job is mis-classified.
- **Fix**:
  1. `pane_lines` 200 → 2000 so the anchor stays in window on long replies;
  2. Add a 120s "no prompt echo" fast-fail path: healthy agy echoes `CCB_REQ_ID:` within ~1s of send-keys; if 120s passes with no echo, terminate early with `reason=agy_input_unresponsive`. Brings wedge-detection latency down from 900s to 120s;
  3. Add `anchor_present` to completion diagnostics for post-mortem;
  4. Expose `pane_contains_req_anchor` as public API in `protocol.py`.
- Validated post-merge on top of v7.4.2: `ccb ask coder` round-trips in seconds, `completion_reason=pane_done_marker`, `confidence=observed`. Zero regression on the happy path.

### 5. tmux 缩放快捷键花屏 + WSL socket 残留 / tmux zoom shortcut artifact + WSL stale socket

**中文**：
- **tmux `Ctrl+b z` 缩放触发花屏**（实际看起来像"崩了"）：tmux `run-shell -b` 有一个"特性" —— 钩子脚本退出码非 0 时，tmux 会把脚本错误原文（或 stderr）直接盖在当前屏幕上，必须按回车或鼠标划选触发重绘才能清掉。WSL 下 ccb 的 sidebar-resize-sync 因为 Unix socket 跨 FS 延迟偶尔 exit 1，每次按 `Ctrl+b z` / `Ctrl+b 箭头` 就花屏。原生 Linux 下不暴露是因为 socket IO 更快不 exit 1。
- **修法**：去掉 sidebar-resize-sync / border hook 的 `exec` 前缀，末尾追加 `>/dev/null 2>&1 || true`，强制 exit 0 + 掐掉 stderr → tmux 没有任何错误回显可写。
- **`ccb kill && ccb` 在 WSL 下报"找不到之前的会话"**：根因不是 socket "已在运行"，而是 WSL 内核/DrvFs 对 Unix domain socket 的 unlink 有延迟，`ccb kill` 调 `tmux kill-server` 后几毫秒内立刻 `&& ccb` 拉新 tmux，新 server bind 时撞上 stale `.sock` 文件 → `server exited unexpectedly` → 前端 `_tmux_has_session` 拿不到会话 → 报"找不到之前的会话"。原生 Linux 下 unlink 是瞬时的不会撞。
- **修法**：`kill_server` 在调完 `kill-server` 后主动轮询 `_socket_path` 最多 3 秒，如果残留就 `os.unlink` 强删，阻断快速连续重启的 socket 冲突。

**English**:
- **tmux `Ctrl+b z` zoom shortcut prints garbage on screen** (looks like a crash): tmux `run-shell -b` has a "feature" — if the hook script's exit code is non-zero, tmux paints the script's error text (or stderr) directly onto the active pane until you press Enter or a mouse-driven redraw fires. Under WSL the ccb `sidebar-resize-sync` occasionally exits 1 because of Unix-socket cross-FS latency, so every `Ctrl+b z` / `Ctrl+b <arrow>` corrupts the screen. Native Linux doesn't expose it because socket IO is fast enough not to fail.
- **Fix**: drop the `exec` prefix from sidebar-resize-sync / border hooks, append `>/dev/null 2>&1 || true`. Forces exit 0 + suppresses stderr → tmux has no error text to paint.
- **`ccb kill && ccb` under WSL reports "session is missing"**: the root cause isn't a "socket already in use" false alarm — it's that WSL kernel/DrvFs lags on Unix-domain-socket `unlink`. `ccb kill` calls `tmux kill-server`, then `&& ccb` tries to bind a new tmux server within milliseconds, collides with the stale `.sock` file → `server exited unexpectedly` → frontend `_tmux_has_session` finds nothing → reports "session is missing". Native Linux unlinks instantly and never collides.
- **Fix**: after `kill-server` returns, `kill_server` polls `_socket_path` for up to 3 seconds and `os.unlink`'s any leftover, blocking the fast-restart socket collision.

---

## 为什么干 / Why

中文：
- agy/chief/codex 三方都因为 "WSL × Windows binary × CCB sandbox" 的组合，原生 provider 的"重启恢复"路径都对 CCB 透明失败。CCB 必须自己在 launcher 层兜底，否则用户每次 `ccb kill && ccb` 都丢全部 agent 上下文，多 agent 协作模式根本不可用。
- agy 完成检测加固是因为本批次诊断到 OAuth 卡死场景下提问方等 15 分钟没动静，远长于人工容忍阈值，需要分层超时（120s 快失败 / 300s 正常超时 / 5min agy 慢思考）才能提供良好体验。

English:
- For all three providers (agy/chief/codex), the combination of "WSL × Windows binary × CCB sandboxed home" silently broke each native provider's restart-resume path. CCB has to compensate at the launcher layer, otherwise every `ccb kill && ccb` wipes every agent's context — making multi-agent workflows essentially unusable.
- The agy completion hardening came out of observing two real OAuth-wedge incidents where the asker waited 15 minutes for nothing. Tiered timeouts (120s fast-fail / 300s normal / 5min slow-thinking) give a more useful UX.

---

## 改了哪些文件 / Changed files (12)

| 文件 / File | 主题 / Theme | 增 / 删 |
|---|---|---|
| `lib/provider_backends/agy/launcher.py` | agy session resume (managed_home, junction, UUID scan) | +308/-1 |
| `lib/provider_backends/claude/launcher_runtime/service.py` | claude ANTHROPIC env inline-inject | +24/-4 |
| `lib/provider_backends/claude/launcher_runtime/history.py` | claude history fallback scan | +23 |
| `lib/provider_backends/claude/launcher_runtime/home.py` | claude USERPROFILE + WSLENV | +16/-1 |
| `lib/provider_backends/codex/launcher_runtime/command_runtime/home.py` | codex USERPROFILE + WSLENV | +14/-1 |
| `lib/provider_backends/codex/launcher_runtime/session_paths.py` | codex \\\\wsl.localhost\\ path support | +4 |
| `lib/ccbd/services/project_namespace_runtime/backend.py` | tmux kill_server socket cleanup | +13 |
| `lib/cli/services/tmux_ui_runtime/service.py` | tmux UI hook non-exec | +7/-5 |
| `lib/provider_backends/agy/execution_runtime/poll.py` | 120s anchor fast-fail, anchor_present diagnostic | +14 |
| `lib/provider_backends/agy/execution_runtime/start.py` | pane capture 200 → 2000 | +1/-1 |
| `lib/provider_backends/agy/protocol.py` | expose `pane_contains_req_anchor` | +7 |
| `lib/provider_backends/agy/execution.py` | restore_detail comment refresh | +6/-1 |

---

## 测试 / Testing

中文：
- 当前 branch 已 cherry-pick 到 upstream `main` 的 v7.4.2 之上，12 个文件全部通过 `python3 -m ast.parse` 语法检查。
- 实际部署到 ccbd 后用 `ccb ask coder "[链路测试] 回 pong + 当前北京时间"` 跑通 chief → coder(agy) → chief 完整回调链路，`completion_reason=pane_done_marker`, `completion_confidence=observed`, 总耗时 ~10s，正常路径零回归。
- 卡死场景的 `agy_input_unresponsive` 路径还没有主动造场景验证，只能等下次 OAuth 卡死时去 events.jsonl 看是否 120s 提前 terminal 而非 900s 兜底。
- agy 重启恢复（5 轮迭代）、chief / codex 重启恢复每一轮都有人工 ccb kill && ccb 复测通过。

English:
- This branch is cherry-picked on top of upstream `main` at v7.4.2; all 12 files pass `python3 -m ast.parse`.
- Live-validated with `ccb ask coder` after deploying to ccbd: full chief → coder(agy) → chief callback round-trips in ~10s with `completion_reason=pane_done_marker` / `confidence=observed`. No regression on the happy path.
- The `agy_input_unresponsive` fast-fail wasn't artificially triggered; will be validated post-merge by inspecting events.jsonl on the next OAuth-wedge event (expect 120s INCOMPLETE rather than 900s timeout).
- The restart-resume fixes (agy 5 rounds, chief, codex) were each manually validated with `ccb kill && ccb` cycles.

---

## 已知未解决问题 / Known unresolved

中文：
- 多 agy 同账号同 cwd 跑时，OAuth refresh token rotation + 共享 `conversations/*.db` 仍会撞 race（其中一个赢另一个被拒）。本 PR 不动这个；需要拆 `.gemini` 子目录（per-agent conversations/ 等）才能根治。
- 上一条的"多账号"备选路径技术上可行（agy 认 `HOME` 环境变量），但每个 agent 需要独立 Google 账号 + 首启浏览器 OAuth，工作量小但有用户准备成本。

English:
- Multiple agy instances on the same account + same cwd still race on OAuth refresh-token rotation and on the shared `conversations/*.db`. Out of scope for this PR — requires splitting `.gemini` into per-agent subdirs (e.g. private `conversations/`).
- A "different account per agent" workaround is technically viable (agy honors the `HOME` env var), at the cost of one Google account per agent and a browser-OAuth step on first launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
