### PR TITLE
[codex] Preserve Claude MCP and plugin overrides

### DIFF
--- a/lib/provider_backends/claude/launcher_runtime/home.py
+++ b/lib/provider_backends/claude/launcher_runtime/home.py
@@ -29,7 +29,7 @@ from storage.atomic import atomic_write_text
 from ..home_layout import ClaudeHomeLayout, claude_layout_for_home, claude_layout_from_session_data
 from .session_paths import read_session_payload, session_file_for_runtime_dir, state_dir_for_runtime_dir
 
-_CLAUDE_RUNTIME_SETTINGS_KEYS = ('hooks', 'permissions')
+_CLAUDE_RUNTIME_SETTINGS_KEYS = ('enabledPlugins', 'hooks', 'permissions')
 _CLAUDE_CCB_PERMISSION_PREFIX = 'Bash(ccb '
 _CLAUDE_AUTH_ENV_KEYS = ('ANTHROPIC_AUTH_TOKEN',)
 _CLAUDE_API_AUTH_ENV_KEYS = ('ANTHROPIC_API_KEY',)
@@ -809,6 +809,13 @@ def _merge_settings_payload(
     for key in _CLAUDE_RUNTIME_SETTINGS_KEYS:
         value = existing_payload.get(key)
         if value is not None:
+            if key == 'enabledPlugins':
+                enabled_plugins = _merge_enabled_plugins_payload(projected_payload.get('enabledPlugins'), value)
+                if enabled_plugins:
+                    merged[key] = enabled_plugins
+                else:
+                    merged.pop(key, None)
+                continue
             if key == 'hooks':
                 hooks = _merge_hooks_payload(projected_payload.get('hooks'), value)
                 if hooks:
@@ -827,9 +834,21 @@ def _merge_settings_payload(
     return None
 
 
+def _merge_enabled_plugins_payload(projected: object, existing: object) -> dict[str, object]:
+    existing_plugins = _settings_mapping_copy(existing)
+    projected_plugins = _settings_mapping_copy(projected)
+    if not existing_plugins:
+        return projected_plugins
+    if not projected_plugins:
+        return existing_plugins
+    merged = dict(existing_plugins)
+    merged.update(projected_plugins)
+    return merged
+
+
 def _merge_hooks_payload(projected: object, existing: object) -> dict[str, object]:
-    projected_hooks = _hooks_mapping_copy(projected)
-    existing_hooks = _hooks_mapping_copy(existing)
+    projected_hooks = _settings_mapping_copy(projected)
+    existing_hooks = _settings_mapping_copy(existing)
     if not projected_hooks:
         return existing_hooks
     if not existing_hooks:
@@ -859,7 +878,7 @@ def _merge_hooks_payload(projected: object, existing: object) -> dict[str, objec
     return merged
 
 
-def _hooks_mapping_copy(value: object) -> dict[str, object]:
+def _settings_mapping_copy(value: object) -> dict[str, object]:
     return dict(_clone_jsonish(value)) if isinstance(value, dict) else {}
 
 

--- a/lib/provider_backends/claude/launcher_runtime/home.py
+++ b/lib/provider_backends/claude/launcher_runtime/home.py
@@ -494,6 +494,8 @@ def _projected_claude_json_payload(
             workspace_path=workspace_path,
         )
 
+    _merge_profile_mcp_servers(merged, profile=profile)
+
     if not _inherits_auth(profile):
         for key in _CLAUDE_JSON_AUTH_METADATA_KEYS:
             merged.pop(key, None)
@@ -529,6 +531,43 @@ def _project_claude_mcp_config(
         workspace_path=workspace_path,
     )
     _refresh_project_mcp_record(merged, target_key=target_key, selected=selected)
+
+
+def _merge_profile_mcp_servers(merged: dict[str, object], *, profile) -> None:
+    profile_servers = _profile_mcp_servers(profile)
+    if not profile_servers:
+        return
+
+    existing = merged.get('mcpServers')
+    servers = dict(existing) if isinstance(existing, dict) else {}
+    for raw_name, raw_config in profile_servers.items():
+        name = str(raw_name or '').strip()
+        if not name:
+            continue
+        if _mcp_server_disabled(raw_config):
+            servers.pop(name, None)
+            continue
+        payload = _clone_jsonish(raw_config)
+        if not isinstance(payload, dict):
+            continue
+        payload.pop('enabled', None)
+        servers[name] = payload
+
+    if servers:
+        merged['mcpServers'] = servers
+    else:
+        merged.pop('mcpServers', None)
+
+
+def _profile_mcp_servers(profile) -> dict[str, object]:
+    if profile is None:
+        return {}
+    raw = getattr(profile, 'mcp_servers', None)
+    return dict(raw) if isinstance(raw, dict) else {}
+
+
+def _mcp_server_disabled(value: object) -> bool:
+    return isinstance(value, dict) and value.get('enabled') is False
 
 
 def _strip_claude_mcp_config(

--- a/test/test_provider_profiles.py
+++ b/test/test_provider_profiles.py
@@ -2250,6 +2250,49 @@ def test_materialize_claude_home_config_projects_inherited_skills_and_commands(t
     assert (layout.claude_dir / 'commands.ccb-projection.json').is_file()
 
 
+def test_materialize_claude_home_config_merges_profile_mcp_server_overrides(tmp_path: Path) -> None:
+    source_home = tmp_path / 'system-home'
+    target_home = tmp_path / 'managed-home'
+    source_home.mkdir(parents=True, exist_ok=True)
+    (source_home / '.claude.json').write_text(
+        json.dumps(
+            {
+                'mcpServers': {
+                    'agentmemory': {'command': 'agentmemory-old'},
+                    'browser-use': {'command': 'browser-use'},
+                    'playwright': {'command': 'playwright'},
+                },
+            },
+            ensure_ascii=False,
+            indent=2,
+        ),
+        encoding='utf-8',
+    )
+
+    layout = materialize_claude_home_config(
+        target_home,
+        profile=ProviderProfileSpec(
+            inherit_memory=False,
+            mcp_servers={
+                'agentmemory': {'command': 'agentmemory-new', 'env': {'AGENTMEMORY_URL': 'http://localhost:3111'}},
+                'browser-use': {'enabled': False},
+                'codegraph': {'command': 'codegraph-mcp'},
+                'playwright': {'enabled': False},
+            },
+        ),
+        source_home=source_home,
+    )
+
+    payload = json.loads(layout.trust_path.read_text(encoding='utf-8'))
+    servers = payload['mcpServers']
+    assert sorted(servers) == ['agentmemory', 'codegraph']
+    assert servers['agentmemory'] == {
+        'command': 'agentmemory-new',
+        'env': {'AGENTMEMORY_URL': 'http://localhost:3111'},
+    }
+    assert servers['codegraph'] == {'command': 'codegraph-mcp'}
+
+
 def test_materialize_claude_home_config_skips_memory_without_project_context(tmp_path: Path) -> None:
     source_home = tmp_path / 'system-home'
     target_home = tmp_path / 'managed-home'

--- a/test/test_provider_profiles.py
+++ b/test/test_provider_profiles.py
@@ -2566,6 +2566,54 @@ def test_materialize_claude_home_config_preserves_managed_auth_when_source_is_lo
     assert payload['permissions']['allow'] == ['Bash(ls)']
 
 
+def test_materialize_claude_home_config_preserves_existing_enabled_plugins(tmp_path: Path) -> None:
+    source_home = tmp_path / 'system-home'
+    target_home = tmp_path / 'managed-home'
+    source_settings = source_home / '.claude' / 'settings.json'
+    source_settings.parent.mkdir(parents=True, exist_ok=True)
+    source_settings.write_text(
+        json.dumps(
+            {
+                'enabledPlugins': {
+                    'source-plugin@marketplace': True,
+                    'typescript-lsp@claude-plugins-official': False,
+                },
+            },
+            ensure_ascii=False,
+            indent=2,
+        ),
+        encoding='utf-8',
+    )
+    target_settings = target_home / '.claude' / 'settings.json'
+    target_settings.parent.mkdir(parents=True, exist_ok=True)
+    target_settings.write_text(
+        json.dumps(
+            {
+                'enabledPlugins': {
+                    'local-only@marketplace': True,
+                    'typescript-lsp@claude-plugins-official': True,
+                },
+            },
+            ensure_ascii=False,
+            indent=2,
+        ),
+        encoding='utf-8',
+    )
+
+    layout = materialize_claude_home_config(
+        target_home,
+        profile=ProviderProfileSpec(inherit_memory=False),
+        source_home=source_home,
+    )
+
+    payload = json.loads(layout.settings_path.read_text(encoding='utf-8'))
+    assert payload['enabledPlugins'] == {
+        'local-only@marketplace': True,
+        'source-plugin@marketplace': True,
+        'typescript-lsp@claude-plugins-official': False,
+    }
+
+
 def test_materialize_claude_home_config_refreshes_source_auth_over_managed_auth(tmp_path: Path) -> None:
     source_home = tmp_path / 'system-home'
     target_home = tmp_path / 'managed-home'


### PR DESCRIPTION
## Summary
- Allow Claude home materialization to apply per-agent `provider_profile.mcp_servers` overrides after inheriting source `.claude.json` MCP config.
- Support `enabled = false` as a deletion override for inherited Claude MCP servers.
- Preserve existing Claude `enabledPlugins` entries during managed home settings refresh, while letting source settings override same-key plugin states.
- Add regression tests for inherited MCP removal and plugin enablement preservation.

## Why
Claude managed homes inherited root `mcpServers` from the source home, but ignored per-agent provider profiles. That made it hard for CCB operators to disable duplicate raw browser MCPs for selected Claude agents without editing generated runtime state.

Separately, CCB settings projection only carried forward hooks and permissions. A plugin such as `typescript-lsp@claude-plugins-official` could remain present in `installed_plugins.json` and cache, but disappear from `enabledPlugins` after CCB refreshed the managed Claude home, making Claude prompt for reinstall/re-enable.

## Impact
Operators can now use `.ccb/ccb.config` as the durable source for Claude MCP differences, including removing inherited servers such as raw `playwright` while keeping other inherited MCPs. Installed Claude plugins also keep their enablement across managed home refreshes unless the source settings explicitly override that plugin key.

## Checks
- `/root/.venv/bin/python3 -m pytest -q test/test_provider_profiles.py -k 'claude_home_config_merges_profile_mcp_server_overrides or claude_home_config_preserves_existing_enabled_plugins'`\n- `/root/.venv/bin/python3 -m py_compile /root/.local/share/codex-dual/lib/provider_backends/claude/launcher_runtime/home.py /home/agnitum/ccb-git/lib/provider_backends/claude/launcher_runtime/home.py`\n- `git diff --check -- lib/provider_backends/claude/launcher_runtime/home.py test/test_provider_profiles.py`\n\n## Not Included\n- No local `.ccb/ccb.config` changes.\n- No provider runtime home or `/root/.claude` state changes.\n- No full-suite run.