### PR TITLE
feat: backport v8.0.4 Codex bridge transport and diagnostics to Rust

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,6 +71,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "ccb-provider-core"
+version = "7.7.0"
+dependencies = [
+ "libc",
+ "tempfile",
+ "tracing",
+]
+
+[[package]]
+name = "ccb-providers"
+version = "7.7.0"
+dependencies = [
+ "rusqlite",
+ "sha2",
+ "tempfile",
+ "tracing",
+]
+
+[[package]]
 name = "ccb-runtime-accelerator"
 version = "7.7.0"
 dependencies = [
@@ -67,6 +123,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
@@ -115,6 +177,108 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,16 +297,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "proc-macro2"
@@ -160,6 +365,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -206,6 +444,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,6 +484,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,6 +544,18 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "windows-link"
@@ -247,6 +570,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -2,6 +2,8 @@
 resolver = "2"
 members = [
     "crates/ccb-runtime-accelerator",
+    "crates/ccb-provider-core",
+    "crates/ccb-providers",
 ]
 
 [workspace.package]

--- a/rust/crates/ccb-provider-core/Cargo.toml
+++ b/rust/crates/ccb-provider-core/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "ccb-provider-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+libc = "0.2"
+tracing = "0.1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/rust/crates/ccb-provider-core/src/fifo_delivery.rs
+++ b/rust/crates/ccb-provider-core/src/fifo_delivery.rs
@@ -1,0 +1,270 @@
+//! Reliable FIFO delivery and ack/spool helpers.
+//!
+//! Mirrors Python `provider_core.fifo_delivery`:
+//! - non-blocking FIFO writes with retry/backoff
+//! - atomic ack files for read confirmation
+//! - spool files for oversized payloads
+
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+/// Outcome of a send attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeliveryResult {
+    /// Receiver confirmed reading the message (ack file observed).
+    Delivered,
+    /// Written, but no read confirmation arrived in time.
+    Unconfirmed,
+    /// Could not be written at all.
+    Failed,
+}
+
+impl DeliveryResult {
+    pub fn is_failed(self) -> bool {
+        matches!(self, DeliveryResult::Failed)
+    }
+}
+
+/// Atomic FIFO write limit. POSIX guarantees >= 512; Linux/macOS use 4096+.
+pub const PIPE_ATOMIC_LIMIT: usize = 4096;
+
+const RETRY_BACKOFFS: &[f64] = &[0.1, 0.3, 0.9];
+
+/// The message could not be handed to the receiving end.
+#[derive(Debug)]
+pub struct CommDeliveryError(pub String);
+
+impl std::fmt::Display for CommDeliveryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for CommDeliveryError {}
+
+/// Write one newline-terminated line to a FIFO, retrying while the FIFO has no
+/// reader (`ENXIO`). Raises `CommDeliveryError` after exhausting retries.
+pub fn write_fifo_line(
+    fifo_path: &Path,
+    line: &str,
+    backoffs: &[f64],
+) -> Result<(), CommDeliveryError> {
+    let mut data = line.as_bytes().to_vec();
+    if !data.ends_with(b"\n") {
+        data.push(b'\n');
+    }
+    if data.len() > PIPE_ATOMIC_LIMIT {
+        return Err(CommDeliveryError(format!(
+            "line of {} bytes exceeds atomic FIFO write limit ({}); spool the payload and send a pointer instead",
+            data.len(),
+            PIPE_ATOMIC_LIMIT
+        )));
+    }
+
+    let backoffs = if backoffs.is_empty() {
+        RETRY_BACKOFFS
+    } else {
+        backoffs
+    };
+    let attempts = backoffs.len() + 1;
+    let mut last_error = String::new();
+
+    for attempt in 0..attempts {
+        let fd = match open_fifo_write_nonblock(fifo_path) {
+            Ok(fd) => fd,
+            Err(e) if e.raw_os_error() == Some(libc::ENXIO) => {
+                last_error = format!("no reader: {}", e);
+                if attempt < backoffs.len() {
+                    std::thread::sleep(Duration::from_secs_f64(backoffs[attempt]));
+                }
+                continue;
+            }
+            Err(e) => {
+                return Err(CommDeliveryError(format!(
+                    "cannot open {}: {}",
+                    fifo_path.display(),
+                    e
+                )))
+            }
+        };
+
+        let written = unsafe { libc::write(fd, data.as_ptr() as *const libc::c_void, data.len()) };
+        let write_err = if written < 0 {
+            Some(io::Error::last_os_error())
+        } else if written as usize != data.len() {
+            Some(io::Error::other(format!(
+                "partial FIFO write to {}: {}/{}",
+                fifo_path.display(),
+                written,
+                data.len()
+            )))
+        } else {
+            None
+        };
+        unsafe { libc::close(fd) };
+
+        if let Some(e) = write_err {
+            if e.kind() == io::ErrorKind::WouldBlock {
+                last_error = format!("would block: {}", e);
+                if attempt < backoffs.len() {
+                    std::thread::sleep(Duration::from_secs_f64(backoffs[attempt]));
+                }
+                continue;
+            }
+            return Err(CommDeliveryError(format!(
+                "write to {} failed: {}",
+                fifo_path.display(),
+                e
+            )));
+        }
+        return Ok(());
+    }
+
+    Err(CommDeliveryError(format!(
+        "receiver not listening on {} after {} attempts ({})",
+        fifo_path.display(),
+        attempts,
+        last_error
+    )))
+}
+
+fn open_fifo_write_nonblock(path: &Path) -> io::Result<libc::c_int> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let cpath = CString::new(path.as_os_str().as_bytes())
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+    let fd = unsafe { libc::open(cpath.as_ptr(), libc::O_WRONLY | libc::O_NONBLOCK) };
+    if fd < 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(fd)
+    }
+}
+
+/// Path to the ack file for a given marker.
+pub fn ack_file_path(ack_dir: &Path, marker: &str) -> PathBuf {
+    ack_dir.join(format!("{}.ack", marker))
+}
+
+/// Atomically record that a message was read; best-effort, never raises.
+pub fn write_ack(ack_dir: &Path, marker: &str) {
+    let _ = std::fs::create_dir_all(ack_dir);
+    let target = ack_file_path(ack_dir, marker);
+    let tmp = target.with_extension("ack.tmp");
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs_f64();
+    if std::fs::write(&tmp, format!("{}", now)).is_ok() {
+        let _ = std::fs::rename(&tmp, &target);
+    }
+}
+
+/// Poll for the receiver's read confirmation. Returns `true` if the ack file
+/// appears in time. Removes the ack file on success.
+pub fn wait_for_ack(ack_dir: &Path, marker: &str, timeout: Duration) -> bool {
+    let target = ack_file_path(ack_dir, marker);
+    let deadline = Instant::now() + timeout;
+    let mut interval = Duration::from_millis(50);
+    loop {
+        if target.exists() {
+            let _ = std::fs::remove_file(&target);
+            return true;
+        }
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return false;
+        }
+        std::thread::sleep(std::cmp::min(interval, remaining));
+        interval = std::cmp::min(interval.mul_f32(1.5), Duration::from_millis(500));
+    }
+}
+
+/// Drop stale ack files.
+pub fn cleanup_acks(ack_dir: &Path, max_age: Duration) {
+    let Ok(cutoff) = SystemTime::now().duration_since(UNIX_EPOCH) else {
+        return;
+    };
+    let cutoff = cutoff.saturating_sub(max_age).as_secs_f64();
+    let Ok(entries) = ack_dir.read_dir() else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("ack") {
+            continue;
+        }
+        let stale = match std::fs::read_to_string(&path) {
+            Ok(s) => s.trim().parse::<f64>().unwrap_or(f64::MAX) < cutoff,
+            Err(_) => false,
+        };
+        if stale {
+            let _ = std::fs::remove_file(&path);
+        }
+    }
+}
+
+/// Persist an oversized payload and return the spool file path.
+pub fn spool_payload(spool_dir: &Path, marker: &str, payload_json: &str) -> PathBuf {
+    let _ = std::fs::create_dir_all(spool_dir);
+    let target = spool_dir.join(format!("{}.json", marker));
+    let tmp = spool_dir.join(format!("{}.json.tmp", marker));
+    if std::fs::write(&tmp, payload_json).is_ok() {
+        let _ = std::fs::rename(&tmp, &target);
+    }
+    target
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ack_round_trip() {
+        let tmp = std::env::temp_dir().join(format!("ccb-test-ack-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        write_ack(&tmp, "marker-1");
+        assert!(ack_file_path(&tmp, "marker-1").exists());
+        assert!(wait_for_ack(&tmp, "marker-1", Duration::from_secs(1)));
+        assert!(!ack_file_path(&tmp, "marker-1").exists());
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn test_spool_payload() {
+        let tmp = std::env::temp_dir().join(format!("ccb-test-spool-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        let path = spool_payload(&tmp, "m1", r#"{"content":"big"}"#);
+        assert!(path.exists());
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            r#"{"content":"big"}"#
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn test_cleanup_acks() {
+        let tmp = std::env::temp_dir().join(format!("ccb-test-cleanup-ack-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        write_ack(&tmp, "fresh");
+        // Manually create a stale ack with an old timestamp.
+        let stale_path = ack_file_path(&tmp, "stale");
+        std::fs::write(&stale_path, "1.0").unwrap();
+
+        cleanup_acks(&tmp, Duration::from_secs(3600));
+        assert!(!stale_path.exists());
+        assert!(ack_file_path(&tmp, "fresh").exists());
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+}

--- a/rust/crates/ccb-provider-core/src/lib.rs
+++ b/rust/crates/ccb-provider-core/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod fifo_delivery;
+pub mod transport;

--- a/rust/crates/ccb-provider-core/src/transport.rs
+++ b/rust/crates/ccb-provider-core/src/transport.rs
@@ -1,0 +1,316 @@
+//! Cross-platform message transport for provider-daemon communication.
+//!
+//! Mirrors Python `provider_core.transport`:
+//! - POSIX: named pipe (`FifoTransport`) with a persistent reader.
+//! - Windows: atomically-renamed message files in an inbox dir (`SpoolDirTransport`).
+
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use crate::fifo_delivery::write_fifo_line;
+
+/// One-directional line transport between a sender and a single reader.
+pub trait MessageTransport: Send + Sync {
+    /// Deliver one JSON line. Returns `Ok(())` once the bytes are handed to the
+    /// transport, or an error if delivery is impossible.
+    fn send_line(&self, line: &str) -> io::Result<()>;
+
+    /// Wait up to `timeout` for the next line, returning `None` on idle.
+    fn read_line(&mut self, timeout: Duration) -> io::Result<Option<String>>;
+
+    /// Release reader-side resources only. The sender side is stateless.
+    fn close(&mut self) {}
+}
+
+/// POSIX named-pipe transport. The reader holds the FIFO open persistently so
+/// that writers never see a window with no reader (which can cause blocking or
+/// lost messages).
+pub struct FifoTransport {
+    path: PathBuf,
+    reader: Option<PersistentFifoReader>,
+}
+
+impl FifoTransport {
+    pub fn new(fifo_path: impl Into<PathBuf>) -> Self {
+        Self {
+            path: fifo_path.into(),
+            reader: None,
+        }
+    }
+}
+
+impl MessageTransport for FifoTransport {
+    fn send_line(&self, line: &str) -> io::Result<()> {
+        write_fifo_line(&self.path, line, &[]).map_err(|e| io::Error::other(e.to_string()))
+    }
+
+    fn read_line(&mut self, timeout: Duration) -> io::Result<Option<String>> {
+        if self.reader.is_none() {
+            self.reader = Some(PersistentFifoReader::new(&self.path)?);
+        }
+        self.reader.as_mut().unwrap().read_line(timeout)
+    }
+
+    fn close(&mut self) {
+        if let Some(reader) = self.reader.take() {
+            reader.close();
+        }
+    }
+}
+
+/// Windows-style inbox-directory transport. Each message is one file that is
+/// atomically renamed into the inbox; the reader consumes files in sorted
+/// order. This is the fallback on platforms without `os.mkfifo`.
+pub struct SpoolDirTransport {
+    inbox: PathBuf,
+}
+
+impl SpoolDirTransport {
+    pub fn new(inbox_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            inbox: inbox_dir.into(),
+        }
+    }
+}
+
+impl MessageTransport for SpoolDirTransport {
+    fn send_line(&self, line: &str) -> io::Result<()> {
+        use std::fs;
+        use std::sync::atomic::{AtomicU64, Ordering};
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let count = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let pid = std::process::id();
+        let name = format!("{nanos:020}-{pid}-{count:06}");
+
+        fs::create_dir_all(&self.inbox)?;
+        let tmp = self.inbox.join(format!("{name}.msg.tmp"));
+        let final_path = self.inbox.join(format!("{name}.msg"));
+        fs::write(&tmp, line)?;
+        fs::rename(&tmp, final_path)
+    }
+
+    fn read_line(&mut self, timeout: Duration) -> io::Result<Option<String>> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if let Some(line) = next_spool_entry(&self.inbox)? {
+                return Ok(Some(line));
+            }
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return Ok(None);
+            }
+            std::thread::sleep(std::cmp::min(Duration::from_millis(200), remaining));
+        }
+    }
+}
+
+fn next_spool_entry(inbox: &Path) -> io::Result<Option<String>> {
+    let mut entries: Vec<PathBuf> = match std::fs::read_dir(inbox) {
+        Ok(iter) => iter
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("msg"))
+            .collect(),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e),
+    };
+    entries.sort();
+    for path in entries {
+        let line = match std::fs::read_to_string(&path) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        let _ = std::fs::remove_file(&path);
+        return Ok(Some(line));
+    }
+    Ok(None)
+}
+
+/// Holds the FIFO read end open for the lifetime of the transport.
+///
+/// Mirrors Python `provider_backends.codex.bridge_runtime.runtime_io.PersistentFifoReader`.
+pub struct PersistentFifoReader {
+    path: PathBuf,
+    read_fd: Option<libc::c_int>,
+    keepalive_fd: Option<libc::c_int>,
+    buffer: Vec<u8>,
+}
+
+impl PersistentFifoReader {
+    pub fn new(fifo_path: impl Into<PathBuf>) -> io::Result<Self> {
+        Ok(Self {
+            path: fifo_path.into(),
+            read_fd: None,
+            keepalive_fd: None,
+            buffer: Vec::new(),
+        })
+    }
+
+    pub fn read_line(&mut self, timeout: Duration) -> io::Result<Option<String>> {
+        if let Some(line) = pop_line(&mut self.buffer) {
+            return Ok(Some(line));
+        }
+        self.ensure_open()?;
+        let fd = self.read_fd.expect("ensure_open did not set read_fd");
+
+        let mut pollfd = libc::pollfd {
+            fd,
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        let ms = timeout.as_millis().min(i32::MAX as u128) as i32;
+        let ready = unsafe { libc::poll(&mut pollfd, 1, ms) };
+        if ready <= 0 {
+            return Ok(None);
+        }
+
+        let mut chunk = [0u8; 65536];
+        let n = unsafe { libc::read(fd, chunk.as_mut_ptr() as *mut libc::c_void, chunk.len()) };
+        if n < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        if n == 0 {
+            return Ok(None);
+        }
+        self.buffer.extend_from_slice(&chunk[..n as usize]);
+        Ok(pop_line(&mut self.buffer))
+    }
+
+    pub fn close(mut self) {
+        Self::close_internal(&mut self);
+    }
+
+    fn ensure_open(&mut self) -> io::Result<()> {
+        if self.read_fd.is_some() {
+            return Ok(());
+        }
+        if !self.path.exists() {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("FIFO does not exist: {}", self.path.display()),
+            ));
+        }
+
+        let read_fd = unsafe { libc::open(c_str(&self.path), libc::O_RDONLY | libc::O_NONBLOCK) };
+        if read_fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        // Keepalive write end: safe because this process already holds a reader.
+        let keepalive_fd = unsafe { libc::open(c_str(&self.path), libc::O_WRONLY) };
+        if keepalive_fd < 0 {
+            unsafe { libc::close(read_fd) };
+            return Err(io::Error::last_os_error());
+        }
+
+        self.read_fd = Some(read_fd);
+        self.keepalive_fd = Some(keepalive_fd);
+        Ok(())
+    }
+
+    fn close_internal(&mut self) {
+        for attr in [&mut self.read_fd, &mut self.keepalive_fd] {
+            if let Some(fd) = attr.take() {
+                unsafe { libc::close(fd) };
+            }
+        }
+    }
+}
+
+impl Drop for PersistentFifoReader {
+    fn drop(&mut self) {
+        Self::close_internal(self);
+    }
+}
+
+fn pop_line(buffer: &mut Vec<u8>) -> Option<String> {
+    if let Some(pos) = buffer.iter().position(|&b| b == b'\n') {
+        let raw: Vec<u8> = buffer.drain(..=pos).collect();
+        let text = String::from_utf8_lossy(&raw[..raw.len() - 1]);
+        Some(text.into_owned())
+    } else {
+        None
+    }
+}
+
+fn c_str(path: &Path) -> *const libc::c_char {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+    use std::sync::Mutex;
+
+    // Leak a stable C string; this helper is only used for FIFO paths that are
+    // opened once per reader lifetime.
+    static BUF: Mutex<Vec<CString>> = Mutex::new(Vec::new());
+    let cstring = CString::new(path.as_os_str().as_bytes()).unwrap();
+    let ptr = cstring.as_ptr();
+    BUF.lock().unwrap().push(cstring);
+    ptr
+}
+
+/// Map a configured FIFO path to this platform's actual endpoint.
+///
+/// POSIX: the FIFO itself. Windows: an `inbox` directory next to it.
+pub fn endpoint_for_fifo_path(fifo_path: &Path) -> PathBuf {
+    #[cfg(unix)]
+    {
+        fifo_path.to_path_buf()
+    }
+    #[cfg(not(unix))]
+    {
+        fifo_path.parent().unwrap_or(fifo_path).join("inbox")
+    }
+}
+
+/// Sole platform-decision point: FIFO on POSIX, inbox dir on Windows.
+pub fn create_transport(endpoint: &Path) -> Box<dyn MessageTransport> {
+    #[cfg(unix)]
+    {
+        Box::new(FifoTransport::new(endpoint))
+    }
+    #[cfg(not(unix))]
+    {
+        Box::new(SpoolDirTransport::new(endpoint))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_endpoint_for_fifo_path_posix() {
+        let fifo = Path::new("/tmp/ccb/input.fifo");
+        assert_eq!(endpoint_for_fifo_path(fifo), fifo);
+    }
+
+    #[test]
+    fn test_spool_dir_transport_round_trip() {
+        let tmp = std::env::temp_dir().join(format!("ccb-test-spool-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        let sender = SpoolDirTransport::new(&tmp);
+        let mut reader = SpoolDirTransport::new(&tmp);
+
+        sender.send_line("first").unwrap();
+        sender.send_line("second").unwrap();
+
+        assert_eq!(
+            reader.read_line(Duration::from_secs(1)).unwrap(),
+            Some("first".to_string())
+        );
+        assert_eq!(
+            reader.read_line(Duration::from_secs(1)).unwrap(),
+            Some("second".to_string())
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+}

--- a/rust/crates/ccb-providers/Cargo.toml
+++ b/rust/crates/ccb-providers/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "ccb-providers"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+rusqlite = { version = "0.31", features = ["bundled"] }
+sha2 = "0.10"
+tracing = "0.1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/rust/crates/ccb-providers/src/lib.rs
+++ b/rust/crates/ccb-providers/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod providers;

--- a/rust/crates/ccb-providers/src/providers.rs
+++ b/rust/crates/ccb-providers/src/providers.rs
@@ -1,0 +1,1 @@
+pub mod codex;

--- a/rust/crates/ccb-providers/src/providers/codex.rs
+++ b/rust/crates/ccb-providers/src/providers/codex.rs
@@ -1,0 +1,1 @@
+pub mod diagnostics;

--- a/rust/crates/ccb-providers/src/providers/codex/diagnostics.rs
+++ b/rust/crates/ccb-providers/src/providers/codex/diagnostics.rs
@@ -1,0 +1,415 @@
+//! Codex diagnostic-log filter.
+//!
+//! Mirrors Python `provider_backends/codex/launcher_runtime/command_runtime/diagnostics.py`.
+//!
+//! By default Codex writes a large volume of diagnostic rows to
+//! `logs_2.sqlite`. This module installs a SQLite trigger that drops those
+//! rows before they are inserted, and optionally redirects the DB to a temp
+//! location so the user's real Codex home stays small.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use rusqlite::Connection;
+use sha2::Digest;
+use tracing::{debug, trace, warn};
+
+const DB_NAME: &str = "logs_2.sqlite";
+const TRIGGER_NAME: &str = "ccb_drop_diagnostic_logs";
+const TRIGGER_SQL: &str =
+    "CREATE TRIGGER ccb_drop_diagnostic_logs BEFORE INSERT ON logs BEGIN SELECT RAISE(IGNORE); END";
+
+/// True when the user explicitly wants Codex diagnostic logs kept.
+pub fn codex_diagnostic_logs_enabled() -> bool {
+    matches!(
+        std::env::var("CCB_CODEX_DIAGNOSTIC_LOGS")
+            .unwrap_or_default()
+            .trim()
+            .to_lowercase()
+            .as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+/// Ensure the managed Codex diagnostic-log policy is applied.
+///
+/// Returns `true` once the trigger is present and the redirect is in place.
+/// `false` means the DB does not exist yet or is temporarily locked; callers
+/// should retry later.
+pub fn ensure_codex_diagnostic_log_filter(codex_home: &Path, runtime_dir: Option<&Path>) -> bool {
+    if codex_diagnostic_logs_enabled() {
+        return remove_codex_diagnostic_log_filter(codex_home);
+    }
+    let _ = ensure_codex_diagnostic_log_redirect(codex_home, runtime_dir);
+    install_codex_diagnostic_log_filter(codex_home)
+}
+
+/// Install the diagnostic-log drop trigger in `codex_home/logs_2.sqlite`.
+pub fn install_codex_diagnostic_log_filter(codex_home: &Path) -> bool {
+    let db_path = codex_home.join(DB_NAME);
+    if !db_path.is_file() {
+        trace!(path = %db_path.display(), "codex log db does not exist yet");
+        return false;
+    }
+    let conn =
+        match Connection::open_with_flags(&db_path, rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE) {
+            Ok(c) => c,
+            Err(e) => {
+                warn!(error = %e, path = %db_path.display(), "cannot open codex log db");
+                return false;
+            }
+        };
+    install_filter_in_connection(&conn, db_path)
+}
+
+fn install_filter_in_connection(conn: &Connection, db_path: PathBuf) -> bool {
+    if !logs_table_exists(conn) {
+        trace!(path = %db_path.display(), "codex log db has no logs table yet");
+        return false;
+    }
+    let current = trigger_sql(conn);
+    if trigger_sql_matches(current.as_deref()) {
+        debug!(path = %db_path.display(), "codex diagnostic filter already installed");
+        return true;
+    }
+    if let Err(e) = conn.execute(&format!("DROP TRIGGER IF EXISTS {}", TRIGGER_NAME), []) {
+        warn!(error = %e, "failed to drop old diagnostic trigger");
+    }
+    if let Err(e) = conn.execute(TRIGGER_SQL, []) {
+        warn!(error = %e, "failed to install diagnostic trigger");
+        return false;
+    }
+    debug!(path = %db_path.display(), "installed codex diagnostic filter");
+    true
+}
+
+/// Remove the trigger and restore the original DB location.
+pub fn remove_codex_diagnostic_log_filter(codex_home: &Path) -> bool {
+    restore_codex_diagnostic_log_redirect(codex_home);
+    let db_path = codex_home.join(DB_NAME);
+    if !db_path.is_file() {
+        return true;
+    }
+    let Ok(conn) =
+        Connection::open_with_flags(&db_path, rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE)
+    else {
+        return false;
+    };
+    let _ = conn.execute(&format!("DROP TRIGGER IF EXISTS {}", TRIGGER_NAME), []);
+    true
+}
+
+/// Apply the filter using `CODEX_SQLITE_HOME` / `CODEX_HOME` env vars.
+pub fn ensure_codex_diagnostic_log_filter_from_env() -> bool {
+    let Some(home) = codex_home_from_env() else {
+        return false;
+    };
+    let runtime_dir = std::env::var("CODEX_RUNTIME_DIR")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| !p.as_os_str().is_empty());
+    ensure_codex_diagnostic_log_filter(&home, runtime_dir.as_deref())
+}
+
+/// Poll-based installer used by long-lived adapters.
+#[derive(Debug)]
+pub struct CodexDiagnosticLogFilterInstaller {
+    ensured: bool,
+    next_attempt: std::time::Instant,
+    interval: Duration,
+}
+
+impl CodexDiagnosticLogFilterInstaller {
+    pub fn new(interval: Duration) -> Self {
+        Self {
+            ensured: false,
+            next_attempt: std::time::Instant::now(),
+            interval: interval.max(Duration::from_millis(100)),
+        }
+    }
+
+    pub fn maybe_install(&mut self) -> bool {
+        if self.ensured {
+            return true;
+        }
+        let now = std::time::Instant::now();
+        if now < self.next_attempt {
+            return false;
+        }
+        self.next_attempt = now + self.interval;
+        self.ensured = ensure_codex_diagnostic_log_filter_from_env();
+        self.ensured
+    }
+}
+
+impl Default for CodexDiagnosticLogFilterInstaller {
+    fn default() -> Self {
+        Self::new(Duration::from_secs(5))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Redirect logic: symlink the real logs_2.sqlite to a temp location.
+// ---------------------------------------------------------------------------
+
+fn ensure_codex_diagnostic_log_redirect(codex_home: &Path, runtime_dir: Option<&Path>) -> bool {
+    let home = expanduser(codex_home);
+    let _ = fs::create_dir_all(&home);
+    let db_path = home.join(DB_NAME);
+
+    if db_path.is_symlink() {
+        return repair_existing_log_db_symlink(&db_path);
+    }
+
+    // Move away any existing real DB / sidecars before creating the symlink.
+    for sidecar in [format!("{}-wal", DB_NAME), format!("{}-shm", DB_NAME)] {
+        let _ = move_path_to_backup(&home.join(sidecar));
+    }
+    let _ = move_path_to_backup(&db_path);
+
+    let target = diagnostic_log_temp_db_path(&home, runtime_dir);
+    let _ = fs::create_dir_all(target.parent().unwrap_or(&target));
+    match std::os::unix::fs::symlink(&target, &db_path) {
+        Ok(()) => true,
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => db_path.is_symlink(),
+        Err(_) => {
+            restore_diagnostic_log_backups(&home);
+            false
+        }
+    }
+}
+
+fn restore_codex_diagnostic_log_redirect(codex_home: &Path) {
+    let home = expanduser(codex_home);
+    let db_path = home.join(DB_NAME);
+    if !db_path.is_symlink() {
+        return;
+    }
+    let _ = fs::remove_file(&db_path);
+    restore_diagnostic_log_backups(&home);
+}
+
+fn repair_existing_log_db_symlink(db_path: &Path) -> bool {
+    let Some(target) = symlink_target_path(db_path) else {
+        return false;
+    };
+    let _ = fs::create_dir_all(target.parent().unwrap_or(&target));
+    if target.exists() && !target.is_file() {
+        return false;
+    }
+    true
+}
+
+fn diagnostic_log_temp_db_path(codex_home: &Path, runtime_dir: Option<&Path>) -> PathBuf {
+    let root: PathBuf = if let Ok(raw) = std::env::var("CCB_CODEX_LOGS_TMPDIR") {
+        expanduser(Path::new(&raw))
+    } else {
+        let uid = std::process::id();
+        std::env::temp_dir().join(format!("ccb-codex-logs-{uid}"))
+    };
+    let digest_source = format!(
+        "{}\n{}",
+        codex_home
+            .canonicalize()
+            .unwrap_or_else(|_| codex_home.to_path_buf())
+            .display(),
+        runtime_dir
+            .and_then(|p| p.canonicalize().ok())
+            .unwrap_or_else(|| runtime_dir.unwrap_or(Path::new("")).to_path_buf())
+            .display()
+    );
+    let digest = format!("{:x}", sha2::Sha256::digest(digest_source.as_bytes()));
+    root.join(&digest[..16]).join(DB_NAME)
+}
+
+// ---------------------------------------------------------------------------
+// Backup helpers
+// ---------------------------------------------------------------------------
+
+fn move_path_to_backup(path: &Path) -> Option<PathBuf> {
+    if !path.exists() && !path.is_symlink() {
+        return None;
+    }
+    let backup = next_backup_path(path);
+    fs::rename(path, &backup).ok()?;
+    Some(backup)
+}
+
+fn next_backup_path(path: &Path) -> PathBuf {
+    let base = path.with_extension(format!(
+        "{}.bak",
+        path.extension().unwrap_or_default().to_string_lossy()
+    ));
+    if !base.exists() && !base.is_symlink() {
+        return base;
+    }
+    for i in 1..1000 {
+        let candidate = path.with_extension(format!(
+            "{}.bak.{}",
+            path.extension().unwrap_or_default().to_string_lossy(),
+            i
+        ));
+        if !candidate.exists() && !candidate.is_symlink() {
+            return candidate;
+        }
+    }
+    path.with_extension(format!(
+        "{}.bak.{}",
+        path.extension().unwrap_or_default().to_string_lossy(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+    ))
+}
+
+fn restore_diagnostic_log_backups(home: &Path) {
+    let db_path = home.join(DB_NAME);
+    if !db_path.exists() && !db_path.is_symlink() {
+        if let Some(backup) = existing_backup_path(&db_path) {
+            let _ = fs::rename(backup, &db_path);
+        }
+    }
+    for sidecar in [format!("{}-wal", DB_NAME), format!("{}-shm", DB_NAME)] {
+        let sidecar_path = home.join(&sidecar);
+        if !sidecar_path.exists() && !sidecar_path.is_symlink() {
+            if let Some(backup) = existing_backup_path(&sidecar_path) {
+                let _ = fs::rename(backup, &sidecar_path);
+            }
+        }
+    }
+}
+
+fn existing_backup_path(path: &Path) -> Option<PathBuf> {
+    let first = path.with_extension(format!(
+        "{}.bak",
+        path.extension().unwrap_or_default().to_string_lossy()
+    ));
+    if first.exists() || first.is_symlink() {
+        return Some(first);
+    }
+    let mut backups: Vec<_> = path
+        .parent()?
+        .read_dir()
+        .ok()?
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| {
+            let name = p.file_name().and_then(|s| s.to_str()).unwrap_or("");
+            name.starts_with(&format!(
+                "{}.",
+                path.file_name().unwrap_or_default().to_string_lossy()
+            )) && name.contains(".bak")
+        })
+        .collect();
+    backups.sort();
+    backups.into_iter().next()
+}
+
+// ---------------------------------------------------------------------------
+// SQLite introspection
+// ---------------------------------------------------------------------------
+
+fn logs_table_exists(conn: &Connection) -> bool {
+    conn.query_row(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='logs' LIMIT 1",
+        [],
+        |_| Ok(true),
+    )
+    .unwrap_or(false)
+}
+
+fn trigger_sql(conn: &Connection) -> Option<String> {
+    conn.query_row(
+        "SELECT sql FROM sqlite_master WHERE type='trigger' AND name=? LIMIT 1",
+        [TRIGGER_NAME],
+        |row| row.get::<_, String>(0),
+    )
+    .ok()
+}
+
+fn trigger_sql_matches(sql: Option<&str>) -> bool {
+    let Some(sql) = sql else { return false };
+    let normalized = sql
+        .to_lowercase()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    let compact = normalized.replace(' ', "");
+    normalized.contains(&format!("create trigger {}", TRIGGER_NAME))
+        && normalized.contains("before insert on logs")
+        && compact.contains("raise(ignore)")
+}
+
+// ---------------------------------------------------------------------------
+// Path helpers
+// ---------------------------------------------------------------------------
+
+fn codex_home_from_env() -> Option<PathBuf> {
+    for key in ["CODEX_SQLITE_HOME", "CODEX_HOME"] {
+        if let Ok(raw) = std::env::var(key) {
+            let raw = raw.trim();
+            if !raw.is_empty() {
+                return Some(PathBuf::from(raw));
+            }
+        }
+    }
+    None
+}
+
+fn expanduser(path: &Path) -> PathBuf {
+    if let Some(s) = path.to_str() {
+        if let Some(rest) = s.strip_prefix("~/") {
+            return std::env::var_os("HOME")
+                .map(PathBuf::from)
+                .unwrap_or_else(|| PathBuf::from("/"))
+                .join(rest);
+        }
+        if s == "~" {
+            return std::env::var_os("HOME")
+                .map(PathBuf::from)
+                .unwrap_or_else(|| PathBuf::from("/"));
+        }
+    }
+    path.to_path_buf()
+}
+
+fn symlink_target_path(path: &Path) -> Option<PathBuf> {
+    fs::read_link(path).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_trigger_sql_matches() {
+        assert!(trigger_sql_matches(Some(TRIGGER_SQL)));
+        assert!(!trigger_sql_matches(Some(
+            "CREATE TRIGGER other BEFORE INSERT ON logs BEGIN SELECT RAISE(IGNORE); END"
+        )));
+        assert!(!trigger_sql_matches(None));
+    }
+
+    #[test]
+    fn test_install_filter_creates_trigger() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db_path = tmp.path().join(DB_NAME);
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute("CREATE TABLE logs (id INTEGER PRIMARY KEY, msg TEXT)", [])
+            .unwrap();
+        drop(conn);
+
+        assert!(install_codex_diagnostic_log_filter(tmp.path()));
+
+        let conn = Connection::open(&db_path).unwrap();
+        assert!(trigger_sql(&conn).is_some());
+        // Inserting a row should be silently dropped by the trigger.
+        conn.execute("INSERT INTO logs (msg) VALUES ('diagnostic')", [])
+            .unwrap();
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM logs", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+}


### PR DESCRIPTION
Adds two new workspace crates:
- `ccb-provider-core`: FifoTransport, SpoolDirTransport, PersistentFifoReader, and reliable FIFO delivery with ack/spool retries.
- `ccb-providers`: CodexDiagnosticLogFilterInstaller for logs_2.sqlite.

These mirror the Python v8.0.4 provider transport/diagnostics surfaces and are prerequisites for eliminating the per-agent Python `bridge.py` process.

- `cargo test -p ccb-provider-core -p ccb-providers -- --test-threads=1` passes
- `cargo clippy -p ccb-provider-core -p ccb-providers -- -D warnings` passes
- `rustfmt --check` passes