### PR TITLE
Port local CCB runtime repairs onto GitHub main

### DIFF
--- a/config/tmux-ccb.conf
+++ b/config/tmux-ccb.conf
@@ -23,6 +23,10 @@ set -sg escape-time 10
 # Focus events for vim/neovim autoread
 set -g focus-events on
 
+# Preserve modified Enter and other extended key sequences for native CLIs such
+# as Kimi Code.
+set -g extended-keys on
+
 # Enable system clipboard integration (OSC 52)
 set -s set-clipboard on
 

--- a/lib/provider_backends/codex/bridge_runtime/runtime_io.py
+++ b/lib/provider_backends/codex/bridge_runtime/runtime_io.py
@@ -66,7 +66,34 @@ class PersistentFifoReader:
             )
             return False
         selector = selectors.DefaultSelector()
-        selector.register(read_fd, selectors.EVENT_READ)
+        try:
+            selector.register(read_fd, selectors.EVENT_READ)
+        except PermissionError as exc:
+            selector.close()
+            log_comm_event(
+                _logger,
+                provider='codex',
+                direction='recv',
+                endpoint=str(self._path),
+                event='fifo_default_selector_unsupported',
+                error=exc,
+            )
+            selector = selectors.SelectSelector()
+            try:
+                selector.register(read_fd, selectors.EVENT_READ)
+            except OSError as fallback_exc:
+                selector.close()
+                os.close(read_fd)
+                os.close(keepalive_fd)
+                log_comm_event(
+                    _logger,
+                    provider='codex',
+                    direction='recv',
+                    endpoint=str(self._path),
+                    event='fifo_selector_register_failed',
+                    error=fallback_exc,
+                )
+                return False
         self._read_fd = read_fd
         self._keepalive_fd = keepalive_fd
         self._selector = selector

--- a/lib/provider_backends/kimi/execution.py
+++ b/lib/provider_backends/kimi/execution.py
@@ -19,6 +19,7 @@ from provider_execution.base import ProviderPollResult, ProviderRuntimeContext, 
 from provider_execution.common import build_item, error_submission, send_prompt_to_runtime_target
 
 from provider_core.protocol import request_anchor_for_job
+from .hindsight import recall_hindsight_memories, retain_hindsight_turn
 from .session import load_project_session
 from .native_log import KimiTurnObservation, observe_kimi_turn
 
@@ -135,7 +136,16 @@ def _start_submission(
         )
 
     req_id = request_anchor_for_job(job.job_id)
-    prompt_body = _with_kimi_context_pointer(job.request.body or "", session)
+    original_prompt_body = job.request.body or ""
+    prompt_body = _with_kimi_context_pointer(original_prompt_body, session)
+    hindsight_recall = recall_hindsight_memories(
+        original_prompt_body,
+        session_id=str(getattr(session, "session_id", "") or req_id),
+        agent_name=job.agent_name,
+        workspace_path=str(work_dir),
+    )
+    if hindsight_recall.context:
+        prompt_body = f"{hindsight_recall.context}\n\n{prompt_body}"
     prompt = wrap_native_prompt(prompt_body, req_id)
     initial_content = _pane_snapshot(backend, pane_id, lines=PANE_LINES_DEFAULT)
     prompt_deferred_until_ready = not _pane_ready_for_input(initial_content)
@@ -157,6 +167,8 @@ def _start_submission(
         diagnostics["send_error"] = send_error
     if prompt_deferred_until_ready:
         diagnostics["prompt_deferred_until_ready"] = True
+    if hindsight_recall.diagnostics:
+        diagnostics["hindsight_recall"] = hindsight_recall.diagnostics
 
     return ProviderSubmission(
         job_id=job.job_id,
@@ -175,6 +187,8 @@ def _start_submission(
             "request_anchor": req_id,
             "req_id": req_id,
             "work_dir": str(work_dir),
+            "hindsight_user_prompt": original_prompt_body,
+            "hindsight_recall": hindsight_recall.diagnostics or {},
             "started_at": now,
             "last_poll_at": now,
             "prompt_sent": prompt_sent,
@@ -353,6 +367,19 @@ def _poll_submission(submission: ProviderSubmission, *, now: str) -> ProviderPol
 
     boundary_ref = str(observation.provider_turn_ref or observation.session_id or session_path or req_id)
     if observation.completed and boundary_ref != _state_str(state, "turn_boundary_ref"):
+        hindsight_prompt = _state_str(state, "hindsight_user_prompt")
+        if reply and hindsight_prompt and not bool(state.get("hindsight_retained")):
+            retain_result = retain_hindsight_turn(
+                prompt=hindsight_prompt,
+                reply=reply,
+                session_id=_state_str(state, "request_anchor") or submission.job_id,
+                job_id=submission.job_id,
+                agent_name=submission.agent_name,
+                workspace_path=work_dir,
+            )
+            state["hindsight_retained"] = bool(retain_result.retained)
+            if retain_result.diagnostics:
+                state["hindsight_retain"] = retain_result.diagnostics
         items.append(
             build_item(
                 submission,

--- a/lib/provider_backends/kimi/execution.py
+++ b/lib/provider_backends/kimi/execution.py
@@ -20,13 +20,14 @@ from provider_execution.common import build_item, error_submission, send_prompt_
 
 from provider_core.protocol import request_anchor_for_job
 from .session import load_project_session
-from .native_log import observe_kimi_turn
+from .native_log import KimiTurnObservation, observe_kimi_turn
 
 
 PANE_LINES_DEFAULT = 2000
 MAX_WAIT_SECS = 300.0
 ANCHOR_WAIT_SECS = 120.0
 READY_WAIT_SECS = 60.0
+PANE_FALLBACK_STABLE_SECS = 10.0
 
 
 class KimiProviderAdapter:
@@ -134,7 +135,8 @@ def _start_submission(
         )
 
     req_id = request_anchor_for_job(job.job_id)
-    prompt = wrap_native_prompt(job.request.body or "", req_id)
+    prompt_body = _with_kimi_context_pointer(job.request.body or "", session)
+    prompt = wrap_native_prompt(prompt_body, req_id)
     initial_content = _pane_snapshot(backend, pane_id, lines=PANE_LINES_DEFAULT)
     prompt_deferred_until_ready = not _pane_ready_for_input(initial_content)
     send_error: str | None = None
@@ -240,6 +242,14 @@ def _poll_submission(submission: ProviderSubmission, *, now: str) -> ProviderPol
     state["total_secs"] = total_secs
 
     observation = observe_kimi_turn(Path(work_dir), req_id)
+    pane_observation = _observe_kimi_pane_turn(backend, pane_id, req_id)
+    if pane_observation is not None:
+        pane_observation = _stabilize_pane_observation(state, pane_observation, now)
+    if pane_observation is not None and (
+        observation is None or (pane_observation.completed and not observation.completed)
+    ):
+        observation = pane_observation
+        state["pane_fallback_observed"] = True
     if observation is None:
         if total_secs >= ANCHOR_WAIT_SECS:
             return _terminal(
@@ -508,7 +518,151 @@ def _pane_snapshot(backend: object, pane_id: str, *, lines: int) -> str:
 
 def _pane_ready_for_input(content: str) -> bool:
     text = content or ""
-    return "── input" in text and "agent (" in text
+    legacy_ready = "── input" in text and "agent (" in text
+    k27_ready = "│ >" in text and "K2.7 Code" in text and "context:" in text
+    return legacy_ready or k27_ready
+
+
+def _observe_kimi_pane_turn(backend: object, pane_id: str, req_id: str) -> KimiTurnObservation | None:
+    content = _pane_snapshot(backend, pane_id, lines=PANE_LINES_DEFAULT)
+    if not content or req_id not in content:
+        return None
+    completed = _pane_ready_for_input(content)
+    reply = _extract_kimi_pane_reply(content, req_id) if completed else ""
+    return KimiTurnObservation(
+        request_seen=True,
+        completed=bool(completed and reply),
+        reply=reply,
+        session_id=pane_id,
+        session_path=f"pane:{pane_id}",
+        provider_turn_ref=f"pane:{pane_id}:{req_id}",
+        line_count=len(content.splitlines()),
+        native_started_at=None,
+        native_completed_at=None,
+    )
+
+
+def _stabilize_pane_observation(
+    state: dict[str, object],
+    observation: KimiTurnObservation,
+    now: str,
+) -> KimiTurnObservation:
+    reply = observation.reply or ""
+    if not reply:
+        state.pop("pane_fallback_candidate_signature", None)
+        state.pop("pane_fallback_candidate_since", None)
+        return observation
+
+    signature = _hash_text(reply)
+    if signature != _state_str(state, "pane_fallback_candidate_signature"):
+        state["pane_fallback_candidate_signature"] = signature
+        state["pane_fallback_candidate_since"] = now
+        return replace(observation, completed=False)
+
+    stable_since = _state_str(state, "pane_fallback_candidate_since") or now
+    stable_secs = _seconds_between(stable_since, now)
+    state["pane_fallback_stable_secs"] = stable_secs
+    if stable_secs < PANE_FALLBACK_STABLE_SECS:
+        return replace(observation, completed=False)
+    return observation
+
+
+def _extract_kimi_pane_reply(content: str, req_id: str) -> str:
+    tail = content.split(req_id, 1)[-1]
+    lines = tail.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+    answer_start: int | None = None
+    first_answer_line = ""
+    for index, line in enumerate(lines):
+        stripped = line.strip()
+        if not stripped.startswith(("●", "•")):
+            continue
+        candidate = stripped.lstrip("●•").strip()
+        if not candidate or _looks_like_kimi_non_answer(candidate):
+            continue
+        answer_start = index
+        first_answer_line = candidate
+        break
+    if answer_start is None:
+        return ""
+
+    reply_lines = [first_answer_line]
+    for line in lines[answer_start + 1 :]:
+        stripped = line.strip()
+        if _looks_like_kimi_input_box_line(stripped):
+            break
+        if stripped.startswith(("●", "•")) and _looks_like_kimi_non_answer(stripped.lstrip("●•").strip()):
+            break
+        reply_lines.append(line.rstrip())
+    return _clean_kimi_pane_reply("\n".join(reply_lines), req_id)
+
+
+def _clean_kimi_pane_reply(text: str, req_id: str) -> str:
+    lines = [line.rstrip() for line in text.replace("\r\n", "\n").replace("\r", "\n").split("\n")]
+    while lines and not lines[0].strip():
+        lines.pop(0)
+    while lines and not lines[-1].strip():
+        lines.pop()
+    if lines and lines[0].strip().startswith(("●", "•")):
+        lines[0] = lines[0].strip().lstrip("●•").strip()
+    return "\n".join(lines).strip()
+
+
+def _looks_like_kimi_input_box_line(stripped: str) -> bool:
+    if not stripped:
+        return False
+    if stripped.startswith("╭") or stripped.startswith("╰"):
+        return True
+    if stripped.startswith("│ >"):
+        return True
+    return "K2.7 Code" in stripped and "context:" in stripped
+
+
+def _looks_like_kimi_non_answer(text: str) -> bool:
+    stripped = text.strip()
+    lowered = stripped.lower()
+    if not stripped or all(char in "🌑🌒🌓🌔🌕🌖🌗🌘⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏ .·" for char in stripped):
+        return True
+    return lowered.startswith(
+        (
+            "using ",
+            "used ",
+            "reading ",
+            "read ",
+            "run ",
+            "running ",
+            "todo",
+            "thinking",
+            "user wants",
+            "user asks",
+            "user says",
+            "user requests",
+            "user requested",
+            "the user wants",
+            "the user asks",
+            "the user says",
+            "the user requested",
+            "they want",
+            "they ask",
+            "they request",
+            "let me ",
+            "let's ",
+            "i'll ",
+            "i will ",
+            "i can ",
+            "i am ",
+            "i'm ",
+            "i need",
+            "i should",
+            "should ",
+            "we have",
+            "we need",
+            "need ",
+            "now need",
+            "good. ",
+            "no docs lint script",
+            "the task",
+        )
+    )
 
 
 def _send_prompt(backend: object, pane_id: str, prompt: str) -> str | None:
@@ -517,6 +671,25 @@ def _send_prompt(backend: object, pane_id: str, prompt: str) -> str | None:
     except Exception as exc:
         return f"send_text_failed:{exc!r}"
     return None
+
+
+def _with_kimi_context_pointer(message: str, session: object) -> str:
+    data = getattr(session, "data", None)
+    context_path = ""
+    if isinstance(data, dict):
+        context_path = str(data.get("kimi_context_path") or "").strip()
+    if not context_path:
+        return message
+    context = "\n".join(
+        [
+            "CCB Kimi context:",
+            f"- Read and follow: {context_path}",
+            "- Kimi does not load local CCB skills directly; this context file is the scoped CCB memory/rules projection.",
+            "- Implementation completed is not review/archive; keep lifecycle truth separate.",
+            "",
+        ]
+    )
+    return f"{context}{message or ''}"
 
 
 def _resolve_work_dir(job: JobRecord, context: ProviderRuntimeContext | None) -> Path | None:

--- a/lib/provider_backends/kimi/hindsight.py
+++ b/lib/provider_backends/kimi/hindsight.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+DEFAULT_API_URL = "http://127.0.0.1:18888"
+DEFAULT_BANK_ID = "codex"
+CONFIG_CANDIDATES = (
+    Path(".hindsight") / "kimi.json",
+    Path(".hindsight") / "codex.json",
+)
+
+
+@dataclass(frozen=True)
+class HindsightRecall:
+    context: str = ""
+    diagnostics: dict[str, object] | None = None
+
+
+@dataclass(frozen=True)
+class HindsightRetain:
+    retained: bool = False
+    diagnostics: dict[str, object] | None = None
+
+
+@dataclass(frozen=True)
+class _HindsightConfig:
+    enabled: bool
+    api_url: str
+    bank_id: str
+    auto_recall: bool
+    auto_retain: bool
+    recall_budget: str
+    recall_max_tokens: int
+    recall_timeout: int
+    retain_context: str
+    recall_preamble: str
+    api_token: str = ""
+    config_path: str = ""
+
+
+def recall_hindsight_memories(
+    prompt: str,
+    *,
+    session_id: str,
+    agent_name: str,
+    workspace_path: str,
+) -> HindsightRecall:
+    config = _load_config()
+    if not config.enabled or not config.auto_recall:
+        return HindsightRecall(diagnostics={"enabled": config.enabled, "auto_recall": config.auto_recall})
+    query = str(prompt or "").strip()
+    if len(query) < 5:
+        return HindsightRecall(diagnostics={"enabled": True, "reason": "prompt_too_short"})
+    try:
+        response = _request(
+            "POST",
+            f"/v1/default/banks/{_quote(config.bank_id)}/memories/recall",
+            {
+                "query": query[:800],
+                "thinking_budget": _thinking_budget(config.recall_budget),
+                "max_tokens": config.recall_max_tokens,
+            },
+            config=config,
+            timeout=config.recall_timeout,
+        )
+    except Exception as exc:
+        return HindsightRecall(diagnostics={"enabled": True, "status": "failed", "reason": str(exc)[:240]})
+
+    results = _response_results(response)
+    if not results:
+        return HindsightRecall(diagnostics={"enabled": True, "status": "empty", "bank_id": config.bank_id})
+
+    context = _format_context(results, preamble=config.recall_preamble)
+    return HindsightRecall(
+        context=context,
+        diagnostics={
+            "enabled": True,
+            "status": "ok",
+            "bank_id": config.bank_id,
+            "result_count": len(results),
+            "session_id": session_id,
+            "agent_name": agent_name,
+            "workspace_path": workspace_path,
+        },
+    )
+
+
+def retain_hindsight_turn(
+    *,
+    prompt: str,
+    reply: str,
+    session_id: str,
+    job_id: str,
+    agent_name: str,
+    workspace_path: str,
+) -> HindsightRetain:
+    config = _load_config()
+    if not config.enabled or not config.auto_retain:
+        return HindsightRetain(diagnostics={"enabled": config.enabled, "auto_retain": config.auto_retain})
+    content = _turn_transcript(prompt=prompt, reply=reply, agent_name=agent_name, workspace_path=workspace_path)
+    if not content.strip():
+        return HindsightRetain(diagnostics={"enabled": True, "reason": "empty_turn"})
+    document_id = f"kimi:{session_id or agent_name}:{job_id}"
+    try:
+        _request(
+            "POST",
+            f"/v1/default/banks/{_quote(config.bank_id)}/memories",
+            {
+                "items": [
+                    {
+                        "content": content,
+                        "context": config.retain_context,
+                        "document_id": document_id,
+                    }
+                ]
+            },
+            config=config,
+            timeout=15,
+        )
+    except Exception as exc:
+        return HindsightRetain(diagnostics={"enabled": True, "status": "failed", "reason": str(exc)[:240]})
+    return HindsightRetain(
+        retained=True,
+        diagnostics={
+            "enabled": True,
+            "status": "ok",
+            "bank_id": config.bank_id,
+            "document_id": document_id,
+            "content_chars": len(content),
+        },
+    )
+
+
+def _load_config() -> _HindsightConfig:
+    payload, path = _load_config_payload()
+    env_api_url = str(os.environ.get("HINDSIGHT_API_URL") or "").strip()
+    env_bank_id = str(os.environ.get("HINDSIGHT_BANK_ID") or "").strip()
+    api_url = (env_api_url or str(payload.get("hindsightApiUrl") or "") or DEFAULT_API_URL).rstrip("/")
+    bank_id = env_bank_id or str(payload.get("bankId") or DEFAULT_BANK_ID).strip()
+    enabled = bool(env_api_url or env_bank_id or path)
+    return _HindsightConfig(
+        enabled=enabled,
+        api_url=api_url,
+        bank_id=bank_id,
+        auto_recall=bool(payload.get("autoRecall", True)),
+        auto_retain=bool(payload.get("autoRetain", True)),
+        recall_budget=str(payload.get("recallBudget") or "mid"),
+        recall_max_tokens=_int(payload.get("recallMaxTokens"), 1024),
+        recall_timeout=_int(payload.get("recallTimeout"), 10),
+        retain_context=_retain_context(payload, path),
+        recall_preamble=str(payload.get("recallPromptPreamble") or "Relevant memories from past conversations:"),
+        api_token=str(os.environ.get("HINDSIGHT_API_TOKEN") or payload.get("hindsightApiToken") or ""),
+        config_path=str(path or ""),
+    )
+
+
+def _load_config_payload() -> tuple[dict[str, object], Path | None]:
+    home = Path.home().expanduser()
+    for relative in CONFIG_CANDIDATES:
+        path = home / relative
+        try:
+            if not path.is_file():
+                continue
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        if isinstance(payload, dict):
+            return payload, path
+    return {}, None
+
+
+def _retain_context(payload: dict[str, object], path: Path | None) -> str:
+    configured = str(payload.get("retainContext") or "").strip()
+    if path is not None and path.name == "kimi.json" and configured:
+        return configured
+    return "kimi"
+
+
+def _request(method: str, path: str, payload: object, *, config: _HindsightConfig, timeout: int) -> object:
+    body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    headers = {"Accept": "application/json", "Content-Type": "application/json"}
+    if config.api_token:
+        headers["Authorization"] = f"Bearer {config.api_token}"
+    request = urllib.request.Request(
+        f"{config.api_url}{path}",
+        data=body,
+        headers=headers,
+        method=method.upper(),
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            raw = response.read()
+            content_type = response.headers.get("content-type", "")
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"HTTP {exc.code}: {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"unreachable: {exc.reason}") from exc
+    if not raw:
+        return {}
+    text = raw.decode("utf-8", errors="replace")
+    if "json" in content_type:
+        return json.loads(text)
+    try:
+        return json.loads(text)
+    except Exception:
+        return {"text": text}
+
+
+def _response_results(response: object) -> list[object]:
+    if not isinstance(response, dict):
+        return []
+    raw = response.get("results") or response.get("memories") or []
+    return list(raw) if isinstance(raw, list) else []
+
+
+def _format_context(results: list[object], *, preamble: str) -> str:
+    lines = [
+        "<hindsight_memories>",
+        preamble,
+        f"Current time - {time.strftime('%Y-%m-%d %H:%M', time.localtime())}",
+        "",
+    ]
+    for item in results[:8]:
+        text = _memory_text(item)
+        if text:
+            lines.append(f"- {text}")
+    lines.append("</hindsight_memories>")
+    return "\n".join(lines).strip()
+
+
+def _memory_text(item: object) -> str:
+    if isinstance(item, str):
+        return item.strip()
+    if not isinstance(item, dict):
+        return ""
+    for key in ("content", "text", "memory", "summary"):
+        value = item.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    value = item.get("memory")
+    if isinstance(value, dict):
+        return _memory_text(value)
+    return ""
+
+
+def _turn_transcript(*, prompt: str, reply: str, agent_name: str, workspace_path: str) -> str:
+    return "\n".join(
+        [
+            f"Provider: kimi",
+            f"Agent: {agent_name}",
+            f"Workspace: {workspace_path}",
+            "",
+            f"User: {prompt.strip()}",
+            "",
+            f"Assistant: {reply.strip()}",
+        ]
+    )
+
+
+def _thinking_budget(value: str) -> int:
+    return {"low": 20, "mid": 50, "high": 100}.get(str(value or "").strip().lower(), 50)
+
+
+def _int(value: object, default: int) -> int:
+    try:
+        return int(value)
+    except Exception:
+        return default
+
+
+def _quote(value: str) -> str:
+    return urllib.parse.quote(str(value), safe="")
+
+
+__all__ = ["HindsightRecall", "HindsightRetain", "recall_hindsight_memories", "retain_hindsight_turn"]

--- a/lib/provider_backends/kimi/hindsight.py
+++ b/lib/provider_backends/kimi/hindsight.py
@@ -42,6 +42,7 @@ class _HindsightConfig:
     recall_timeout: int
     retain_context: str
     recall_preamble: str
+    show_hook_context: bool
     api_token: str = ""
     config_path: str = ""
 
@@ -79,6 +80,8 @@ def recall_hindsight_memories(
         return HindsightRecall(diagnostics={"enabled": True, "status": "empty", "bank_id": config.bank_id})
 
     context = _format_context(results, preamble=config.recall_preamble)
+    if config.show_hook_context:
+        context = _format_visible_hook_context(context)
     return HindsightRecall(
         context=context,
         diagnostics={
@@ -89,6 +92,7 @@ def recall_hindsight_memories(
             "session_id": session_id,
             "agent_name": agent_name,
             "workspace_path": workspace_path,
+            "show_hook_context": config.show_hook_context,
         },
     )
 
@@ -157,6 +161,8 @@ def _load_config() -> _HindsightConfig:
         recall_timeout=_int(payload.get("recallTimeout"), 10),
         retain_context=_retain_context(payload, path),
         recall_preamble=str(payload.get("recallPromptPreamble") or "Relevant memories from past conversations:"),
+        show_hook_context=_bool_env("CCB_KIMI_HINDSIGHT_SHOW_HOOK_CONTEXT")
+        or _bool(payload.get("showHookContext"), False),
         api_token=str(os.environ.get("HINDSIGHT_API_TOKEN") or payload.get("hindsightApiToken") or ""),
         config_path=str(path or ""),
     )
@@ -237,6 +243,16 @@ def _format_context(results: list[object], *, preamble: str) -> str:
     return "\n".join(lines).strip()
 
 
+def _format_visible_hook_context(context: str) -> str:
+    indented = "\n".join(f"  {line}" if line else "" for line in context.splitlines())
+    return "\n".join(
+        [
+            "UserPromptSubmit hook (completed)",
+            f"hook context: {indented}",
+        ]
+    ).strip()
+
+
 def _memory_text(item: object) -> str:
     if isinstance(item, str):
         return item.strip()
@@ -275,6 +291,22 @@ def _int(value: object, default: int) -> int:
         return int(value)
     except Exception:
         return default
+
+
+def _bool(value: object, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    return default
+
+
+def _bool_env(name: str) -> bool:
+    return _bool(os.environ.get(name), False)
 
 
 def _quote(value: str) -> str:

--- a/lib/provider_backends/pane_quiet_support/execution.py
+++ b/lib/provider_backends/pane_quiet_support/execution.py
@@ -432,7 +432,9 @@ def _pane_ready_for_input(content: str, provider: str) -> bool:
     if provider != "kimi":
         return True
     text = content or ""
-    return "── input" in text and "agent (" in text
+    legacy_ready = "── input" in text and "agent (" in text
+    k27_ready = "│ >" in text and "K2.7 Code" in text and "context:" in text
+    return legacy_ready or k27_ready
 
 
 def _send_prompt(backend: object, pane_id: str, prompt: str) -> str | None:

--- a/lib/provider_profiles/codex_home_config.py
+++ b/lib/provider_profiles/codex_home_config.py
@@ -54,6 +54,8 @@ _CODEX_ACTIVITY_HOOK_EVENTS = (
     'Stop',
 )
 _CODEX_ACTIVITY_HOOK_TIMEOUT_S = 5
+_CODEX_INHERITED_HOOK_EVENTS = frozenset({'SessionStart', 'UserPromptSubmit', 'Stop'})
+_CODEX_INHERITED_HOOK_COMMAND_MARKERS = ('.hindsight/codex/scripts/',)
 _TOML_TABLE_HEADER_RE = re.compile(r'^\s*\[{1,2}[^\]]+\]{1,2}\s*(?:#.*)?$')
 
 
@@ -155,6 +157,7 @@ def materialize_codex_home_config(
     _install_codex_activity_hooks(
         target_home,
         target_config,
+        source_home=source_home,
         project_root=project_root,
         agent_name=agent_name,
         runtime_dir=runtime_dir,
@@ -173,15 +176,18 @@ def materialize_codex_home_config(
 def repair_codex_activity_hooks(
     target_home: Path,
     *,
+    source_home: Path | None = None,
     project_root: Path | None,
     agent_name: str | None,
     runtime_dir: Path | None,
     workspace_path: Path | None,
 ) -> None:
     target_home = Path(target_home).expanduser()
+    source_home = Path(source_home).expanduser() if source_home is not None else _system_codex_home()
     _install_codex_activity_hooks(
         target_home,
         target_home / 'config.toml',
+        source_home=source_home,
         project_root=project_root,
         agent_name=agent_name,
         runtime_dir=runtime_dir,
@@ -725,6 +731,7 @@ def _install_codex_activity_hooks(
     target_home: Path,
     target_config: Path,
     *,
+    source_home: Path | None = None,
     project_root: Path | None,
     agent_name: str | None,
     runtime_dir: Path | None,
@@ -743,6 +750,10 @@ def _install_codex_activity_hooks(
         workspace_path=Path(workspace_path).expanduser(),
     )
     event_groups = _codex_activity_hook_events(command)
+    event_groups = _merge_codex_hook_groups(
+        event_groups,
+        _allowed_inherited_codex_hooks(source_home),
+    )
     hooks_payload = {'hooks': event_groups}
     hooks_path.parent.mkdir(parents=True, exist_ok=True)
     atomic_write_text(
@@ -803,6 +814,113 @@ def _codex_activity_hook_events(command: str) -> dict[str, list[dict[str, object
         ]
         for event_name in _CODEX_ACTIVITY_HOOK_EVENTS
     }
+
+
+def _allowed_inherited_codex_hooks(source_home: Path | None) -> dict[str, list[dict[str, object]]]:
+    if source_home is None:
+        return {}
+    hooks_path = Path(source_home).expanduser() / 'hooks.json'
+    try:
+        payload = json.loads(hooks_path.read_text(encoding='utf-8'))
+    except Exception:
+        return {}
+    hooks = payload.get('hooks') if isinstance(payload, dict) else None
+    if not isinstance(hooks, dict):
+        return {}
+
+    selected: dict[str, list[dict[str, object]]] = {}
+    for event_name, raw_groups in hooks.items():
+        event = str(event_name)
+        if event not in _CODEX_INHERITED_HOOK_EVENTS or not isinstance(raw_groups, list):
+            continue
+        groups: list[dict[str, object]] = []
+        for raw_group in raw_groups:
+            group = _allowed_inherited_codex_hook_group(raw_group)
+            if group is not None:
+                groups.append(group)
+        if groups:
+            selected[event] = groups
+    return selected
+
+
+def _allowed_inherited_codex_hook_group(raw_group: object) -> dict[str, object] | None:
+    if not isinstance(raw_group, dict):
+        return None
+    raw_handlers = raw_group.get('hooks')
+    if not isinstance(raw_handlers, list):
+        return None
+    handlers: list[dict[str, object]] = []
+    for raw_handler in raw_handlers:
+        handler = _allowed_inherited_codex_hook_handler(raw_handler)
+        if handler is None:
+            return None
+        handlers.append(handler)
+    if not handlers:
+        return None
+    group: dict[str, object] = {'hooks': handlers}
+    if raw_group.get('matcher') is not None:
+        group['matcher'] = str(raw_group.get('matcher') or '')
+    return group
+
+
+def _allowed_inherited_codex_hook_handler(raw_handler: object) -> dict[str, object] | None:
+    if not isinstance(raw_handler, dict):
+        return None
+    if str(raw_handler.get('type') or '') != 'command':
+        return None
+    command = str(raw_handler.get('command') or '')
+    normalized_command = command.replace('\\', '/')
+    if not any(marker in normalized_command for marker in _CODEX_INHERITED_HOOK_COMMAND_MARKERS):
+        return None
+    handler: dict[str, object] = {
+        'type': 'command',
+        'command': command,
+    }
+    if raw_handler.get('timeout') is not None:
+        try:
+            handler['timeout'] = int(raw_handler.get('timeout') or 0)
+        except (TypeError, ValueError):
+            return None
+    if raw_handler.get('async') is not None:
+        handler['async'] = bool(raw_handler.get('async'))
+    if raw_handler.get('statusMessage') is not None:
+        handler['statusMessage'] = str(raw_handler.get('statusMessage') or '')
+    return handler
+
+
+def _merge_codex_hook_groups(
+    base: dict[str, list[dict[str, object]]],
+    inherited: dict[str, list[dict[str, object]]],
+) -> dict[str, list[dict[str, object]]]:
+    merged: dict[str, list[dict[str, object]]] = {
+        event: [_clone_mapping(group) for group in groups]
+        for event, groups in base.items()
+    }
+    seen_commands = {
+        _codex_hook_group_command_identity(group)
+        for groups in merged.values()
+        for group in groups
+    }
+    for event, groups in inherited.items():
+        event_groups = merged.setdefault(event, [])
+        for group in groups:
+            identity = _codex_hook_group_command_identity(group)
+            if identity in seen_commands:
+                continue
+            event_groups.append(_clone_mapping(group))
+            seen_commands.add(identity)
+    return merged
+
+
+def _codex_hook_group_command_identity(group: dict[str, object]) -> tuple[str, ...]:
+    handlers = group.get('hooks')
+    if not isinstance(handlers, list):
+        return ()
+    return tuple(
+        str(handler.get('command') or '')
+        for handler in handlers
+        if isinstance(handler, dict)
+    )
 
 
 def _merge_codex_activity_hook_state(

--- a/scripts/hindsight
+++ b/scripts/hindsight
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Small Linux-native Hindsight API wrapper for CCB agents.
+
+This intentionally talks to the already-running Hindsight service over HTTP.
+It does not invoke Docker, Windows interop, or the Rust CLI build output.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+DEFAULT_API_URL = "http://127.0.0.1:18888"
+
+
+class HindsightError(RuntimeError):
+    pass
+
+
+def api_url() -> str:
+    return os.environ.get("HINDSIGHT_API_URL", DEFAULT_API_URL).rstrip("/")
+
+
+def request(method: str, path: str, payload: object | None = None) -> object:
+    if not path.startswith("/"):
+        path = f"/{path}"
+    body = None
+    headers = {"Accept": "application/json"}
+    if payload is not None:
+        body = json.dumps(payload).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+
+    api_key = os.environ.get("HINDSIGHT_API_KEY")
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    req = urllib.request.Request(
+        f"{api_url()}{path}",
+        data=body,
+        headers=headers,
+        method=method.upper(),
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            raw = resp.read()
+            content_type = resp.headers.get("content-type", "")
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise HindsightError(f"HTTP {exc.code} {method.upper()} {path}: {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise HindsightError(f"cannot reach Hindsight API at {api_url()}: {exc.reason}") from exc
+
+    if not raw:
+        return {}
+    text = raw.decode("utf-8", errors="replace")
+    if "json" in content_type:
+        return json.loads(text)
+    return text
+
+
+def emit(value: object, output: str) -> None:
+    if output == "raw" and isinstance(value, str):
+        print(value)
+        return
+    print(json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True))
+
+
+def add_common(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "-o",
+        "--output",
+        choices=("json", "raw"),
+        default="json",
+        help="Output format. JSON is the default.",
+    )
+
+
+def handle(args: argparse.Namespace) -> object:
+    if args.command == "health":
+        return request("GET", "/health")
+    if args.command == "version":
+        return request("GET", "/version")
+    if args.command == "raw":
+        payload = json.loads(args.json) if args.json else None
+        return request(args.method, args.path, payload)
+
+    if args.command == "bank":
+        if args.bank_command == "list":
+            return request("GET", "/v1/default/banks")
+        if args.bank_command == "stats":
+            return request("GET", f"/v1/default/banks/{quote(args.bank_id)}/stats")
+
+    if args.command == "memory":
+        bank = quote(args.bank_id)
+        if args.memory_command == "list":
+            query = urllib.parse.urlencode({"limit": args.limit, "offset": args.offset})
+            return request("GET", f"/v1/default/banks/{bank}/memories/list?{query}")
+        if args.memory_command == "retain":
+            item: dict[str, str] = {"content": args.content}
+            if args.context:
+                item["context"] = args.context
+            if args.document_id:
+                item["document_id"] = args.document_id
+            return request("POST", f"/v1/default/banks/{bank}/memories", {"items": [item]})
+        if args.memory_command == "recall":
+            return request(
+                "POST",
+                f"/v1/default/banks/{bank}/memories/recall",
+                {"query": args.query, "thinking_budget": args.thinking_budget},
+            )
+        if args.memory_command == "reflect":
+            payload: dict[str, object] = {
+                "query": args.query,
+                "thinking_budget": args.thinking_budget,
+            }
+            if args.context:
+                payload["context"] = args.context
+            return request("POST", f"/v1/default/banks/{bank}/reflect", payload)
+
+    raise HindsightError("unsupported command")
+
+
+def quote(value: str) -> str:
+    return urllib.parse.quote(value, safe="")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="hindsight",
+        description="Linux-native wrapper for the running Hindsight HTTP API.",
+    )
+    parser.add_argument(
+        "--api-url",
+        default=None,
+        help=f"Override API URL for this invocation. Default: {DEFAULT_API_URL}",
+    )
+    parser.add_argument(
+        "--version",
+        action="store_true",
+        help="Print the Hindsight API version and exit.",
+    )
+    add_common(parser)
+
+    sub = parser.add_subparsers(dest="command")
+
+    sub.add_parser("health")
+    sub.add_parser("version")
+
+    raw = sub.add_parser("raw", help="Call an arbitrary API path.")
+    raw.add_argument("method")
+    raw.add_argument("path")
+    raw.add_argument("json", nargs="?")
+
+    bank = sub.add_parser("bank")
+    bank_sub = bank.add_subparsers(dest="bank_command", required=True)
+    bank_sub.add_parser("list")
+    bank_stats = bank_sub.add_parser("stats")
+    bank_stats.add_argument("bank_id")
+
+    memory = sub.add_parser("memory")
+    memory_sub = memory.add_subparsers(dest="memory_command", required=True)
+
+    mem_list = memory_sub.add_parser("list")
+    mem_list.add_argument("bank_id")
+    mem_list.add_argument("--limit", type=int, default=20)
+    mem_list.add_argument("--offset", type=int, default=0)
+
+    retain = memory_sub.add_parser("retain")
+    retain.add_argument("bank_id")
+    retain.add_argument("content")
+    retain.add_argument("--context")
+    retain.add_argument("--document-id")
+
+    recall = memory_sub.add_parser("recall")
+    recall.add_argument("bank_id")
+    recall.add_argument("query")
+    recall.add_argument("--thinking-budget", type=int, default=50)
+
+    reflect = memory_sub.add_parser("reflect")
+    reflect.add_argument("bank_id")
+    reflect.add_argument("query")
+    reflect.add_argument("--thinking-budget", type=int, default=30)
+    reflect.add_argument("--context")
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    if args.api_url:
+        os.environ["HINDSIGHT_API_URL"] = args.api_url
+
+    try:
+        if args.version:
+            value = request("GET", "/version")
+            api_version = value.get("api_version") if isinstance(value, dict) else value
+            print(api_version)
+            return 0
+        if not args.command:
+            parser.print_help()
+            return 2
+        emit(handle(args), args.output)
+        return 0
+    except (HindsightError, json.JSONDecodeError) as exc:
+        print(f"hindsight: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/test_install_script_sidebar.py
+++ b/test/test_install_script_sidebar.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+import shutil
 import subprocess
 
 
@@ -333,6 +334,10 @@ def test_install_script_fails_when_sidebar_build_needs_missing_rust(tmp_path: Pa
     crate_dir.mkdir(parents=True)
     out_bin.parent.mkdir(parents=True)
     fake_bin.mkdir()
+    for tool in ('dirname', 'grep', 'mkdir', 'uname'):
+        tool_path = shutil.which(tool)
+        assert tool_path is not None
+        (fake_bin / tool).symlink_to(tool_path)
     (crate_dir / 'Cargo.toml').write_text('[package]\nname = "ccb-agent-sidebar"\nversion = "0.0.0"\n', encoding='utf-8')
     out_bin.write_text('# CCB_AGENT_SIDEBAR_WRAPPER\n', encoding='utf-8')
     out_bin.chmod(0o755)
@@ -353,7 +358,7 @@ build_sidebar_helper_if_possible
 
     proc = subprocess.run(
         ['/bin/bash', str(harness)],
-        env={**os.environ, 'PATH': '/usr/bin:/bin'},
+        env={**os.environ, 'PATH': str(fake_bin)},
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,

--- a/test/test_kimi_hindsight_bridge.py
+++ b/test/test_kimi_hindsight_bridge.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ccbd.api_models import DeliveryScope, JobRecord, JobStatus, MessageEnvelope
+from completion.models import CompletionSourceKind
+import provider_backends.kimi.hindsight as kimi_hindsight
+from provider_backends.kimi.execution import KimiProviderAdapter
+from provider_backends.kimi.hindsight import HindsightRecall, HindsightRetain
+from provider_backends.kimi.native_log import KimiTurnObservation
+from provider_execution.base import ProviderSubmission
+
+
+class _Backend:
+    def __init__(self, text: str = "") -> None:
+        self._text = text
+        self.sent: list[str] = []
+
+    def get_pane_content(self, pane_id: str, *, lines: int) -> str:
+        del pane_id, lines
+        return self._text
+
+    def send_text(self, pane_id: str, text: str) -> None:
+        del pane_id
+        self.sent.append(text)
+
+    def send_keys(self, pane_id: str, *keys: str) -> None:
+        del pane_id
+        self.sent.extend(keys)
+
+
+def _job(*, body: str = "do work", job_id: str = "job_native123", workspace_path: Path) -> JobRecord:
+    return JobRecord(
+        job_id=job_id,
+        submission_id=None,
+        agent_name="kimi1",
+        provider="kimi",
+        request=MessageEnvelope(
+            project_id="proj",
+            to_agent="kimi1",
+            from_actor="user",
+            body=body,
+            task_id=None,
+            reply_to=None,
+            message_type="ask",
+            delivery_scope=DeliveryScope.SINGLE,
+        ),
+        status=JobStatus.RUNNING,
+        terminal_decision=None,
+        cancel_requested_at=None,
+        workspace_path=str(workspace_path),
+        created_at="2026-06-13T00:00:00Z",
+        updated_at="2026-06-13T00:00:00Z",
+    )
+
+
+def _submission(work_dir: Path, *, extra_state: dict[str, object] | None = None) -> ProviderSubmission:
+    return ProviderSubmission(
+        job_id="job_native123",
+        agent_name="kimi1",
+        provider="kimi",
+        accepted_at="2026-06-13T00:00:00Z",
+        ready_at="2026-06-13T00:00:00Z",
+        source_kind=CompletionSourceKind.SESSION_EVENT_LOG,
+        reply="",
+        runtime_state={
+            "mode": "native_turn_log",
+            "backend": _Backend(),
+            "pane_id": "%9",
+            "req_id": "job_native123",
+            "request_anchor": "job_native123",
+            "work_dir": str(work_dir),
+            "started_at": "2026-06-13T00:00:00Z",
+            "last_poll_at": "2026-06-13T00:00:00Z",
+            "prompt_sent": True,
+            "next_seq": 1,
+            "anchor_emitted": False,
+            "reply_buffer": "",
+            "last_reply_signature": "",
+            "turn_boundary_ref": "",
+            "session_path": "",
+            **(extra_state or {}),
+        },
+    )
+
+
+def test_kimi_start_injects_hindsight_recall_into_prompt(monkeypatch, tmp_path: Path) -> None:
+    work_dir = tmp_path / "project"
+    work_dir.mkdir()
+    backend = _Backend("ready")
+    session = type(
+        "Session",
+        (),
+        {
+            "session_id": "session-1",
+            "pane_id": "%9",
+            "data": {},
+            "backend": lambda self: backend,
+        },
+    )()
+    monkeypatch.setattr("provider_backends.kimi.execution.load_project_session", lambda *args, **kwargs: session)
+    monkeypatch.setattr("provider_backends.kimi.execution._pane_ready_for_input", lambda content: True)
+    monkeypatch.setattr(
+        "provider_backends.kimi.execution.recall_hindsight_memories",
+        lambda *args, **kwargs: HindsightRecall(
+            context="<hindsight_memories>\n- remembered preference\n</hindsight_memories>",
+            diagnostics={"status": "ok", "result_count": 1},
+        ),
+    )
+
+    submission = KimiProviderAdapter().start(
+        _job(body="please implement", workspace_path=work_dir),
+        context=None,
+        now="2026-06-13T00:00:00Z",
+    )
+
+    sent = "".join(backend.sent)
+    assert submission.runtime_state["prompt_sent"] is True
+    assert "remembered preference" in sent
+    assert "please implement" in sent
+    assert submission.diagnostics["hindsight_recall"]["status"] == "ok"
+    assert submission.runtime_state["hindsight_user_prompt"] == "please implement"
+
+
+def test_kimi_poll_retains_completed_turn_once(monkeypatch, tmp_path: Path) -> None:
+    work_dir = tmp_path / "project"
+    work_dir.mkdir()
+    calls: list[dict[str, str]] = []
+
+    def retain_stub(**kwargs) -> HindsightRetain:
+        calls.append({key: str(value) for key, value in kwargs.items()})
+        return HindsightRetain(retained=True, diagnostics={"status": "ok"})
+
+    observation = KimiTurnObservation(
+        request_seen=True,
+        completed=True,
+        reply="KIMI_RETAIN_OK",
+        session_id="session-1",
+        session_path="session-path",
+        provider_turn_ref="turn-1",
+        line_count=4,
+        native_started_at=None,
+        native_completed_at="2026-06-13T00:00:10Z",
+    )
+    monkeypatch.setattr("provider_backends.kimi.execution.observe_kimi_turn", lambda *args, **kwargs: observation)
+    monkeypatch.setattr("provider_backends.kimi.execution._observe_kimi_pane_turn", lambda *args, **kwargs: None)
+    monkeypatch.setattr("provider_backends.kimi.execution.retain_hindsight_turn", retain_stub)
+
+    stable = KimiProviderAdapter().poll(
+        _submission(work_dir, extra_state={"hindsight_user_prompt": "remember this task"}),
+        now="2026-06-13T00:00:16Z",
+    )
+
+    assert stable is not None
+    assert len(calls) == 1
+    assert calls[0]["prompt"] == "remember this task"
+    assert calls[0]["reply"] == "KIMI_RETAIN_OK"
+    assert stable.submission.runtime_state["hindsight_retained"] is True
+    assert stable.submission.runtime_state["hindsight_retain"]["status"] == "ok"
+
+    KimiProviderAdapter().poll(stable.submission, now="2026-06-13T00:00:17Z")
+    assert len(calls) == 1
+
+
+def test_kimi_reuses_codex_hindsight_config_without_codex_retain_context(monkeypatch, tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    config_dir = home / ".hindsight"
+    config_dir.mkdir(parents=True)
+    (config_dir / "codex.json").write_text(
+        json.dumps(
+            {
+                "hindsightApiUrl": "http://127.0.0.1:18888",
+                "bankId": "local-ai-memory",
+                "retainContext": "codex",
+                "autoRetain": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+    requests: list[dict[str, object]] = []
+
+    def request_stub(method: str, path: str, payload: object, **kwargs) -> object:
+        requests.append({"method": method, "path": path, "payload": payload, **kwargs})
+        return {}
+
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(kimi_hindsight, "_request", request_stub)
+
+    retained = kimi_hindsight.retain_hindsight_turn(
+        prompt="remember this",
+        reply="done",
+        session_id="session-1",
+        job_id="job-1",
+        agent_name="kimi1",
+        workspace_path="/repo",
+    )
+
+    payload = requests[0]["payload"]
+    assert retained.retained is True
+    assert isinstance(payload, dict)
+    assert payload["items"][0]["context"] == "kimi"

--- a/test/test_kimi_hindsight_bridge.py
+++ b/test/test_kimi_hindsight_bridge.py
@@ -200,3 +200,38 @@ def test_kimi_reuses_codex_hindsight_config_without_codex_retain_context(monkeyp
     assert retained.retained is True
     assert isinstance(payload, dict)
     assert payload["items"][0]["context"] == "kimi"
+
+
+def test_kimi_can_render_visible_hindsight_hook_context(monkeypatch, tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    config_dir = home / ".hindsight"
+    config_dir.mkdir(parents=True)
+    (config_dir / "kimi.json").write_text(
+        json.dumps(
+            {
+                "hindsightApiUrl": "http://127.0.0.1:18888",
+                "bankId": "local-ai-memory",
+                "showHookContext": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def request_stub(method: str, path: str, payload: object, **kwargs) -> object:
+        del method, path, payload, kwargs
+        return {"results": [{"content": "visible memory"}]}
+
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(kimi_hindsight, "_request", request_stub)
+
+    recall = kimi_hindsight.recall_hindsight_memories(
+        "please use memory",
+        session_id="session-1",
+        agent_name="kimi1",
+        workspace_path="/repo",
+    )
+
+    assert "UserPromptSubmit hook (completed)" in recall.context
+    assert "hook context:   <hindsight_memories>" in recall.context
+    assert "visible memory" in recall.context
+    assert recall.diagnostics["show_hook_context"] is True

--- a/test/test_native_cli_completion.py
+++ b/test/test_native_cli_completion.py
@@ -13,14 +13,19 @@ from provider_backends.deepseek.native_log import (
     deepseek_project_root,
     observe_deepseek_session,
 )
-from provider_backends.kimi.execution import KimiProviderAdapter
+from provider_backends.kimi.execution import KimiProviderAdapter, _with_kimi_context_pointer
 from provider_backends.kimi.native_log import kimi_project_hash, kimi_sessions_root, observe_kimi_turn
 from provider_backends.native_cli_support import wrap_native_prompt
 from provider_execution.base import ProviderSubmission
 
 
 class _Backend:
-    pass
+    def __init__(self, text: str = "") -> None:
+        self._text = text
+
+    def get_pane_content(self, pane_id: str, *, lines: int) -> str:
+        del pane_id, lines
+        return self._text
 
 
 def _submission(
@@ -29,8 +34,10 @@ def _submission(
     source_kind: CompletionSourceKind,
     work_dir: Path,
     req_id: str = "job_native123",
+    pane_text: str = "",
     extra_state: dict[str, object] | None = None,
 ) -> ProviderSubmission:
+    backend = _Backend(pane_text)
     return ProviderSubmission(
         job_id=req_id,
         agent_name=f"{provider}1",
@@ -41,7 +48,7 @@ def _submission(
         reply="",
         runtime_state={
             "mode": "native",
-            "backend": _Backend(),
+            "backend": backend,
             "pane_id": "%9",
             "req_id": req_id,
             "request_anchor": req_id,
@@ -123,6 +130,137 @@ def test_kimi_observes_wire_turn_end_and_poll_emits_boundary(monkeypatch, tmp_pa
         CompletionItemKind.ASSISTANT_FINAL,
         CompletionItemKind.TURN_BOUNDARY,
     ]
+
+
+def test_kimi_prompt_includes_context_pointer_when_session_has_projection() -> None:
+    session = type("Session", (), {"data": {"kimi_context_path": "/tmp/CCB_KIMI_CONTEXT.md"}})()
+
+    prompt = _with_kimi_context_pointer("do work", session)
+
+    assert "/tmp/CCB_KIMI_CONTEXT.md" in prompt
+    assert "Kimi does not load local CCB skills directly" in prompt
+    assert prompt.endswith("do work")
+
+
+def test_kimi_poll_uses_k27_pane_fallback_when_wire_log_missing(tmp_path: Path) -> None:
+    work_dir = tmp_path / "project"
+    work_dir.mkdir()
+    pane_text = (
+        "✦ K2.7 Code is ready higher end-to-end coding task success rates\n"
+        "✨ CCB_REQ_ID: job_native123\n"
+        "   Please answer one line.\n"
+        " ● The user wants a one-line response. I should reply exactly that.\n"
+        " ● KIMI_READY_OK after_reload\n"
+        "╭────────────────────────────────────────────────────────╮\n"
+        "│ >                                                      │\n"
+        "╰────────────────────────────────────────────────────────╯\n"
+        "yolo  K2.7 Code thinking  /tmp/project  context: 0.1% (1/262.1k)\n"
+    )
+
+    first = KimiProviderAdapter().poll(
+        _submission(
+            provider="kimi",
+            source_kind=CompletionSourceKind.SESSION_EVENT_LOG,
+            work_dir=work_dir,
+            pane_text=pane_text,
+        ),
+        now="2026-06-13T00:00:05Z",
+    )
+
+    assert first is not None
+    assert first.decision is None
+    assert first.submission.reply == "KIMI_READY_OK after_reload"
+    assert first.submission.runtime_state["pane_fallback_observed"] is True
+    assert [item.kind for item in first.items] == [
+        CompletionItemKind.SESSION_ROTATE,
+        CompletionItemKind.ANCHOR_SEEN,
+        CompletionItemKind.ASSISTANT_FINAL,
+    ]
+
+    stable = KimiProviderAdapter().poll(first.submission, now="2026-06-13T00:00:16Z")
+
+    assert stable is not None
+    assert stable.decision is None
+    assert stable.submission.reply == "KIMI_READY_OK after_reload"
+    assert [item.kind for item in stable.items] == [CompletionItemKind.TURN_BOUNDARY]
+
+
+def test_kimi_pane_fallback_does_not_complete_on_tool_progress(tmp_path: Path) -> None:
+    work_dir = tmp_path / "project"
+    work_dir.mkdir()
+    pane_text = (
+        "✦ K2.7 Code is ready higher end-to-end coding task success rates\n"
+        "✨ CCB_REQ_ID: job_native123\n"
+        "   Please implement a task.\n"
+        " ● Using TodoList (Explore e-contract repo structure and existing HMAC verifier)\n"
+        "  🌔\n"
+        " ● Using Read\n"
+        "  🌕\n"
+        "╭────────────────────────────────────────────────────────╮\n"
+        "│ >                                                      │\n"
+        "╰────────────────────────────────────────────────────────╯\n"
+        "yolo  K2.7 Code thinking  /tmp/project  context: 0.1% (1/262.1k)\n"
+    )
+
+    result = KimiProviderAdapter().poll(
+        _submission(
+            provider="kimi",
+            source_kind=CompletionSourceKind.SESSION_EVENT_LOG,
+            work_dir=work_dir,
+            pane_text=pane_text,
+        ),
+        now="2026-06-13T00:00:05Z",
+    )
+
+    assert result is not None
+    assert result.decision is None
+    assert result.submission.reply == ""
+    assert [item.kind for item in result.items] == [
+        CompletionItemKind.SESSION_ROTATE,
+        CompletionItemKind.ANCHOR_SEEN,
+    ]
+
+
+def test_kimi_pane_fallback_keeps_multibullet_receipt_from_first_answer(tmp_path: Path) -> None:
+    work_dir = tmp_path / "project"
+    work_dir.mkdir()
+    pane_text = (
+        "✦ K2.7 Code is ready higher end-to-end coding task success rates\n"
+        "✨ CCB_REQ_ID: job_native123\n"
+        "   Please resend receipt.\n"
+        " ● User asks to resend receipt, no commands no changes.\n"
+        " ● CCB_REQ_ID: job_native123\n"
+        "\n"
+        "   Implementation Receipt\n"
+        "\n"
+        "   Changed files\n"
+        "\n"
+        "   • src/routes/modules/contract-center-internal-signature-auth.ts\n"
+        "   • src/routes/__tests__/contract-center-internal-signature-auth.spec.ts\n"
+        "\n"
+        "   Not proven / risks\n"
+        "\n"
+        "   • allowlist 配置值按 exact match 处理，含首尾空格会 fail closed。\n"
+        "╭────────────────────────────────────────────────────────╮\n"
+        "│ >                                                      │\n"
+        "╰────────────────────────────────────────────────────────╯\n"
+        "yolo  K2.7 Code thinking  /tmp/project  context: 0.1% (1/262.1k)\n"
+    )
+
+    result = KimiProviderAdapter().poll(
+        _submission(
+            provider="kimi",
+            source_kind=CompletionSourceKind.SESSION_EVENT_LOG,
+            work_dir=work_dir,
+            pane_text=pane_text,
+        ),
+        now="2026-06-13T00:00:05Z",
+    )
+
+    assert result is not None
+    assert result.submission.reply.startswith("CCB_REQ_ID: job_native123")
+    assert "Changed files" in result.submission.reply
+    assert "allowlist 配置值" in result.submission.reply
 
 
 def test_kimi_completed_empty_reply_is_incomplete(monkeypatch, tmp_path: Path) -> None:

--- a/test/test_pane_quiet_support.py
+++ b/test/test_pane_quiet_support.py
@@ -145,6 +145,25 @@ def test_pane_quiet_poll_sends_deferred_kimi_prompt_when_input_ready() -> None:
     assert result.submission.runtime_state["prompt_deferred_until_ready"] is False
 
 
+def test_pane_quiet_poll_sends_deferred_kimi_prompt_with_k27_input_box() -> None:
+    text = (
+        "✦ K2.7 Code is ready higher end-to-end coding task success rates\n"
+        "╭────────────────────────────────────────────────────────╮\n"
+        "│ >                                                      │\n"
+        "╰────────────────────────────────────────────────────────╯\n"
+        "yolo  K2.7 Code thinking  /home/agnitum/o13  context: 0.0% (0/262.1k)\n"
+    )
+    result = poll_submission(_submission(text, prompt_sent=False), now="2026-06-13T00:00:03Z")
+
+    assert result is not None
+    assert result.decision is None
+    backend = result.submission.runtime_state["backend"]
+    assert isinstance(backend, _Backend)
+    assert backend.sent_texts == ["pending prompt"]
+    assert result.submission.runtime_state["prompt_sent"] is True
+    assert result.submission.runtime_state["prompt_deferred_until_ready"] is False
+
+
 def test_pane_quiet_poll_reports_kimi_input_not_ready_timeout() -> None:
     result = poll_submission(_submission("Kimi is booting\n", prompt_sent=False), now="2026-06-13T00:02:00Z")
 

--- a/test/test_provider_hook_settings.py
+++ b/test/test_provider_hook_settings.py
@@ -506,6 +506,73 @@ command = "echo external-hook"
     assert not (workspace / '.codex').exists()
 
 
+def test_prepare_provider_workspace_preserves_allowed_codex_hindsight_hooks(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    project_root = tmp_path / 'repo'
+    workspace = project_root / 'workspace'
+    system_home = tmp_path / 'system-home'
+    system_codex = system_home / '.codex'
+    hindsight_root = system_home / '.hindsight' / 'codex' / 'scripts'
+    system_codex.mkdir(parents=True, exist_ok=True)
+    hindsight_root.mkdir(parents=True, exist_ok=True)
+    (system_codex / 'AGENTS.md').write_text('system codex memory\n', encoding='utf-8')
+    (system_codex / 'config.toml').write_text('model = "gpt-test"\n', encoding='utf-8')
+    (system_codex / 'hooks.json').write_text(
+        json.dumps(
+            {
+                'hooks': {
+                    'SessionStart': [
+                        {'hooks': [{'type': 'command', 'command': f'python3 "{hindsight_root / "session_start.py"}"', 'timeout': 5}]}
+                    ],
+                    'UserPromptSubmit': [
+                        {'hooks': [{'type': 'command', 'command': f'python3 "{hindsight_root / "recall.py"}"', 'timeout': 12}]}
+                    ],
+                    'Stop': [
+                        {'hooks': [{'type': 'command', 'command': f'python3 "{hindsight_root / "retain.py"}"', 'timeout': 30}]}
+                    ],
+                    'PostToolUse': [
+                        {'hooks': [{'type': 'command', 'command': 'echo unmanaged-root-hook'}]}
+                    ],
+                }
+            },
+            indent=2,
+        ),
+        encoding='utf-8',
+    )
+    project_root.mkdir(parents=True, exist_ok=True)
+    _write_project_memory(project_root, 'shared ccb memory\n')
+    monkeypatch.setenv('CODEX_HOME', str(system_codex))
+    layout = PathLayout(project_root)
+    runtime_dir = layout.agent_provider_runtime_dir('agent1', 'codex')
+
+    prepare_provider_workspace(
+        layout=layout,
+        spec=_spec('agent1', provider='codex'),
+        workspace_path=workspace,
+        completion_dir=runtime_dir / 'completion',
+        agent_name='agent1',
+        refresh_profile=True,
+    )
+
+    codex_home = project_root / '.ccb' / 'agents' / 'agent1' / 'provider-state' / 'codex' / 'home'
+    hooks_payload = json.loads((codex_home / 'hooks.json').read_text(encoding='utf-8'))
+    user_prompt_commands = [
+        hook['command']
+        for group in hooks_payload['hooks']['UserPromptSubmit']
+        for hook in group['hooks']
+    ]
+    assert any('ccb-provider-activity-hook' in command for command in user_prompt_commands)
+    assert any('.hindsight/codex/scripts/recall.py' in command for command in user_prompt_commands)
+    assert not any('unmanaged-root-hook' in command for commands in hooks_payload['hooks'].values() for group in commands for command in [group['hooks'][0]['command']])
+
+    config = tomllib.loads((codex_home / 'config.toml').read_text(encoding='utf-8'))
+    state = config['hooks']['state']
+    assert any(key.endswith(':user_prompt_submit:1:0') for key in state)
+    assert len(state) == 9
+
+
 def test_prepare_provider_workspace_respects_codex_explicit_runtime_home(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
Reapply the useful parts of the local 4e34125 repair commit onto a fresh agnitum2009/claude_codex_bridge main clone, keeping GitHub main as the authority instead of replaying the broad local snapshot.

Constraint: direct cherry-pick conflicted with release v7.5.1 README, package, provider, and plan changes already present on origin/main.

Rejected: force-applying the old snapshot commit | would overwrite newer GitHub main content and reintroduce broad unrelated churn.

Rejected: committing runtime/cache state | /home/agnitum/ccb-git stays source-only for this port.

Confidence: high

Scope-risk: moderate

Directive: Restart CCB after installing this source so running daemons reload Codex hook inheritance and Kimi pane fallback code.

Tested: python3 -m py_compile on changed Python entrypoints and tests; pytest test/test_provider_hook_settings.py -k 'hindsight_hooks or codex_activity_hooks_and_trust_state' => 2 passed; pytest test/test_native_cli_providers.py test/test_native_cli_completion.py test/test_pane_quiet_support.py => 30 passed; scripts/hindsight health/version; git diff --check.

Not-tested: full repository pytest suite, cargo tests, npm/package release flow, live CCB daemon restart.