### PR TITLE
Fix inter-agent comm reliability: silent message loss, cancellation, Windows support

### DIFF
--- a/OPTIMIZATION_PLAN.md
+++ b/OPTIMIZATION_PLAN.md
@@ -1,0 +1,238 @@
+# CCB 通讯可靠性改造 — 实施任务书
+
+> 版本: v1.0 (2026-06-13)
+> 适用代码版本: v7.4.3
+> 本文档面向执行模型: 每个任务自包含, 按顺序执行, 每个任务完成后必须跑验收命令再进入下一个。
+> **重要**: 文中 file:line 引用基于 v7.4.3 调查结果, 动手前先打开文件确认行号仍然准确; 若代码已变动, 以本文描述的"行为特征"定位代码, 不要盲改。
+
+---
+
+## 一、背景: 用户报告的三个核心症状
+
+1. **静默丢消息**: cc(Claude) 给 cx(Codex) 发消息, 发送方显示 "✅ Sent", 接收方从未收到, 双方都以为成功。间歇性发生。
+2. **平台行为不一致**: macOS 和 Windows/PC 上行为不同, Windows 上通讯机制更不可靠。
+3. **任务无法撤销**: 主控(cc) 派错任务后被真人纠正, 但 cx 手里的任务无法打断, 必须等它跑完。
+
+## 二、根因分析(已完成的调查结论)
+
+### 2.1 存在两条并行通讯路径
+
+- **路径 A (设计良好, 但未被全程使用)**: ccbd 中央守护进程
+  - `lib/ccbd/app.py` — 守护进程, Unix socket JSON-RPC
+  - `lib/ccbd/services/dispatcher.py:93-96` — JobDispatcher, 持有 JobStore + MessageBureauFacade
+  - `lib/message_bureau/facade.py:30-160` — 消息状态机 (QUEUED→DELIVERING→COMPLETED/FAILED/CANCELLED/SUPERSEDED/DEAD_LETTER)
+  - `lib/mailbox_kernel/service.py:43-220` — 收件箱内核, 有 `claim_next()/ack_reply()/abandon()/supersede()` 和投递租约 (DeliveryLease)
+  - `lib/message_bureau/control_queue_runtime/ack.py:29-64` — ACK 机制已实现
+- **路径 B (裸路径, 丢消息的来源)**: 直接 FIFO 写入
+  - `lib/provider_backends/codex/comm_runtime/communicator_io_runtime/asking.py:10-35` — `send_message()` 直接 `open(fifo, "w")` 写一行 JSON, `ask_async()` 只要不抛异常就打印 "✅ Sent" 并 return True
+  - `lib/provider_backends/codex/bridge_runtime/runtime_io.py:14-24` — 读端每个循环 **打开 FIFO→读一行→关闭**, 异常时 `except (OSError, JSONDecodeError): return None` 静默吞掉
+  - `lib/provider_backends/codex/bridge_runtime/service.py:68-75` — 读循环里 `time.sleep(idle_sleep)` 默认 50ms, **睡眠期间 FIFO 无读者**, 此时写端 open 会阻塞或报错 → 这就是间歇性丢消息的时序窗口
+
+### 2.2 最后一公里无确认
+
+- 发送方的"成功" = `open+write+flush` 没抛异常, **没有任何"对方已读取"的确认**。
+- claude 侧 tmux 路径同样: `lib/provider_backends/claude/comm_runtime/communicator_facade.py:86-90` — `send_text()` 无返回值, 函数无条件 `return True`。
+- 发送失败无重试、无退避、无超时。
+
+### 2.3 Windows 上 FIFO 根本不存在
+
+- `lib/provider_backends/codex/launcher_runtime/runtime_state.py:22-27` — `ensure_fifo()` 直接调 `os.mkfifo(path, mode)`, **无平台检查**。Windows 上 `os.mkfifo` 不存在, 抛 AttributeError, 且无 fallback。
+- WSL 检测代码存在但只用于 HOME 路径设置, 不影响 FIFO。
+
+### 2.4 取消状态传不到工作 pane
+
+- message_bureau 有 CANCELLED/SUPERSEDED 状态, mailbox_kernel 有 `abandon()/supersede()`, **但这些只改库里的状态**, 没有任何机制通知/打断正在 tmux pane 里跑的 agent。agent 不检查取消标志, 也没人给它的 pane 发中断键。
+
+### 2.5 全库 913 处 `except Exception`
+
+大量静默吞错, 通讯路径上的失败被埋掉, 用户看不到任何告警。
+
+## 三、改造原则
+
+1. **建于现有设施之上, 不新建 broker**。mailbox_kernel/message_bureau/jobs 的状态机和持久化是好的, 问题在裸路径和最后一公里。
+2. **不引入 SQLite**。现有 JSON/JSONL 原子写已够用, 引入数据库是无谓的迁移风险。
+3. **每个任务独立可验证**, 改完跑 `./ccb_test`(或 `python -m pytest test/ -x -q`)回归。
+4. **行为兼容优先**: 对外 CLI/MCP 接口不变, 只改内部可靠性。
+
+---
+
+## 四、任务清单(按顺序执行)
+
+### Phase 0 — 让失败可见(最低风险, 先做)
+
+#### 任务 0.1: 通讯路径上的静默异常全部加日志
+
+**目标**: 不改任何行为, 只把通讯链路上被吞掉的异常记录下来。
+
+**改动文件**:
+- `lib/provider_backends/codex/bridge_runtime/runtime_io.py:23` — `except (OSError, json.JSONDecodeError): return None` 改为捕获后先写日志再 return None。
+- `lib/provider_backends/codex/comm_runtime/communicator_io_runtime/asking.py:33` — `except Exception` 分支除了 print, 同时写结构化日志。
+- 搜索 `lib/provider_backends/*/comm_runtime/` 和 `lib/provider_backends/*/bridge_runtime/` 下所有 `except` 后直接 `return None`/`pass`/`continue` 的位置, 逐一加日志。
+
+**实现要求**:
+- 新建 `lib/provider_core/comm_logging.py`, 提供 `get_comm_logger(name)`, 使用标准 logging, 写入 `~/.ccb/logs/comm.log`(目录从现有配置体系取, 搜索代码中已有的日志目录约定并复用; 如果项目已有统一 logger 设施, 用现有的, 不要重复造)。
+- 日志格式必须含: 时间戳、provider、方向(send/recv)、fifo 路径或 pane id、异常类型和 message。
+- 日志写入本身的失败必须被吞掉(日志不能反过来弄崩通讯)。
+
+**验收**:
+1. `python -m pytest test/ -x -q` 全绿(或与改动前 baseline 相同的失败集)。
+2. 人为制造一次失败(把某个 session 的 input_fifo 替换为普通文件后发消息), 确认 comm.log 里出现对应记录。
+
+---
+
+#### 任务 0.2: 发送成功语义收紧 — 禁止假 "✅"
+
+**目标**: `ask_async()` 在没有读端确认前不再打印 "✅ Sent", 改为 "📤 Written (unconfirmed)"。这是诚实性修复, 为 Phase 1 的真确认做铺垫。
+
+**改动文件**:
+- `lib/provider_backends/codex/comm_runtime/communicator_io_runtime/asking.py:25-35`
+- claude 侧: `lib/provider_backends/claude/comm_runtime/communicator_facade.py:86-90` — `_send_via_terminal` 的 docstring 和调用方提示语同步修改。
+
+**验收**: 现有测试中所有断言 "✅ Sent" 字样的测试同步更新; `grep -rn "Sent to Codex" lib/ test/` 确认无遗漏。
+
+---
+
+### Phase 1 — 修复 FIFO 最后一公里(核心修复)
+
+#### 任务 1.1: 读端持久持有 FIFO, 消灭 50ms 失聪窗口
+
+**目标**: bridge 读循环不再"每读一行就关 FIFO"。
+
+**改动文件**: `lib/provider_backends/codex/bridge_runtime/runtime_io.py` 和 `service.py`
+
+**实现要求**:
+- 在 `BridgeRuntimeState` 上持有一个长期打开的 FIFO 读文件对象。
+- 正确处理 FIFO 的 EOF 语义: 当所有写端关闭后 `readline()` 返回 `''`(EOF), 此时**不要关闭重开盲等**, 用如下模式:
+  ```python
+  # 打开时同时持有一个写端, 防止 EOF 风暴:
+  # read fd 用 os.open(path, os.O_RDONLY | os.O_NONBLOCK) 打开,
+  # 再 os.open(path, os.O_WRONLY) 持有一个 dummy 写端,
+  # 之后用 selectors 监听 read fd 可读, readline 永不见 EOF。
+  ```
+- 用 `selectors.DefaultSelector` + 超时轮询替代 `time.sleep(idle_sleep)`: select 阻塞等数据, 超时则检查 `self._running`。CPU 占用更低且零失聪窗口。
+- bridge 退出时(`stop()`)关闭两个 fd, 删除行为保持与现状一致。
+- 处理一行内多条消息/半条消息: 维护一个字节缓冲, 按 `\n` 切分, 不完整的尾部留到下次。
+
+**验收**:
+1. 新增测试 `test/test_bridge_fifo_persistent_reader.py`:
+   - 启动 bridge 读循环(用现有 test/stubs 的方式), 连续高频发送 200 条消息(无间隔), 断言 200 条全部被接收、顺序正确。
+   - 这个测试在旧实现下应当能复现丢失(先在旧代码上跑一次确认它确实 fail, 再应用修复)。
+2. 现有 `test/test_ccbd_comms_recover.py` 等通讯相关测试全绿。
+
+---
+
+#### 任务 1.2: 写端加超时与重试
+
+**目标**: 发送方 open FIFO 永不无限阻塞; 瞬时失败自动重试。
+
+**改动文件**: `lib/provider_backends/codex/comm_runtime/communicator_io_runtime/asking.py`
+
+**实现要求**:
+- 用 `os.open(path, os.O_WRONLY | os.O_NONBLOCK)` 尝试打开; 若抛 `OSError(ENXIO)`(无读者), 按 0.1s/0.3s/0.9s 退避重试 3 次, 全部失败则抛 `CommDeliveryError`(新建异常类型, 放 `lib/provider_core/` 下), 上层捕获后明确报 "❌ 无法投递: 接收端未在监听"。
+- 写入用 `os.write` 一次性写完整行(FIFO 上 ≤ PIPE_BUF=512B/4KB 的写是原子的; 超长消息见下一条)。
+- **超长消息处理**: 若 JSON 超过 4096 字节, 不直接写 FIFO 正文, 改为把正文落盘到 spool 文件(`<session_dir>/spool/<marker>.json`), FIFO 里只写一行 `{"marker":..., "spool": "<path>"}` 指针。读端看到 spool 字段就去读文件。这同时解决了大消息的原子性问题。
+- 重试和最终失败都写 comm.log(用任务 0.1 的 logger)。
+
+**验收**:
+1. 新增测试: 无读者时发送 → 断言 3 次重试后抛 `CommDeliveryError`, 总耗时 < 2s。
+2. 新增测试: 8KB 大消息 → 断言走 spool 路径且读端完整收到。
+
+---
+
+#### 任务 1.3: 读取确认(真 ACK)
+
+**目标**: 发送方能确认"bridge 已读到这条消息", 才打 "✅"。
+
+**实现要求**:
+- bridge 读到一条消息并解析成功后, 立即写确认文件: `<session_dir>/acks/<marker>.ack`(内容为时间戳, 原子写: 先写 tmp 再 rename)。marker 已存在于消息体中(`asking.py:11-16` 生成)。
+- 发送方 `ask_async()` 写完 FIFO 后, 轮询 ack 文件最多 5s(0.05s 间隔, 指数放宽到 0.5s); 拿到 ack → 打 "✅ Delivered"; 超时 → 打 "⚠️ Written but unconfirmed (receiver may be busy)" 并写 comm.log, **return True 改为返回三态**: 新建 `DeliveryResult` 枚举 (DELIVERED / UNCONFIRMED / FAILED), 调用方按需处理(搜索所有 `ask_async` 调用点同步适配, 保持向后兼容可加 `bool(result)` 语义: DELIVERED/UNCONFIRMED 为真, FAILED 为假)。
+- acks 目录定期清理: bridge 每次启动时删除 24h 前的 ack 文件。
+- `ask_sync()` 复用同一机制, send 阶段确认后再进入等回复阶段; 这样能区分 "发送失败" 和 "回复超时" 两种错误, 错误信息分别明示。
+
+**验收**:
+1. 新增测试: 正常收发 → DeliveryResult.DELIVERED, ack 文件存在。
+2. 新增测试: bridge 不在跑 → FAILED(由任务 1.2 的重试失败触发)。
+3. 新增测试: bridge 暂停(收到但不处理)场景模拟 → UNCONFIRMED。
+
+---
+
+### Phase 2 — 任务取消打通到 pane(解决"派错任务无法撤回")
+
+#### 任务 2.1: 取消标志的落地与检查协议
+
+**目标**: 主控取消一个任务后, 工作 agent 能在工作间隙感知并停手。
+
+**实现要求**:
+- message_bureau 已有 CANCELLED/SUPERSEDED 状态(`lib/message_bureau/` 的 AttemptState)。新增: 当任务被标记取消时, 在目标 agent 的 session 目录写 `cancel_flags/<job_id>.cancel` 标志文件(原子写)。挂接点在 `lib/ccbd/services/dispatcher.py` 的 `cancel()` 路径(先读懂现有 cancel() 做了什么, 在状态落库之后追加写标志文件)。
+- 在发给 agent 的任务消息模板中(找到 message_bureau 组装下发 prompt 的位置), 注入一段标准指令: "开始每个子步骤前, 检查文件 <cancel_flag_path> 是否存在; 若存在, 立即停止当前任务, 回复 CANCELLED 并等待新指令。" — 这是协议层约定, 让 agent 自查。
+- 提供 CLI: `ccb cancel <job_id>`(若已有类似命令则增强之; 先 `grep -rn "def.*cancel" lib/cli/` 确认现状)。
+
+**验收**: 新增集成测试: 派一个长任务给 stub provider → 标记取消 → 断言 cancel 标志文件出现、job 状态变为 CANCELLED。
+
+#### 任务 2.2: 硬打断 — 向 pane 发送中断键
+
+**目标**: 软标志之外的强制手段, 立即打断正在生成的 agent。
+
+**实现要求**:
+- 新增 `lib/terminal_runtime/` 下的 `interrupt_pane(pane_id)`: 通过现有 tmux 封装(复用 `lib/terminal_runtime/tmux_send.py` 的 `tmux_run_fn` 模式)发送 `send-keys -t <pane> Escape`(Codex/Claude CLI 均以 Esc 打断生成; 各 provider 的打断键允许在 provider backend 里覆写, 在 provider 抽象上加 `interrupt_keys() -> list[str]`, 默认 `["Escape"]`)。
+- `ccb cancel <job_id> --force` 触发: 先写软标志, 再向该 job 绑定的 pane 发打断键, 然后通过路径 A 给该 agent 发一条高优先级消息说明任务已取消。
+- 打断后不自动派新任务, 把控制权交还主控/用户。
+
+**验收**: 集成测试(标记 `provider_blackbox`, 需要真实 tmux): 在 stub pane 里跑一个长命令 → `ccb cancel --force` → 断言命令被中断。
+
+---
+
+### Phase 3 — Windows/跨平台传输层
+
+#### 任务 3.1: 传输抽象 + Windows fallback
+
+**目标**: Windows 上通讯走文件收件箱轮询, 与 FIFO 行为对齐; macOS/Linux 保持 FIFO。
+
+**实现要求**:
+- 新建 `lib/provider_core/transport.py`, 定义 `MessageTransport` 抽象: `send_line(text) -> None`(可抛 CommDeliveryError)、`read_lines() -> Iterator[str]`、`close()`。
+- 实现 `FifoTransport`(包装 Phase 1 的成果)和 `SpoolDirTransport`(Windows): 写端把每条消息原子写入 `<session_dir>/inbox/<单调序号>-<marker>.json`(先写 `.tmp` 再 `os.replace`), 读端按文件名排序轮询消费后删除。序号用 `<session_dir>/inbox/.seq` 文件 + 文件锁递增(Windows 上用 `msvcrt.locking`, POSIX 用 `fcntl.flock`; 项目里 `lib/provider_core/runtime_lock.py` 已有跨平台锁, **先读它, 能复用就复用**)。
+- `ensure_fifo()`(`launcher_runtime/runtime_state.py:22-27`)改为: POSIX 走 mkfifo, Windows 创建 inbox 目录。选择逻辑集中在 transport 工厂函数 `create_transport(session_info)` 里, **全库只允许这一处做平台判断**。
+- ACK 机制(任务 1.3)在两种 transport 下行为一致(ack 本来就是文件, 天然跨平台)。
+
+**验收**:
+1. SpoolDirTransport 的单元测试在 macOS 上也能跑(它不依赖 Windows API, 锁用条件分支测 POSIX 路径)。
+2. 同一套收发测试参数化跑两种 transport, 断言行为一致(200 条连发不丢、大消息、ACK)。
+
+#### 任务 3.2: 平台判断收敛(顺手做)
+
+把通讯路径上散落的 `os.name == 'nt'`/WSL 检测收敛到 `lib/provider_core/platform_info.py`: `is_windows()/is_wsl()/is_macos()` 三个函数 + 模块级缓存。只改通讯链路涉及的文件(`runtime_lock.py`, `terminal_runtime/backend_env.py`, `pane_registry_runtime/common_runtime/matching.py:20`), 其他 10+ 处留待后续, 不在本期范围。
+
+**验收**: `grep -rn "os.name" lib/provider_core/ lib/terminal_runtime/` 仅剩 platform_info.py 一处。
+
+---
+
+### Phase 4 — 收口: 裸路径并入调度路径(可选, 最后做)
+
+#### 任务 4.1: ask_async/ask_sync 经由 ccbd 记录
+
+**目标**: 路径 B 的每次收发都在 message_bureau 留痕, 使所有消息可查、可重放、可取消。
+
+**实现要求**:
+- 不改变投递机制(仍走 transport), 只在发送前调 message_bureau 的 `record_submission()`、确认后调对应的状态更新(先读 `lib/ccbd/services/dispatcher_runtime/submission_recording.py` 学习现有用法)。
+- ccbd 不在跑时降级为纯 transport 模式(现在的行为), 写 comm.log 提示。
+
+**验收**: 发一条消息后, 通过现有的查询接口(找 `lib/ccbd/project_view/` 或 CLI 的消息列表命令)能看到这条记录及其 DELIVERED 状态。
+
+---
+
+## 五、执行约束(给实施模型的硬性要求)
+
+1. **顺序执行**, 每个任务一个独立 commit, commit message 用 `phaseN.M: <概要>` 格式。
+2. 动手前先跑 `python -m pytest test/ -q` 记录 baseline 失败集; 之后每个任务完成时, 失败集不得新增。
+3. 涉及 tmux 的集成测试若本机环境跑不了, 标记 skip 并在 commit message 注明, 不得删除测试。
+4. 不重命名/移动现有公共 API(被 test/ 或 mcp/ 或 bin/ 引用的符号); 新能力一律新增符号。
+5. 每个 `except Exception` 的收紧只允许发生在本文点名的文件; 其余 900+ 处不动。
+6. 禁止引入新第三方依赖(标准库 only); 禁止引入 SQLite。
+7. 遇到与本文档描述不符的代码现状(行号漂移、机制已变), 停下来在 PLAN_NOTES.md 里记录差异和你的调整决策, 再继续。
+
+## 六、不在本期范围(明确排除)
+
+- 拆分巨型模块(project_view/service.py 等) — 另立项目。
+- 轮询全面改 async/事件驱动 — Phase 1 的 selectors 已消除最痛的轮询。
+- 全库 913 处异常处理治理 — 只治通讯链路。
+- plans/、archive/ 等仓库卫生清理 — 与可靠性无关, 单独半天任务。

--- a/PLAN_NOTES.md
+++ b/PLAN_NOTES.md
@@ -25,7 +25,23 @@
    `pkill -9 -f ccbd/main.py`。
 4. 本机无 pytest,使用 `.venv-test/` 虚拟环境(未提交)。
 
+## Phase 3(已完成)
+
+- **phase3.1** (a48c74f) `lib/provider_core/transport.py`:MessageTransport 抽象,
+  FifoTransport(POSIX)/ SpoolDirTransport(Windows inbox 目录,原子改名,
+  time_ns+pid+counter 命名免锁排序)。`ensure_fifo` 在 Windows 上不再调
+  `os.mkfifo`(原本直接 AttributeError),改为创建 inbox 目录。
+  发送端与 bridge 读端均经 `create_transport`(全库唯一平台决策点)。
+  对等测试:同一套场景(200 连发、超时、丢读者)参数化跑两种 transport。
+- **phase3.2** (7f21f7b) `platform_info.py` 收敛 is_windows/is_macos/is_wsl;
+  runtime_lock、pane matching、terminal env 已切换。
+  **偏差**:backend_env.py 保留 `sys.platform` —— 其测试 monkeypatch 该接缝,
+  收敛会绕过测试桩(曾导致 2 个测试失败,已回退)。
+  **偏差**:inbox 序号未用计划中的 .seq 文件 + 文件锁,改用
+  time_ns+pid+counter 文件名,免锁且天然有序。
+- 注意:test_v2_phase2_entrypoint.py 的 gemini 重启用例在全量并发下偶发失败
+  (残留 ccbd 守护进程干扰),单独重跑稳定通过;遇到时先 pkill ccbd 再重跑该文件确认。
+
 ## 未完成(后续)
 
-- Phase 3:Windows/跨平台传输抽象(SpoolDirTransport)、平台判断收敛。
 - Phase 4(可选):裸路径收发经由 message_bureau 留痕。

--- a/PLAN_NOTES.md
+++ b/PLAN_NOTES.md
@@ -1,0 +1,31 @@
+# OPTIMIZATION_PLAN.md 执行记录
+
+执行日期: 2026-06-13 | 基线: v7.4.3, 测试基线 2570 passed / 2 skipped
+最终状态: 2586 passed / 2 skipped / 0 failed(新增 16 个测试)
+
+## 已完成
+
+- **phase0.1** (4b96d83) 通讯链路静默异常接入 `~/.ccb/logs/comm.log`(`CCB_COMM_LOG_DIR` 可覆盖)。
+- **phase0.2** (ee67ffc) codex/claude/gemini/opencode 四处假 "✅ Sent" 改为 "📤 Written, delivery unconfirmed"。
+- **phase1.1** (a72f6aa) `PersistentFifoReader`:bridge 持久持有 FIFO 读端 + dummy 写端防 EOF 风暴,selectors 超时等待替代 50ms sleep 轮询。200 条连发零丢失回归测试。
+- **phase1.2** (877268a) `write_fifo_line`:O_NONBLOCK + 0.1/0.3/0.9s 退避重试,失败抛 `CommDeliveryError`;>4KB 消息走 spool 文件 + FIFO 指针行,bridge 读后解析并删除。
+- **phase1.3** (a0732a6) ACK:bridge 读到消息立即原子写 `acks/<marker>.ack`;`ask_async` 返回三态 `DeliveryResult`(bool 兼容);`ask_sync` 区分"发送未确认"与"回复超时"。
+- **phase2.1** (c1b85f7) 取消标志:`cancel` 时写 `agents/<name>/cancel_flags/<job_id>.cancel`,下发执行的 prompt(仅内存副本)注入自查停止指令。
+
+## 与计划的偏差
+
+1. **任务 2.2(硬打断)无需实施**:调查发现 `ExecutionService.cancel()` 已经通过
+   `interrupt_and_clear_runtime_target`(`lib/provider_execution/common_runtime/terminal.py:26`)
+   向 pane 发送 C-c/Escape/C-u,`ccb cancel <job_id>` CLI 也已存在
+   (`lib/cli/services/cancel.py`)。计划中的 `--force` 子开关不需要——默认行为已含硬打断。
+2. **ask_sync/ask_async 对无 `input_fifo` 属性的 comm 对象做了防御**(测试桩
+   `_Comm` 没有该属性,曾导致 1 个测试失败,已修复:getattr 缺省跳过 ACK 等待)。
+3. **测试环境注意**:套件运行期间禁止编辑 lib/ —— 测试会启动 ccbd 子进程实时导入源码,
+   中途编辑造成过 6 个误报失败。另:套件会遗留 ccbd 守护进程,重跑前
+   `pkill -9 -f ccbd/main.py`。
+4. 本机无 pytest,使用 `.venv-test/` 虚拟环境(未提交)。
+
+## 未完成(后续)
+
+- Phase 3:Windows/跨平台传输抽象(SpoolDirTransport)、平台判断收敛。
+- Phase 4(可选):裸路径收发经由 message_bureau 留痕。

--- a/lib/ccbd/services/dispatcher_runtime/cancel_flags.py
+++ b/lib/ccbd/services/dispatcher_runtime/cancel_flags.py
@@ -1,0 +1,48 @@
+"""Filesystem cancel flags (phase 2.1).
+
+Marking a job CANCELLED in the stores does not reach an agent that is already
+mid-task in its pane. A flag file gives agents a cheap, transport-independent
+way to notice cancellation between work steps: the dispatch prompt tells them
+to check it and stop if present.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+
+def cancel_flag_path(layout, agent_name: str, job_id: str) -> Path:
+    return layout.agent_dir(agent_name) / "cancel_flags" / f"{job_id}.cancel"
+
+
+def write_cancel_flag(layout, agent_name: str, job_id: str) -> Path | None:
+    """Atomically drop the flag; best-effort, never raises."""
+    try:
+        target = cancel_flag_path(layout, agent_name, job_id)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        tmp = target.with_suffix(".cancel.tmp")
+        tmp.write_text(str(time.time()), encoding="utf-8")
+        os.replace(tmp, target)
+        return target
+    except OSError:
+        return None
+
+
+def cleanup_cancel_flags(layout, agent_name: str, *, max_age_seconds: float = 86_400.0) -> None:
+    """Drop stale flags so the directory does not grow; never raises."""
+    try:
+        flag_dir = layout.agent_dir(agent_name) / "cancel_flags"
+        cutoff = time.time() - max_age_seconds
+        for entry in flag_dir.glob("*.cancel"):
+            try:
+                if entry.stat().st_mtime < cutoff:
+                    entry.unlink()
+            except OSError:
+                continue
+    except OSError:
+        pass
+
+
+__all__ = ["cancel_flag_path", "cleanup_cancel_flags", "write_cancel_flag"]

--- a/lib/ccbd/services/dispatcher_runtime/cancellation.py
+++ b/lib/ccbd/services/dispatcher_runtime/cancellation.py
@@ -6,6 +6,7 @@ from agents.models import AgentState
 from ccbd.api_models import CancelReceipt, JobStatus, TargetKind
 from completion.models import CompletionConfidence, CompletionDecision, CompletionStatus
 
+from .cancel_flags import cleanup_cancel_flags, write_cancel_flag
 from .completion import build_terminal_state
 from .finalization_runtime.artifacts import spill_terminal_reply_if_needed
 from .reply_delivery import resolve_reply_delivery_terminal
@@ -32,6 +33,11 @@ def cancel_job(dispatcher, job_id: str, *, record_reply: bool = True) -> CancelR
     marked = replace(current, cancel_requested_at=cancelled_at, updated_at=cancelled_at)
     dispatcher._append_job(marked)
     dispatcher._append_event(marked, 'job_cancel_requested', {'status': current.status.value}, timestamp=cancelled_at)
+    if current.target_kind is TargetKind.AGENT and current.agent_name:
+        # Visible to the agent itself: the dispatch prompt instructs agents to
+        # check this flag between steps and stop if it exists.
+        write_cancel_flag(dispatcher._layout, current.agent_name, job_id)
+        cleanup_cancel_flags(dispatcher._layout, current.agent_name)
     dispatcher._state.remove_queued_for(current.target_kind, current.target_name, job_id)
     dispatcher._state.clear_active_for(current.target_kind, current.target_name, job_id=job_id)
     if dispatcher._execution_service is not None:

--- a/lib/ccbd/services/dispatcher_runtime/lifecycle_start_runtime/start.py
+++ b/lib/ccbd/services/dispatcher_runtime/lifecycle_start_runtime/start.py
@@ -53,7 +53,10 @@ def start_running_job(
         sync_runtime(dispatcher, running.agent_name, state=AgentState.BUSY)
     submission = None
     if dispatcher._execution_service is not None and should_start_execution(dispatcher, running, runtime_context):
-        submission = dispatcher._execution_service.start(running, runtime_context=runtime_context)
+        submission = dispatcher._execution_service.start(
+            with_cancel_flag_notice(dispatcher, running),
+            runtime_context=runtime_context,
+        )
     if is_reply_delivery_job(running) and dispatcher._execution_service is not None:
         return complete_reply_delivery_after_start(
             dispatcher,
@@ -62,6 +65,28 @@ def start_running_job(
             submission=submission,
         )
     return running
+
+
+def with_cancel_flag_notice(dispatcher, running: JobRecord) -> JobRecord:
+    """Append the cancel-flag protocol note to the prompt handed to execution.
+
+    Only the in-memory copy passed to the execution service is modified; the
+    stored job/message records keep the original body.
+    """
+    if running.target_kind is not TargetKind.AGENT or not running.agent_name:
+        return running
+    if is_reply_delivery_job(running):
+        return running
+    try:
+        flag_path = cancel_flag_path(dispatcher._layout, running.agent_name, running.job_id)
+    except Exception:
+        return running
+    notice = (
+        "\n\n[ccb] Before each work step, check whether the file "
+        f"`{flag_path}` exists. If it does, this task has been cancelled: "
+        "stop immediately, reply with CANCELLED, and wait for new instructions."
+    )
+    return replace(running, request=replace(running.request, body=running.request.body + notice))
 
 
 def should_start_execution(dispatcher, current: JobRecord, runtime_context) -> bool:

--- a/lib/pane_registry_runtime/common_runtime/matching.py
+++ b/lib/pane_registry_runtime/common_runtime/matching.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+from provider_core.platform_info import is_windows
+
 
 def normalize_path_for_match(value: str | Path | None) -> str:
     raw = str(value or "").strip()
@@ -17,7 +19,7 @@ def normalize_path_for_match(value: str | Path | None) -> str:
     except Exception:
         pass
     normalized = raw.replace("\\", "/").rstrip("/")
-    if os.name == "nt":
+    if is_windows():
         normalized = normalized.lower()
     return normalized
 

--- a/lib/provider_backends/claude/comm_runtime/communicator_facade.py
+++ b/lib/provider_backends/claude/comm_runtime/communicator_facade.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from provider_core.comm_logging import get_comm_logger, log_comm_event
 from provider_core.protocol import is_done_text, make_req_id, strip_done_text
 from terminal_runtime import get_backend_for_session, get_pane_id_from_session
 
@@ -20,6 +21,9 @@ from . import (
     remember_claude_session as _remember_claude_session_impl,
     remember_claude_session_binding,
 )
+
+
+_comm_logger = get_comm_logger("claude.comm")
 
 
 def _claude_log_reader_cls():
@@ -86,7 +90,18 @@ class ClaudeCommunicator:
     def _send_via_terminal(self, content: str) -> bool:
         if not self.backend or not self.pane_id:
             raise RuntimeError("Terminal session not configured")
-        self.backend.send_text(self.pane_id, content)
+        try:
+            self.backend.send_text(self.pane_id, content)
+        except Exception as exc:
+            log_comm_event(
+                _comm_logger,
+                provider="claude",
+                direction="send",
+                endpoint=str(self.pane_id),
+                event="send_via_terminal_failed",
+                error=exc,
+            )
+            raise
         return True
 
     def _remember_claude_session(self, session_path: Path) -> None:

--- a/lib/provider_backends/claude/comm_runtime/communicator_runtime/messaging.py
+++ b/lib/provider_backends/claude/comm_runtime/communicator_runtime/messaging.py
@@ -66,7 +66,7 @@ def ensure_healthy_session(comm) -> None:
 
 
 def emit_async_success() -> None:
-    print("✅ Sent to Claude")
+    print("📤 Written to Claude, delivery unconfirmed")
     print("Hint: `ccb pend <agent|job_id>` is only a supplementary observer view, not an authoritative completion path")
 
 

--- a/lib/provider_backends/codex/bridge_runtime/binding_runtime.py
+++ b/lib/provider_backends/codex/bridge_runtime/binding_runtime.py
@@ -10,8 +10,11 @@ from provider_backends.codex.comm_runtime.log_reader_facade import CodexLogReade
 from provider_backends.codex.session import CodexProjectSession
 from provider_backends.codex.session_runtime.follow_policy import should_follow_workspace_sessions
 from provider_backends.codex.session_switch import STATE_AUTO_REBINDABLE, commit_rebind, resolve_switch_decision, write_decision
+from provider_core.comm_logging import get_comm_logger, log_comm_event
 
 from .env import env_float, path_or_none, read_session_data, session_root, session_work_dir
+
+_logger = get_comm_logger('codex.bridge')
 
 
 class CodexBindingTracker:
@@ -39,8 +42,15 @@ class CodexBindingTracker:
         while self._running:
             try:
                 self.refresh_once()
-            except Exception:
-                pass
+            except Exception as exc:
+                log_comm_event(
+                    _logger,
+                    provider='codex',
+                    direction='recv',
+                    endpoint=str(self.session_file),
+                    event='binding_refresh_failed',
+                    error=exc,
+                )
             time.sleep(max(0.05, self._poll_interval))
 
     def refresh_once(self) -> bool:

--- a/lib/provider_backends/codex/bridge_runtime/runtime_io.py
+++ b/lib/provider_backends/codex/bridge_runtime/runtime_io.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from provider_core.comm_logging import get_comm_logger, log_comm_event
+from provider_core.fifo_delivery import write_ack
 from provider_core.runtime_specs import provider_marker_prefix
 
 from .runtime_state import BridgeRuntimeState
@@ -203,6 +204,9 @@ def process_request(
 ) -> None:
     content = payload.get('content', '')
     marker = payload.get('marker') or generate_marker()
+    # Confirm receipt before doing any work so the sender's ack wait is not
+    # coupled to how long the pane forward takes.
+    write_ack(state.paths.runtime_dir / 'acks', marker)
     timestamp = timestamp_now()
     log_bridge(
         state,

--- a/lib/provider_backends/codex/bridge_runtime/runtime_io.py
+++ b/lib/provider_backends/codex/bridge_runtime/runtime_io.py
@@ -6,9 +6,12 @@ import time
 from datetime import datetime, timezone
 from typing import Any
 
+from provider_core.comm_logging import get_comm_logger, log_comm_event
 from provider_core.runtime_specs import provider_marker_prefix
 
 from .runtime_state import BridgeRuntimeState
+
+_logger = get_comm_logger('codex.bridge')
 
 
 def read_request(state: BridgeRuntimeState) -> dict[str, Any] | None:
@@ -20,7 +23,15 @@ def read_request(state: BridgeRuntimeState) -> dict[str, Any] | None:
             if not line:
                 return None
             return json.loads(line)
-    except (OSError, json.JSONDecodeError):
+    except (OSError, json.JSONDecodeError) as exc:
+        log_comm_event(
+            _logger,
+            provider='codex',
+            direction='recv',
+            endpoint=str(state.paths.input_fifo),
+            event='read_request_failed',
+            error=exc,
+        )
         return None
 
 
@@ -43,6 +54,14 @@ def process_request(
         state.codex_session.send(content)
     except Exception as exc:
         message = f'Failed to send to Codex: {exc}'
+        log_comm_event(
+            _logger,
+            provider='codex',
+            direction='send',
+            endpoint='codex_session',
+            event='forward_to_pane_failed',
+            error=exc,
+        )
         append_history(state, 'codex', message, marker, log_console_fn=log_console_fn)
         log_console_fn(message)
 
@@ -73,8 +92,15 @@ def log_bridge(state: BridgeRuntimeState, message: str) -> None:
     try:
         with state.paths.bridge_log.open('a', encoding='utf-8') as handle:
             handle.write(f'{timestamp_now()} {message}\n')
-    except Exception:
-        pass
+    except Exception as exc:
+        log_comm_event(
+            _logger,
+            provider='codex',
+            direction='send',
+            endpoint=str(state.paths.bridge_log),
+            event='bridge_log_write_failed',
+            error=exc,
+        )
 
 
 def timestamp_now() -> str:

--- a/lib/provider_backends/codex/bridge_runtime/runtime_io.py
+++ b/lib/provider_backends/codex/bridge_runtime/runtime_io.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import json
 import os
+import selectors
 import time
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
 from provider_core.comm_logging import get_comm_logger, log_comm_event
@@ -14,7 +16,165 @@ from .runtime_state import BridgeRuntimeState
 _logger = get_comm_logger('codex.bridge')
 
 
-def read_request(state: BridgeRuntimeState) -> dict[str, Any] | None:
+class PersistentFifoReader:
+    """Holds the FIFO read end open for the bridge's whole lifetime.
+
+    The previous implementation opened/read/closed the FIFO on every loop
+    iteration, leaving a window with no reader during the idle sleep; writers
+    racing into that window blocked or failed, which is how messages were
+    silently lost. Holding the read end (plus a dummy write end so EOF is
+    never observed when senders disconnect) removes that window entirely.
+    """
+
+    def __init__(self, fifo_path: Path):
+        self._path = fifo_path
+        self._read_fd: int | None = None
+        self._keepalive_fd: int | None = None
+        self._selector: selectors.BaseSelector | None = None
+        self._buffer = b''
+
+    def _ensure_open(self) -> bool:
+        if self._read_fd is not None:
+            return True
+        if not self._path.exists():
+            return False
+        try:
+            read_fd = os.open(str(self._path), os.O_RDONLY | os.O_NONBLOCK)
+        except OSError as exc:
+            log_comm_event(
+                _logger,
+                provider='codex',
+                direction='recv',
+                endpoint=str(self._path),
+                event='fifo_open_read_failed',
+                error=exc,
+            )
+            return False
+        try:
+            # Safe: this process already holds a reader, so O_WRONLY cannot block.
+            keepalive_fd = os.open(str(self._path), os.O_WRONLY)
+        except OSError as exc:
+            os.close(read_fd)
+            log_comm_event(
+                _logger,
+                provider='codex',
+                direction='recv',
+                endpoint=str(self._path),
+                event='fifo_open_keepalive_failed',
+                error=exc,
+            )
+            return False
+        selector = selectors.DefaultSelector()
+        selector.register(read_fd, selectors.EVENT_READ)
+        self._read_fd = read_fd
+        self._keepalive_fd = keepalive_fd
+        self._selector = selector
+        return True
+
+    def _pop_line(self) -> str | None:
+        if b'\n' not in self._buffer:
+            return None
+        raw, self._buffer = self._buffer.split(b'\n', 1)
+        return raw.decode('utf-8', errors='replace')
+
+    def read_line(self, timeout: float) -> str | None:
+        """Wait up to `timeout` seconds for one complete line."""
+        line = self._pop_line()
+        if line is not None:
+            return line
+        if not self._ensure_open():
+            if timeout > 0:
+                time.sleep(min(timeout, 0.05))
+            return None
+        assert self._selector is not None and self._read_fd is not None
+        if not self._selector.select(timeout):
+            return None
+        try:
+            chunk = os.read(self._read_fd, 65536)
+        except BlockingIOError:
+            return None
+        except OSError as exc:
+            log_comm_event(
+                _logger,
+                provider='codex',
+                direction='recv',
+                endpoint=str(self._path),
+                event='fifo_read_failed',
+                error=exc,
+            )
+            self.close()
+            return None
+        if chunk:
+            self._buffer += chunk
+        return self._pop_line()
+
+    def close(self) -> None:
+        if self._selector is not None:
+            try:
+                self._selector.close()
+            except Exception:
+                pass
+            self._selector = None
+        for attr in ('_read_fd', '_keepalive_fd'):
+            fd = getattr(self, attr)
+            if fd is not None:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+                setattr(self, attr, None)
+
+
+def _resolve_spool(state: BridgeRuntimeState, payload: dict[str, Any]) -> dict[str, Any] | None:
+    spool_ref = payload.get('spool')
+    if not spool_ref:
+        return payload
+    spool_file = Path(spool_ref)
+    try:
+        body = json.loads(spool_file.read_text(encoding='utf-8'))
+    except (OSError, json.JSONDecodeError) as exc:
+        log_comm_event(
+            _logger,
+            provider='codex',
+            direction='recv',
+            endpoint=str(spool_file),
+            event='spool_read_failed',
+            error=exc,
+        )
+        return None
+    try:
+        spool_file.unlink()
+    except OSError:
+        pass
+    return body
+
+
+def _parse_request_line(state: BridgeRuntimeState, line: str) -> dict[str, Any] | None:
+    if not line.strip():
+        return None
+    try:
+        payload = json.loads(line)
+    except json.JSONDecodeError as exc:
+        log_comm_event(
+            _logger,
+            provider='codex',
+            direction='recv',
+            endpoint=str(state.paths.input_fifo),
+            event='request_parse_failed',
+            error=exc,
+        )
+        return None
+    return _resolve_spool(state, payload)
+
+
+def read_request(state: BridgeRuntimeState, *, timeout: float = 0.0) -> dict[str, Any] | None:
+    reader = state.fifo_reader
+    if reader is not None:
+        line = reader.read_line(timeout)
+        if line is None:
+            return None
+        return _parse_request_line(state, line)
+    # Legacy one-shot path, kept for callers that build a state without a reader.
     if not state.paths.input_fifo.exists():
         return None
     try:
@@ -22,7 +182,7 @@ def read_request(state: BridgeRuntimeState) -> dict[str, Any] | None:
             line = fifo.readline()
             if not line:
                 return None
-            return json.loads(line)
+            return _parse_request_line(state, line)
     except (OSError, json.JSONDecodeError) as exc:
         log_comm_event(
             _logger,
@@ -112,6 +272,7 @@ def generate_marker() -> str:
 
 
 __all__ = [
+    'PersistentFifoReader',
     'append_history',
     'generate_marker',
     'log_bridge',

--- a/lib/provider_backends/codex/bridge_runtime/runtime_state.py
+++ b/lib/provider_backends/codex/bridge_runtime/runtime_state.py
@@ -25,12 +25,13 @@ class BridgeRuntimeState:
     paths: BridgePaths
     binding_tracker: CodexBindingTracker
     codex_session: TerminalCodexSession
-    # PersistentFifoReader; typed loosely to avoid a runtime_io import cycle.
+    # MessageTransport (or PersistentFifoReader); anything with
+    # read_line(timeout)/close(). Typed loosely to avoid import cycles.
     fifo_reader: Any = None
 
 
 def build_bridge_runtime_state(runtime_dir: Path, *, pane_id: str) -> BridgeRuntimeState:
-    from .runtime_io import PersistentFifoReader
+    from provider_core.transport import create_transport, endpoint_for_fifo_path
 
     artifacts = ensure_runtime_artifact_layout(runtime_dir)
     paths = BridgePaths(
@@ -45,7 +46,7 @@ def build_bridge_runtime_state(runtime_dir: Path, *, pane_id: str) -> BridgeRunt
         paths=paths,
         binding_tracker=CodexBindingTracker(runtime_dir),
         codex_session=TerminalCodexSession(pane_id),
-        fifo_reader=PersistentFifoReader(paths.input_fifo),
+        fifo_reader=create_transport(endpoint_for_fifo_path(paths.input_fifo)),
     )
 
 

--- a/lib/provider_backends/codex/bridge_runtime/runtime_state.py
+++ b/lib/provider_backends/codex/bridge_runtime/runtime_state.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from provider_backends.codex.runtime_artifacts import ensure_runtime_artifact_layout
 
@@ -24,9 +25,13 @@ class BridgeRuntimeState:
     paths: BridgePaths
     binding_tracker: CodexBindingTracker
     codex_session: TerminalCodexSession
+    # PersistentFifoReader; typed loosely to avoid a runtime_io import cycle.
+    fifo_reader: Any = None
 
 
 def build_bridge_runtime_state(runtime_dir: Path, *, pane_id: str) -> BridgeRuntimeState:
+    from .runtime_io import PersistentFifoReader
+
     artifacts = ensure_runtime_artifact_layout(runtime_dir)
     paths = BridgePaths(
         runtime_dir=artifacts.runtime_dir,
@@ -40,6 +45,7 @@ def build_bridge_runtime_state(runtime_dir: Path, *, pane_id: str) -> BridgeRunt
         paths=paths,
         binding_tracker=CodexBindingTracker(runtime_dir),
         codex_session=TerminalCodexSession(pane_id),
+        fifo_reader=PersistentFifoReader(paths.input_fifo),
     )
 
 

--- a/lib/provider_backends/codex/bridge_runtime/service.py
+++ b/lib/provider_backends/codex/bridge_runtime/service.py
@@ -6,6 +6,8 @@ import time
 from pathlib import Path
 from typing import Any
 
+from provider_core.fifo_delivery import cleanup_acks
+
 from .env import env_float
 from .runtime_io import process_request, read_request
 from .runtime_state import build_bridge_runtime_state
@@ -59,6 +61,7 @@ class DualBridge:
 
     def run(self) -> int:
         self._log_console('Codex bridge started, waiting for Claude commands...')
+        cleanup_acks(self._runtime.paths.runtime_dir / 'acks')
         self.binding_tracker.start()
         idle_sleep = env_float('CCB_BRIDGE_IDLE_SLEEP', 0.05)
         error_backoff_min = env_float('CCB_BRIDGE_ERROR_BACKOFF_MIN', 0.05)

--- a/lib/provider_backends/codex/bridge_runtime/service.py
+++ b/lib/provider_backends/codex/bridge_runtime/service.py
@@ -64,13 +64,12 @@ class DualBridge:
         error_backoff_min = env_float('CCB_BRIDGE_ERROR_BACKOFF_MIN', 0.05)
         error_backoff_max = env_float('CCB_BRIDGE_ERROR_BACKOFF_MAX', 0.2)
         error_backoff = max(0.0, min(error_backoff_min, error_backoff_max))
+        poll_timeout = idle_sleep if idle_sleep else 0.05
         try:
             while self._running:
                 try:
-                    payload = self._read_request()
+                    payload = self._read_request(timeout=poll_timeout)
                     if payload is None:
-                        if idle_sleep:
-                            time.sleep(idle_sleep)
                         continue
                     self._process_request(payload)
                     error_backoff = max(0.0, min(error_backoff_min, error_backoff_max))
@@ -85,12 +84,14 @@ class DualBridge:
                         error_backoff = min(error_backoff_max, max(error_backoff_min, error_backoff * 2))
         finally:
             self.binding_tracker.stop()
+            if self._runtime.fifo_reader is not None:
+                self._runtime.fifo_reader.close()
 
         self._log_console('Codex bridge exited')
         return 0
 
-    def _read_request(self):
-        return read_request(self._runtime)
+    def _read_request(self, *, timeout: float = 0.0):
+        return read_request(self._runtime, timeout=timeout)
 
     def _process_request(self, payload) -> None:
         process_request(self._runtime, payload, log_console_fn=self._log_console)

--- a/lib/provider_backends/codex/comm_runtime/communicator_facade.py
+++ b/lib/provider_backends/codex/comm_runtime/communicator_facade.py
@@ -5,6 +5,7 @@ import time
 from pathlib import Path
 from typing import Any
 
+from provider_core.fifo_delivery import DeliveryResult
 from runtime_env import env_float
 from terminal_runtime import get_backend_for_session, get_pane_id_from_session
 
@@ -102,7 +103,8 @@ class CodexCommunicator:
     def _generate_marker(self) -> str:
         return f"{self.marker_prefix}-{int(time.time())}-{os.getpid()}"
 
-    def ask_async(self, question: str) -> bool:
+    def ask_async(self, question: str) -> "DeliveryResult":
+        # DeliveryResult is bool-compatible: FAILED is falsy, others truthy.
         return _ask_async_impl(self, question)
 
     def ask_sync(self, question: str, timeout: int | None = None) -> str | None:

--- a/lib/provider_backends/codex/comm_runtime/communicator_io_runtime/asking.py
+++ b/lib/provider_backends/codex/comm_runtime/communicator_io_runtime/asking.py
@@ -7,7 +7,13 @@ from typing import Any
 from pathlib import Path
 
 from provider_core.comm_logging import get_comm_logger, log_comm_event
-from provider_core.fifo_delivery import PIPE_ATOMIC_LIMIT, spool_payload, write_fifo_line
+from provider_core.fifo_delivery import (
+    PIPE_ATOMIC_LIMIT,
+    DeliveryResult,
+    spool_payload,
+    wait_for_ack,
+    write_fifo_line,
+)
 
 from .common import ensure_session_health, remember_log_hint
 
@@ -34,14 +40,11 @@ def send_message(comm, content: str) -> tuple[str, dict[str, Any]]:
     return marker, state
 
 
-def ask_async(comm, question: str) -> bool:
+def ask_async(comm, question: str) -> DeliveryResult:
     try:
         ensure_session_health(comm)
         marker, state = comm._send_message(question)
         remember_log_hint(comm, state)
-        print(f"📤 Written to Codex, delivery unconfirmed (marker: {marker[:12]}...)")
-        print("Hint: `ccb pend <agent|job_id>` is only a supplementary observer view, not an authoritative completion path")
-        return True
     except Exception as exc:
         log_comm_event(
             _logger,
@@ -52,7 +55,28 @@ def ask_async(comm, question: str) -> bool:
             error=exc,
         )
         print(f"❌ Send failed: {exc}")
-        return False
+        return DeliveryResult.FAILED
+
+    input_fifo = getattr(comm, "input_fifo", None)
+    if not input_fifo:
+        print(f"📤 Written to Codex, delivery unconfirmed (marker: {marker[:12]}...)")
+        return DeliveryResult.UNCONFIRMED
+    ack_dir = Path(input_fifo).parent / "acks"
+    if wait_for_ack(ack_dir, marker):
+        print(f"✅ Delivered to Codex (marker: {marker[:12]}...)")
+        result = DeliveryResult.DELIVERED
+    else:
+        log_comm_event(
+            _logger,
+            provider='codex',
+            direction='send',
+            endpoint=str(comm.input_fifo),
+            event='ack_timeout',
+        )
+        print(f"⚠️ Written but unconfirmed — receiver may be busy (marker: {marker[:12]}...)")
+        result = DeliveryResult.UNCONFIRMED
+    print("Hint: `ccb pend <agent|job_id>` is only a supplementary observer view, not an authoritative completion path")
+    return result
 
 
 __all__ = ["ask_async", "send_message"]

--- a/lib/provider_backends/codex/comm_runtime/communicator_io_runtime/asking.py
+++ b/lib/provider_backends/codex/comm_runtime/communicator_io_runtime/asking.py
@@ -31,7 +31,7 @@ def ask_async(comm, question: str) -> bool:
         ensure_session_health(comm)
         marker, state = comm._send_message(question)
         remember_log_hint(comm, state)
-        print(f"✅ Sent to Codex (marker: {marker[:12]}...)")
+        print(f"📤 Written to Codex, delivery unconfirmed (marker: {marker[:12]}...)")
         print("Hint: `ccb pend <agent|job_id>` is only a supplementary observer view, not an authoritative completion path")
         return True
     except Exception as exc:

--- a/lib/provider_backends/codex/comm_runtime/communicator_io_runtime/asking.py
+++ b/lib/provider_backends/codex/comm_runtime/communicator_io_runtime/asking.py
@@ -12,8 +12,8 @@ from provider_core.fifo_delivery import (
     DeliveryResult,
     spool_payload,
     wait_for_ack,
-    write_fifo_line,
 )
+from provider_core.transport import create_transport, endpoint_for_fifo_path
 
 from .common import ensure_session_health, remember_log_hint
 
@@ -36,7 +36,7 @@ def send_message(comm, content: str) -> tuple[str, dict[str, Any]]:
         # body in a spool file and send a small pointer line instead.
         spool_file = spool_payload(fifo_path.parent / "spool", marker, line)
         line = json.dumps({"marker": marker, "spool": str(spool_file)}, ensure_ascii=False)
-    write_fifo_line(fifo_path, line)
+    create_transport(endpoint_for_fifo_path(fifo_path)).send_line(line)
     return marker, state
 
 

--- a/lib/provider_backends/codex/comm_runtime/communicator_io_runtime/asking.py
+++ b/lib/provider_backends/codex/comm_runtime/communicator_io_runtime/asking.py
@@ -4,7 +4,10 @@ import json
 from datetime import datetime
 from typing import Any
 
+from pathlib import Path
+
 from provider_core.comm_logging import get_comm_logger, log_comm_event
+from provider_core.fifo_delivery import PIPE_ATOMIC_LIMIT, spool_payload, write_fifo_line
 
 from .common import ensure_session_health, remember_log_hint
 
@@ -20,9 +23,14 @@ def send_message(comm, content: str) -> tuple[str, dict[str, Any]]:
     }
 
     state = comm.log_reader.capture_state()
-    with open(comm.input_fifo, "w", encoding="utf-8") as fifo:
-        fifo.write(json.dumps(message, ensure_ascii=False) + "\n")
-        fifo.flush()
+    fifo_path = Path(comm.input_fifo)
+    line = json.dumps(message, ensure_ascii=False)
+    if len(line.encode("utf-8")) + 1 > PIPE_ATOMIC_LIMIT:
+        # Oversized payloads can't be written atomically to a FIFO; park the
+        # body in a spool file and send a small pointer line instead.
+        spool_file = spool_payload(fifo_path.parent / "spool", marker, line)
+        line = json.dumps({"marker": marker, "spool": str(spool_file)}, ensure_ascii=False)
+    write_fifo_line(fifo_path, line)
     return marker, state
 
 

--- a/lib/provider_backends/codex/comm_runtime/communicator_io_runtime/asking.py
+++ b/lib/provider_backends/codex/comm_runtime/communicator_io_runtime/asking.py
@@ -4,7 +4,11 @@ import json
 from datetime import datetime
 from typing import Any
 
+from provider_core.comm_logging import get_comm_logger, log_comm_event
+
 from .common import ensure_session_health, remember_log_hint
+
+_logger = get_comm_logger('codex.comm')
 
 
 def send_message(comm, content: str) -> tuple[str, dict[str, Any]]:
@@ -31,6 +35,14 @@ def ask_async(comm, question: str) -> bool:
         print("Hint: `ccb pend <agent|job_id>` is only a supplementary observer view, not an authoritative completion path")
         return True
     except Exception as exc:
+        log_comm_event(
+            _logger,
+            provider='codex',
+            direction='send',
+            endpoint=str(getattr(comm, 'input_fifo', '?')),
+            event='ask_async_failed',
+            error=exc,
+        )
         print(f"❌ Send failed: {exc}")
         return False
 

--- a/lib/provider_backends/codex/comm_runtime/communicator_io_runtime/waiting.py
+++ b/lib/provider_backends/codex/comm_runtime/communicator_io_runtime/waiting.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import time
+from pathlib import Path
 
 from provider_core.comm_logging import get_comm_logger, log_comm_event
+from provider_core.fifo_delivery import wait_for_ack
 from ui_text import t
 
 from .common import ensure_session_health, remember_log_hint
@@ -14,7 +16,21 @@ def ask_sync(comm, question: str, timeout: int | None = None) -> str | None:
     try:
         ensure_session_health(comm)
         print(f"🔔 {t('sending_to', provider='Codex')}", flush=True)
-        _, state = comm._send_message(question)
+        marker, state = comm._send_message(question)
+        input_fifo = getattr(comm, 'input_fifo', None)
+        if input_fifo:
+            ack_dir = Path(input_fifo).parent / "acks"
+            if wait_for_ack(ack_dir, marker):
+                print("✅ Delivery confirmed by bridge", flush=True)
+            else:
+                log_comm_event(
+                    _logger,
+                    provider='codex',
+                    direction='send',
+                    endpoint=str(input_fifo),
+                    event='ack_timeout_sync',
+                )
+                print("⚠️ Delivery unconfirmed — still waiting for a reply, but the bridge may not have received the question", flush=True)
 
         wait_timeout = comm.timeout if timeout is None else int(timeout)
         if wait_timeout == 0:

--- a/lib/provider_backends/codex/comm_runtime/communicator_io_runtime/waiting.py
+++ b/lib/provider_backends/codex/comm_runtime/communicator_io_runtime/waiting.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import time
 
+from provider_core.comm_logging import get_comm_logger, log_comm_event
 from ui_text import t
 
 from .common import ensure_session_health, remember_log_hint
+
+_logger = get_comm_logger('codex.comm')
 
 
 def ask_sync(comm, question: str, timeout: int | None = None) -> str | None:
@@ -21,6 +24,14 @@ def ask_sync(comm, question: str, timeout: int | None = None) -> str | None:
         print(f"⏳ Waiting for Codex reply (timeout {wait_timeout}s)...")
         return _wait_once(comm, state, float(wait_timeout))
     except Exception as exc:
+        log_comm_event(
+            _logger,
+            provider='codex',
+            direction='send',
+            endpoint=str(getattr(comm, 'input_fifo', '?')),
+            event='ask_sync_failed',
+            error=exc,
+        )
         print(f"❌ Sync ask failed: {exc}")
         return None
 

--- a/lib/provider_backends/codex/launcher_runtime/runtime_state.py
+++ b/lib/provider_backends/codex/launcher_runtime/runtime_state.py
@@ -20,6 +20,12 @@ def prepare_runtime(runtime_dir: Path) -> dict[str, object]:
 
 
 def ensure_fifo(path: Path, mode: int) -> None:
+    if not hasattr(os, 'mkfifo'):
+        # Windows has no FIFOs; the transport layer falls back to an inbox
+        # directory next to the would-be FIFO (provider_core.transport.
+        # SpoolDirTransport), so nothing must exist at the FIFO path itself.
+        path.parent.joinpath('inbox').mkdir(parents=True, exist_ok=True)
+        return
     if path.exists():
         if stat.S_ISFIFO(path.stat().st_mode):
             return

--- a/lib/provider_backends/gemini/comm_runtime/communicator_runtime/asking_runtime/asking.py
+++ b/lib/provider_backends/gemini/comm_runtime/communicator_runtime/asking_runtime/asking.py
@@ -16,7 +16,7 @@ def ask_async(comm, question: str) -> bool:
     try:
         ensure_session_health(comm)
         comm._send_via_terminal(question)
-        print("✅ Sent to Gemini")
+        print("📤 Written to Gemini, delivery unconfirmed")
         print("Hint: `ccb pend <agent|job_id>` is only a supplementary observer view, not an authoritative completion path")
         return True
     except Exception as exc:

--- a/lib/provider_backends/opencode/runtime/communicator.py
+++ b/lib/provider_backends/opencode/runtime/communicator.py
@@ -123,7 +123,7 @@ def ask_async(comm, question: str) -> bool:
     try:
         _ensure_session_health(comm, probe_terminal=False)
         comm._send_via_terminal(question)
-        print("✅ Sent to OpenCode")
+        print("📤 Written to OpenCode, delivery unconfirmed")
         print("Hint: `ccb pend <agent|job_id>` is only a supplementary observer view, not an authoritative completion path")
         return True
     except Exception as exc:

--- a/lib/provider_core/comm_logging.py
+++ b/lib/provider_core/comm_logging.py
@@ -1,0 +1,72 @@
+"""Structured logging for the inter-agent communication path.
+
+Failures on the comm path (FIFO reads/writes, pane sends) were historically
+swallowed; this logger makes them observable without changing behavior.
+Logging itself must never break communication, so every operation here is
+best-effort.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+_LOG_ENV_DIR = "CCB_COMM_LOG_DIR"
+_DEFAULT_DIR = Path.home() / ".ccb" / "logs"
+_FORMAT = "%(asctime)s %(name)s %(levelname)s %(message)s"
+
+_configured: dict[str, logging.Logger] = {}
+
+
+def _log_dir() -> Path:
+    override = os.environ.get(_LOG_ENV_DIR)
+    return Path(override) if override else _DEFAULT_DIR
+
+
+def get_comm_logger(name: str) -> logging.Logger:
+    """Return a logger writing to <log_dir>/comm.log; never raises."""
+    full_name = f"ccb.comm.{name}"
+    cached = _configured.get(full_name)
+    if cached is not None:
+        return cached
+    logger = logging.getLogger(full_name)
+    logger.propagate = False
+    logger.setLevel(logging.INFO)
+    if not logger.handlers:
+        try:
+            log_dir = _log_dir()
+            log_dir.mkdir(parents=True, exist_ok=True)
+            handler = RotatingFileHandler(
+                log_dir / "comm.log", maxBytes=2_000_000, backupCount=2, encoding="utf-8"
+            )
+            handler.setFormatter(logging.Formatter(_FORMAT))
+            logger.addHandler(handler)
+        except Exception:
+            logger.addHandler(logging.NullHandler())
+    _configured[full_name] = logger
+    return logger
+
+
+def log_comm_event(
+    logger: logging.Logger,
+    *,
+    provider: str,
+    direction: str,
+    endpoint: str,
+    event: str,
+    error: BaseException | None = None,
+) -> None:
+    """Record one comm-path event; swallows its own failures."""
+    try:
+        detail = f"provider={provider} direction={direction} endpoint={endpoint} event={event}"
+        if error is not None:
+            logger.warning("%s error_type=%s error=%s", detail, type(error).__name__, error)
+        else:
+            logger.info(detail)
+    except Exception:
+        pass
+
+
+__all__ = ["get_comm_logger", "log_comm_event"]

--- a/lib/provider_core/fifo_delivery.py
+++ b/lib/provider_core/fifo_delivery.py
@@ -9,10 +9,22 @@ raises ``CommDeliveryError`` instead of failing silently.
 
 from __future__ import annotations
 
+import enum
 import errno
 import os
 import time
 from pathlib import Path
+
+
+class DeliveryResult(enum.Enum):
+    """Outcome of a send; truthy unless the write itself failed."""
+
+    DELIVERED = "delivered"      # receiver confirmed reading the message
+    UNCONFIRMED = "unconfirmed"  # written, but no read confirmation in time
+    FAILED = "failed"            # could not be written at all
+
+    def __bool__(self) -> bool:
+        return self is not DeliveryResult.FAILED
 
 # Writes up to PIPE_BUF bytes are atomic on a FIFO; POSIX guarantees >= 512,
 # Linux/macOS use 4096+. Lines longer than this must go through a spool file.
@@ -77,6 +89,55 @@ def write_fifo_line(
     ) from last_error
 
 
+def ack_file_path(ack_dir: Path, marker: str) -> Path:
+    return ack_dir / f"{marker}.ack"
+
+
+def write_ack(ack_dir: Path, marker: str) -> None:
+    """Atomically record that a message was read; best-effort, never raises."""
+    try:
+        ack_dir.mkdir(parents=True, exist_ok=True)
+        target = ack_file_path(ack_dir, marker)
+        tmp = target.with_suffix(".ack.tmp")
+        tmp.write_text(str(time.time()), encoding="utf-8")
+        os.replace(tmp, target)
+    except OSError:
+        pass
+
+
+def wait_for_ack(ack_dir: Path, marker: str, *, timeout: float = 5.0) -> bool:
+    """Poll for the receiver's read confirmation; True if it appears in time."""
+    target = ack_file_path(ack_dir, marker)
+    deadline = time.monotonic() + timeout
+    interval = 0.05
+    while True:
+        if target.exists():
+            try:
+                target.unlink()
+            except OSError:
+                pass
+            return True
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return False
+        time.sleep(min(interval, remaining))
+        interval = min(interval * 1.5, 0.5)
+
+
+def cleanup_acks(ack_dir: Path, *, max_age_seconds: float = 86_400.0) -> None:
+    """Drop stale ack files; best-effort, never raises."""
+    try:
+        cutoff = time.time() - max_age_seconds
+        for entry in ack_dir.glob("*.ack"):
+            try:
+                if entry.stat().st_mtime < cutoff:
+                    entry.unlink()
+            except OSError:
+                continue
+    except OSError:
+        pass
+
+
 def spool_payload(spool_dir: Path, marker: str, payload_json: str) -> Path:
     """Atomically persist an oversized payload; returns the spool file path."""
     spool_dir.mkdir(parents=True, exist_ok=True)
@@ -87,4 +148,14 @@ def spool_payload(spool_dir: Path, marker: str, payload_json: str) -> Path:
     return target
 
 
-__all__ = ["CommDeliveryError", "PIPE_ATOMIC_LIMIT", "spool_payload", "write_fifo_line"]
+__all__ = [
+    "CommDeliveryError",
+    "DeliveryResult",
+    "PIPE_ATOMIC_LIMIT",
+    "ack_file_path",
+    "cleanup_acks",
+    "spool_payload",
+    "wait_for_ack",
+    "write_ack",
+    "write_fifo_line",
+]

--- a/lib/provider_core/fifo_delivery.py
+++ b/lib/provider_core/fifo_delivery.py
@@ -1,0 +1,90 @@
+"""Reliable single-line writes to a FIFO (phase 1.2).
+
+The previous sender used a blocking ``open(fifo, "w")`` with no timeout: it
+could hang forever when no reader was listening, and a transient absence of
+the reader lost the message outright. This module opens the FIFO
+non-blocking, retries with backoff while the reader is briefly away, and
+raises ``CommDeliveryError`` instead of failing silently.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+import time
+from pathlib import Path
+
+# Writes up to PIPE_BUF bytes are atomic on a FIFO; POSIX guarantees >= 512,
+# Linux/macOS use 4096+. Lines longer than this must go through a spool file.
+PIPE_ATOMIC_LIMIT = 4096
+
+_RETRY_BACKOFFS = (0.1, 0.3, 0.9)
+
+
+class CommDeliveryError(RuntimeError):
+    """The message could not be handed to the receiving end."""
+
+
+def write_fifo_line(
+    fifo_path: Path,
+    line: str,
+    *,
+    backoffs: tuple[float, ...] = _RETRY_BACKOFFS,
+) -> None:
+    """Write one newline-terminated line to the FIFO, or raise CommDeliveryError.
+
+    Retries while the FIFO has no reader (ENXIO); never blocks indefinitely.
+    """
+    data = line.encode("utf-8")
+    if not data.endswith(b"\n"):
+        data += b"\n"
+    if len(data) > PIPE_ATOMIC_LIMIT:
+        raise CommDeliveryError(
+            f"line of {len(data)} bytes exceeds atomic FIFO write limit "
+            f"({PIPE_ATOMIC_LIMIT}); spool the payload and send a pointer instead"
+        )
+
+    last_error: OSError | None = None
+    attempts = len(backoffs) + 1
+    for attempt in range(attempts):
+        try:
+            fd = os.open(str(fifo_path), os.O_WRONLY | os.O_NONBLOCK)
+        except OSError as exc:
+            if exc.errno == errno.ENXIO:  # no reader currently listening
+                last_error = exc
+                if attempt < len(backoffs):
+                    time.sleep(backoffs[attempt])
+                continue
+            raise CommDeliveryError(f"cannot open {fifo_path}: {exc}") from exc
+        try:
+            written = os.write(fd, data)
+            if written != len(data):
+                raise CommDeliveryError(
+                    f"partial FIFO write to {fifo_path}: {written}/{len(data)} bytes"
+                )
+            return
+        except BlockingIOError as exc:
+            last_error = exc
+            if attempt < len(backoffs):
+                time.sleep(backoffs[attempt])
+            continue
+        except OSError as exc:
+            raise CommDeliveryError(f"write to {fifo_path} failed: {exc}") from exc
+        finally:
+            os.close(fd)
+    raise CommDeliveryError(
+        f"receiver not listening on {fifo_path} after {attempts} attempts"
+    ) from last_error
+
+
+def spool_payload(spool_dir: Path, marker: str, payload_json: str) -> Path:
+    """Atomically persist an oversized payload; returns the spool file path."""
+    spool_dir.mkdir(parents=True, exist_ok=True)
+    target = spool_dir / f"{marker}.json"
+    tmp = spool_dir / f"{marker}.json.tmp"
+    tmp.write_text(payload_json, encoding="utf-8")
+    os.replace(tmp, target)
+    return target
+
+
+__all__ = ["CommDeliveryError", "PIPE_ATOMIC_LIMIT", "spool_payload", "write_fifo_line"]

--- a/lib/provider_core/platform_info.py
+++ b/lib/provider_core/platform_info.py
@@ -1,0 +1,29 @@
+"""Single home for platform predicates used on the comm path (phase 3.2)."""
+
+from __future__ import annotations
+
+import functools
+import os
+import sys
+
+
+def is_windows() -> bool:
+    return os.name == "nt"
+
+
+def is_macos() -> bool:
+    return sys.platform == "darwin"
+
+
+@functools.cache
+def is_wsl() -> bool:
+    if "WSL_DISTRO_NAME" in os.environ:
+        return True
+    try:
+        with open("/proc/version", encoding="utf-8") as handle:
+            return "microsoft" in handle.read().lower()
+    except OSError:
+        return False
+
+
+__all__ = ["is_macos", "is_windows", "is_wsl"]

--- a/lib/provider_core/runtime_lock.py
+++ b/lib/provider_core/runtime_lock.py
@@ -10,11 +10,13 @@ import tempfile
 from pathlib import Path
 from typing import Optional
 
+from .platform_info import is_windows
+
 from project.runtime_paths import project_anchor_exists, project_lock_dir
 
 
 def _is_pid_alive(pid: int) -> bool:
-    if os.name == "nt":
+    if is_windows():
         try:
             import ctypes
 
@@ -50,7 +52,7 @@ class ProviderLock:
 
     def _try_acquire_once(self) -> bool:
         try:
-            if os.name == "nt":
+            if is_windows():
                 import msvcrt
 
                 try:
@@ -69,7 +71,7 @@ class ProviderLock:
             pid_bytes = f"{os.getpid()}\n".encode()
             os.lseek(self._fd, 0, os.SEEK_SET)
             os.write(self._fd, pid_bytes)
-            if os.name == "nt":
+            if is_windows():
                 try:
                     os.ftruncate(self._fd, max(1, len(pid_bytes)))
                 except Exception:
@@ -144,7 +146,7 @@ class ProviderLock:
         if self._fd is not None:
             try:
                 if self._acquired:
-                    if os.name == "nt":
+                    if is_windows():
                         import msvcrt
 
                         try:

--- a/lib/provider_core/transport.py
+++ b/lib/provider_core/transport.py
@@ -1,0 +1,137 @@
+"""Cross-platform message transport (phase 3.1).
+
+POSIX systems use a FIFO (FifoTransport). Windows has no os.mkfifo, so it
+uses an inbox directory of atomically-renamed one-message files consumed in
+filename order (SpoolDirTransport). ``create_transport`` is the single place
+in the codebase allowed to make that platform decision.
+
+Both transports share the same contract:
+- ``send_line`` delivers one JSON line or raises CommDeliveryError
+- ``read_line`` waits up to a timeout for the next line, returning None on idle
+"""
+
+from __future__ import annotations
+
+import itertools
+import os
+import time
+from pathlib import Path
+
+from .fifo_delivery import CommDeliveryError, write_fifo_line
+
+
+class MessageTransport:
+    """One-directional line transport between a sender and a single reader."""
+
+    def send_line(self, line: str) -> None:
+        raise NotImplementedError
+
+    def read_line(self, timeout: float) -> str | None:
+        raise NotImplementedError
+
+    def close(self) -> None:  # reader-side resources only
+        pass
+
+
+class FifoTransport(MessageTransport):
+    """POSIX named-pipe transport; reader holds the FIFO open persistently."""
+
+    def __init__(self, fifo_path: Path):
+        self._path = Path(fifo_path)
+        self._reader = None  # lazy: only the receiving process needs it
+
+    def send_line(self, line: str) -> None:
+        write_fifo_line(self._path, line)
+
+    def read_line(self, timeout: float) -> str | None:
+        if self._reader is None:
+            from provider_backends.codex.bridge_runtime.runtime_io import PersistentFifoReader
+
+            self._reader = PersistentFifoReader(self._path)
+        return self._reader.read_line(timeout)
+
+    def close(self) -> None:
+        if self._reader is not None:
+            self._reader.close()
+            self._reader = None
+
+
+_msg_counter = itertools.count()
+
+
+class SpoolDirTransport(MessageTransport):
+    """Inbox-directory transport for platforms without FIFOs.
+
+    Each message is one file, written to a .tmp name and atomically renamed
+    into the inbox. Names sort by (monotonic-ish wall clock ns, pid, counter),
+    so concurrent writers never collide and the reader consumes in order.
+    """
+
+    def __init__(self, inbox_dir: Path):
+        self._inbox = Path(inbox_dir)
+
+    def send_line(self, line: str) -> None:
+        name = f"{time.time_ns():020d}-{os.getpid()}-{next(_msg_counter):06d}.msg"
+        try:
+            self._inbox.mkdir(parents=True, exist_ok=True)
+            tmp = self._inbox / (name + ".tmp")
+            tmp.write_text(line, encoding="utf-8")
+            os.replace(tmp, self._inbox / name)
+        except OSError as exc:
+            raise CommDeliveryError(f"cannot write to inbox {self._inbox}: {exc}") from exc
+
+    def read_line(self, timeout: float) -> str | None:
+        deadline = time.monotonic() + timeout
+        while True:
+            entry = self._next_entry()
+            if entry is not None:
+                try:
+                    line = entry.read_text(encoding="utf-8")
+                except OSError:
+                    line = None
+                try:
+                    entry.unlink()
+                except OSError:
+                    pass
+                if line is not None:
+                    return line
+                continue
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return None
+            time.sleep(min(0.05, remaining))
+
+    def _next_entry(self) -> Path | None:
+        try:
+            names = sorted(p for p in self._inbox.iterdir() if p.name.endswith(".msg"))
+        except OSError:
+            return None
+        return names[0] if names else None
+
+
+def endpoint_for_fifo_path(fifo_path: Path) -> Path:
+    """Map a configured FIFO path to this platform's actual endpoint.
+
+    POSIX: the FIFO itself. Windows: an ``inbox`` directory next to it.
+    """
+    fifo_path = Path(fifo_path)
+    if hasattr(os, "mkfifo"):
+        return fifo_path
+    return fifo_path.parent / "inbox"
+
+
+def create_transport(endpoint: Path) -> MessageTransport:
+    """Sole platform-decision point: FIFO on POSIX, inbox dir on Windows."""
+    endpoint = Path(endpoint)
+    if hasattr(os, "mkfifo") and not endpoint.is_dir():
+        return FifoTransport(endpoint)
+    return SpoolDirTransport(endpoint)
+
+
+__all__ = [
+    "FifoTransport",
+    "MessageTransport",
+    "SpoolDirTransport",
+    "create_transport",
+    "endpoint_for_fifo_path",
+]

--- a/lib/terminal_runtime/env.py
+++ b/lib/terminal_runtime/env.py
@@ -7,6 +7,8 @@ import subprocess
 from pathlib import Path
 import re
 
+from provider_core.platform_info import is_windows as _platform_is_windows
+
 
 def env_float(name: str, default: float) -> float:
     raw = os.environ.get(name)
@@ -37,11 +39,11 @@ def sanitize_filename(value: str) -> str:
 
 
 def is_windows() -> bool:
-    return platform.system() == "Windows"
+    return _platform_is_windows()
 
 
 def subprocess_kwargs() -> dict:
-    if os.name == "nt":
+    if is_windows():
         flags = getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000)
         return {"creationflags": flags}
     return {}

--- a/test/test_bridge_fifo_persistent_reader.py
+++ b/test/test_bridge_fifo_persistent_reader.py
@@ -1,0 +1,119 @@
+"""Regression tests for the persistent FIFO reader (phase 1.1).
+
+The old bridge loop opened/read/closed the FIFO each iteration and slept
+between reads, leaving windows with no reader where sender writes blocked or
+failed silently. These tests assert the new reader never drops messages under
+rapid sequential sends.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+
+import pytest
+
+from provider_backends.codex.bridge_runtime.runtime_io import PersistentFifoReader
+
+pytestmark = pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="requires POSIX FIFOs")
+
+
+@pytest.fixture()
+def fifo_path(tmp_path):
+    path = tmp_path / "input.fifo"
+    os.mkfifo(path, 0o600)
+    return path
+
+
+def _drain(reader: PersistentFifoReader, count: int, timeout_per_line: float = 2.0) -> list[str]:
+    lines: list[str] = []
+    misses = 0
+    while len(lines) < count and misses < 50:
+        line = reader.read_line(timeout_per_line)
+        if line is None:
+            misses += 1
+            continue
+        misses = 0
+        lines.append(line)
+    return lines
+
+
+def test_rapid_sequential_sends_are_all_received_in_order(fifo_path):
+    reader = PersistentFifoReader(fifo_path)
+    total = 200
+    received: list[str] = []
+
+    def consume():
+        received.extend(_drain(reader, total))
+
+    consumer = threading.Thread(target=consume)
+    consumer.start()
+    try:
+        # Mimic the sender: open/write/close per message, no pacing.
+        for i in range(total):
+            with open(fifo_path, "w", encoding="utf-8") as fifo:
+                fifo.write(json.dumps({"marker": f"m-{i}", "content": f"msg {i}"}) + "\n")
+    finally:
+        consumer.join(timeout=30)
+        reader.close()
+
+    assert not consumer.is_alive(), "consumer thread hung"
+    assert len(received) == total
+    markers = [json.loads(line)["marker"] for line in received]
+    assert markers == [f"m-{i}" for i in range(total)]
+
+
+def test_multiple_messages_in_single_write_are_split(fifo_path):
+    reader = PersistentFifoReader(fifo_path)
+    try:
+        reader.read_line(0.01)  # prime: hold the read end open before any writer
+        with open(fifo_path, "w", encoding="utf-8") as fifo:
+            fifo.write('{"marker": "a"}\n{"marker": "b"}\n')
+        first = reader.read_line(2.0)
+        second = reader.read_line(2.0)
+        assert json.loads(first)["marker"] == "a"
+        assert json.loads(second)["marker"] == "b"
+    finally:
+        reader.close()
+
+
+def test_partial_line_is_buffered_until_newline(fifo_path):
+    reader = PersistentFifoReader(fifo_path)
+    try:
+        reader.read_line(0.01)  # prime: hold the read end open before any writer
+        fd = os.open(fifo_path, os.O_WRONLY)
+        try:
+            os.write(fd, b'{"marker": "par')
+            assert reader.read_line(0.2) is None
+            os.write(fd, b'tial"}\n')
+            line = reader.read_line(2.0)
+            assert json.loads(line)["marker"] == "partial"
+        finally:
+            os.close(fd)
+    finally:
+        reader.close()
+
+
+def test_no_eof_storm_after_writer_disconnects(fifo_path):
+    reader = PersistentFifoReader(fifo_path)
+    try:
+        reader.read_line(0.01)  # prime: hold the read end open before any writer
+        with open(fifo_path, "w", encoding="utf-8") as fifo:
+            fifo.write('{"marker": "x"}\n')
+        assert json.loads(reader.read_line(2.0))["marker"] == "x"
+        # Writer has disconnected; reader must idle quietly, not spin on EOF.
+        assert reader.read_line(0.2) is None
+        with open(fifo_path, "w", encoding="utf-8") as fifo:
+            fifo.write('{"marker": "y"}\n')
+        assert json.loads(reader.read_line(2.0))["marker"] == "y"
+    finally:
+        reader.close()
+
+
+def test_missing_fifo_returns_none(tmp_path):
+    reader = PersistentFifoReader(tmp_path / "absent.fifo")
+    try:
+        assert reader.read_line(0.05) is None
+    finally:
+        reader.close()

--- a/test/test_cancel_flags.py
+++ b/test/test_cancel_flags.py
@@ -1,0 +1,71 @@
+"""Tests for filesystem cancel flags written on job cancellation (phase 2.1)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ccbd.api_models import DeliveryScope, MessageEnvelope
+from ccbd.services.dispatcher import JobDispatcher
+from ccbd.services.dispatcher_runtime.cancel_flags import (
+    cancel_flag_path,
+    cleanup_cancel_flags,
+    write_cancel_flag,
+)
+from ccbd.services.registry import AgentRegistry
+from storage.paths import PathLayout
+
+from test_v2_ccbd_dispatcher import _bootstrap_test_project, _provider_config, _runtime
+
+
+def _make_dispatcher(tmp_path: Path):
+    project_root = tmp_path / "repo"
+    ctx = _bootstrap_test_project(project_root)
+    layout = PathLayout(project_root)
+    config = _provider_config("codex")
+    registry = AgentRegistry(layout, config)
+    registry.upsert(_runtime("codex", project_id=ctx.project_id, layout=layout, pid=101))
+    dispatcher = JobDispatcher(layout, config, registry, clock=lambda: "2026-06-13T00:00:00Z")
+    return ctx, layout, dispatcher
+
+
+def _submit(dispatcher, ctx, body: str):
+    return dispatcher.submit(
+        MessageEnvelope(
+            project_id=ctx.project_id,
+            to_agent="codex",
+            from_actor="user",
+            body=body,
+            task_id=None,
+            reply_to=None,
+            message_type="ask",
+            delivery_scope=DeliveryScope.SINGLE,
+        )
+    )
+
+
+def test_cancel_writes_flag_file_for_agent(tmp_path: Path) -> None:
+    ctx, layout, dispatcher = _make_dispatcher(tmp_path)
+    receipt = _submit(dispatcher, ctx, "task body")
+    job_id = receipt.jobs[0].job_id
+
+    dispatcher.cancel(job_id)
+
+    flag = cancel_flag_path(layout, "codex", job_id)
+    assert flag.exists(), "cancel must drop a flag file visible to the agent"
+    assert dispatcher.get(job_id).status.value == "cancelled"
+
+
+def test_write_and_cleanup_cancel_flags(tmp_path: Path) -> None:
+    ctx, layout, _ = _make_dispatcher(tmp_path)
+    import os
+    import time
+
+    fresh = write_cancel_flag(layout, "codex", "job-fresh")
+    stale = write_cancel_flag(layout, "codex", "job-stale")
+    assert fresh is not None and stale is not None
+    os.utime(stale, (time.time() - 100_000, time.time() - 100_000))
+
+    cleanup_cancel_flags(layout, "codex")
+
+    assert fresh.exists()
+    assert not stale.exists()

--- a/test/test_fifo_delivery.py
+++ b/test/test_fifo_delivery.py
@@ -12,7 +12,11 @@ from provider_backends.codex.bridge_runtime.runtime_io import PersistentFifoRead
 from provider_core.fifo_delivery import (
     CommDeliveryError,
     PIPE_ATOMIC_LIMIT,
+    ack_file_path,
+    cleanup_acks,
     spool_payload,
+    wait_for_ack,
+    write_ack,
     write_fifo_line,
 )
 
@@ -56,6 +60,44 @@ def test_spool_roundtrip(tmp_path):
     spool_file = spool_payload(tmp_path / "spool", "m-big", payload)
     assert spool_file.exists()
     assert json.loads(spool_file.read_text(encoding="utf-8"))["marker"] == "m-big"
+
+
+def test_ack_roundtrip(tmp_path):
+    ack_dir = tmp_path / "acks"
+    write_ack(ack_dir, "m-1")
+    assert wait_for_ack(ack_dir, "m-1", timeout=1.0)
+    # consumed: a second wait for the same marker must time out
+    assert not wait_for_ack(ack_dir, "m-1", timeout=0.2)
+
+
+def test_wait_for_ack_times_out_when_never_written(tmp_path):
+    start = time.monotonic()
+    assert not wait_for_ack(tmp_path / "acks", "m-none", timeout=0.3)
+    assert time.monotonic() - start < 1.0
+
+
+def test_ack_appearing_mid_wait_is_seen(tmp_path):
+    import threading
+
+    ack_dir = tmp_path / "acks"
+
+    def late_ack():
+        time.sleep(0.2)
+        write_ack(ack_dir, "m-late")
+
+    threading.Thread(target=late_ack).start()
+    assert wait_for_ack(ack_dir, "m-late", timeout=3.0)
+
+
+def test_cleanup_acks_removes_only_stale_files(tmp_path):
+    ack_dir = tmp_path / "acks"
+    write_ack(ack_dir, "m-old")
+    write_ack(ack_dir, "m-new")
+    old = ack_file_path(ack_dir, "m-old")
+    os.utime(old, (time.time() - 100_000, time.time() - 100_000))
+    cleanup_acks(ack_dir)
+    assert not old.exists()
+    assert ack_file_path(ack_dir, "m-new").exists()
 
 
 def test_large_message_via_spool_pointer_reaches_reader(fifo_path, tmp_path):

--- a/test/test_fifo_delivery.py
+++ b/test/test_fifo_delivery.py
@@ -1,0 +1,72 @@
+"""Tests for non-blocking FIFO delivery with retry and spool (phase 1.2)."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+
+import pytest
+
+from provider_backends.codex.bridge_runtime.runtime_io import PersistentFifoReader
+from provider_core.fifo_delivery import (
+    CommDeliveryError,
+    PIPE_ATOMIC_LIMIT,
+    spool_payload,
+    write_fifo_line,
+)
+
+pytestmark = pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="requires POSIX FIFOs")
+
+
+@pytest.fixture()
+def fifo_path(tmp_path):
+    path = tmp_path / "input.fifo"
+    os.mkfifo(path, 0o600)
+    return path
+
+
+def test_send_without_reader_raises_after_bounded_retries(fifo_path):
+    start = time.monotonic()
+    with pytest.raises(CommDeliveryError, match="not listening"):
+        write_fifo_line(fifo_path, '{"marker": "lost"}')
+    elapsed = time.monotonic() - start
+    assert elapsed < 2.5, f"retries took {elapsed:.1f}s; backoff schedule broken"
+
+
+def test_send_with_reader_succeeds(fifo_path):
+    reader = PersistentFifoReader(fifo_path)
+    try:
+        reader.read_line(0.01)  # open the read end
+        write_fifo_line(fifo_path, '{"marker": "ok"}')
+        line = reader.read_line(2.0)
+        assert json.loads(line)["marker"] == "ok"
+    finally:
+        reader.close()
+
+
+def test_oversized_line_is_rejected_by_writer(fifo_path):
+    big = '{"content": "' + "x" * PIPE_ATOMIC_LIMIT + '"}'
+    with pytest.raises(CommDeliveryError, match="spool"):
+        write_fifo_line(fifo_path, big)
+
+
+def test_spool_roundtrip(tmp_path):
+    payload = json.dumps({"marker": "m-big", "content": "y" * 8192})
+    spool_file = spool_payload(tmp_path / "spool", "m-big", payload)
+    assert spool_file.exists()
+    assert json.loads(spool_file.read_text(encoding="utf-8"))["marker"] == "m-big"
+
+
+def test_large_message_via_spool_pointer_reaches_reader(fifo_path, tmp_path):
+    reader = PersistentFifoReader(fifo_path)
+    try:
+        reader.read_line(0.01)
+        body = json.dumps({"marker": "m-big", "content": "z" * 8192})
+        spool_file = spool_payload(tmp_path / "spool", "m-big", body)
+        write_fifo_line(fifo_path, json.dumps({"marker": "m-big", "spool": str(spool_file)}))
+        line = reader.read_line(2.0)
+        pointer = json.loads(line)
+        assert pointer["spool"] == str(spool_file)
+    finally:
+        reader.close()

--- a/test/test_transport_parity.py
+++ b/test/test_transport_parity.py
@@ -1,0 +1,109 @@
+"""Behavior-parity tests for FifoTransport vs SpoolDirTransport (phase 3.1).
+
+The same send/receive scenarios run against both transports so Windows (inbox
+directory) and POSIX (FIFO) behave identically at the contract level.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+
+import pytest
+
+from provider_core.fifo_delivery import CommDeliveryError
+from provider_core.transport import (
+    FifoTransport,
+    SpoolDirTransport,
+    create_transport,
+    endpoint_for_fifo_path,
+)
+
+HAS_FIFO = hasattr(os, "mkfifo")
+
+TRANSPORTS = ["spool"] + (["fifo"] if HAS_FIFO else [])
+
+
+@pytest.fixture(params=TRANSPORTS)
+def transport(request, tmp_path):
+    if request.param == "fifo":
+        path = tmp_path / "input.fifo"
+        os.mkfifo(path, 0o600)
+        t = FifoTransport(path)
+        t.read_line(0.01)  # hold the FIFO read end open before any sender
+    else:
+        t = SpoolDirTransport(tmp_path / "inbox")
+    yield t
+    t.close()
+
+
+def test_single_message_roundtrip(transport):
+    transport.send_line('{"marker": "a", "content": "hi"}')
+    line = transport.read_line(2.0)
+    assert json.loads(line)["marker"] == "a"
+
+
+def test_200_rapid_sends_no_loss_in_order(transport):
+    total = 200
+    received: list[str] = []
+
+    def consume():
+        misses = 0
+        while len(received) < total and misses < 50:
+            line = transport.read_line(1.0)
+            if line is None:
+                misses += 1
+                continue
+            misses = 0
+            received.append(line)
+
+    consumer = threading.Thread(target=consume)
+    consumer.start()
+    for i in range(total):
+        transport.send_line(json.dumps({"marker": f"m-{i}"}))
+    consumer.join(timeout=30)
+    assert not consumer.is_alive()
+    assert [json.loads(l)["marker"] for l in received] == [f"m-{i}" for i in range(total)]
+
+
+def test_idle_read_times_out_quickly(transport):
+    import time
+
+    start = time.monotonic()
+    assert transport.read_line(0.2) is None
+    assert time.monotonic() - start < 1.0
+
+
+def test_fifo_send_without_reader_raises():
+    if not HAS_FIFO:
+        pytest.skip("requires POSIX FIFOs")
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as d:
+        path = Path(d) / "input.fifo"
+        os.mkfifo(path, 0o600)
+        with pytest.raises(CommDeliveryError):
+            FifoTransport(path).send_line('{"marker": "lost"}')
+
+
+def test_spool_send_never_needs_reader(tmp_path):
+    t = SpoolDirTransport(tmp_path / "inbox")
+    t.send_line('{"marker": "parked"}')
+    assert json.loads(t.read_line(1.0))["marker"] == "parked"
+
+
+def test_endpoint_mapping(tmp_path):
+    fifo = tmp_path / "input.fifo"
+    endpoint = endpoint_for_fifo_path(fifo)
+    if HAS_FIFO:
+        assert endpoint == fifo
+    else:
+        assert endpoint == tmp_path / "inbox"
+
+
+def test_create_transport_picks_spool_for_directory(tmp_path):
+    inbox = tmp_path / "inbox"
+    inbox.mkdir()
+    assert isinstance(create_transport(inbox), SpoolDirTransport)


### PR DESCRIPTION
## 概述 / Summary

修复 agent 间通讯的三类长期问题:静默丢消息、任务无法撤销、Windows 不可用。10 个 commit 按阶段组织,可逐个审阅;全量测试 2599 passed / 0 failed,新增 23 个回归测试。

Fixes three long-standing inter-agent communication issues: silent message loss, uncancellable tasks, and Windows breakage. Ten commits organized by phase for review; full suite green (2599 passed, +23 new regression tests).

## 问题与修复 / Problems & Fixes

### 1. 静默丢消息(发送方显示成功,接收方没收到)/ Silent message loss

**根因 / Root cause**: bridge 读循环每读一行就关闭 FIFO 再睡 50ms(`bridge_runtime/service.py`),睡眠期间 FIFO 无读者,此时写入会阻塞或失败;发送方只要 `open+write` 不抛异常就打印 "✅ Sent",没有任何投递确认。
The bridge read loop opened/read/closed the FIFO each iteration with a 50ms sleep in between — a reader-less window where sender writes blocked or failed. The sender printed "✅ Sent" on a successful `write()` with no delivery confirmation.

**修复 / Fix**:
- `PersistentFifoReader`:读端全程持有(dummy 写端防 EOF 风暴),selectors 等待替代 sleep 轮询。200 条无间隔连发零丢失(回归测试)。
- 写端 `O_NONBLOCK` + 0.1/0.3/0.9s 退避重试,失败抛 `CommDeliveryError`;>4KB 消息走 spool 文件 + 指针行(FIFO 原子写限制)。
- 真 ACK:bridge 读到消息立即原子写 `acks/<marker>.ack`;发送方等到确认才显示 `✅ Delivered`,否则 `⚠️ unconfirmed` / `❌ failed`(三态 `DeliveryResult`,bool 兼容,不破坏现有调用方)。
- 通讯链路所有静默吞掉的异常接入结构化日志 `~/.ccb/logs/comm.log`。

### 2. 任务无法撤销 / Tasks could not be cancelled mid-flight

**修复 / Fix**: `cancel` 现在额外写 `agents/<name>/cancel_flags/<job_id>.cancel` 标志文件,且下发执行的 prompt(仅内存副本,落库记录不变)注入指令让 agent 在步骤间自查标志并停止。pane 硬打断(C-c/Escape)在 `ExecutionService.cancel` 中已存在,本 PR 未改动。
Cancellation now drops an atomic flag file visible to the agent, and the dispatched prompt (in-memory only) instructs agents to check it between steps. Hard pane interrupt already existed in `ExecutionService.cancel`.

### 3. Windows 上通讯启动即崩 / Windows broken at startup

**根因 / Root cause**: `ensure_fifo` 无条件调用 `os.mkfifo`,Windows 上不存在该函数,直接 `AttributeError`,无 fallback。

**修复 / Fix**: 新增 `provider_core/transport.py` 传输抽象——POSIX 走 `FifoTransport`,Windows 走 `SpoolDirTransport`(inbox 目录,每消息一文件,临时名+原子改名,`time_ns+pid+counter` 命名免锁有序)。平台决策集中在 `create_transport` 一处;同一套场景参数化跑两种 transport 的对等测试保证行为一致。`is_windows/is_wsl/is_macos` 收敛到 `provider_core/platform_info.py`。

## 测试 / Testing

- 基线 2570 passed → 现 2599 passed / 0 failed / 2 skipped(新增 23 个测试)
- 新增测试文件:`test_bridge_fifo_persistent_reader.py`、`test_fifo_delivery.py`、`test_cancel_flags.py`、`test_transport_parity.py`
- 详细诊断与执行记录见仓库内 `OPTIMIZATION_PLAN.md` / `PLAN_NOTES.md`(随 PR 提交,如不需要可在合并前删除)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
