### PR TITLE
feat(completion): split empty reply reason into model_empty_output / delivery_late_empty / api_empty_after_error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+### Empty-Reply Diagnostics Split
+
+- **Completion Reason Disambiguation**: `ProtocolTurnDetector` and
+  `SessionBoundaryDetector` now split the generic
+  `incomplete/task_complete_empty_reply` reason into three explicit cases:
+  - `model_empty_output` — the provider saw the request anchor and returned a
+    turn boundary, but the model produced no assistant text.
+  - `delivery_late_empty` — the turn boundary arrived before the request anchor
+    was observed, indicating the prompt was not delivered or the reader was
+    bound to stale history.
+  - `api_empty_after_error` — the provider reported an API error during the
+    turn and then completed without assistant reply text.
+  Diagnostics include `empty_reply_reason` and a diagnosis tailored to the case.
+- **Codex API-Error Propagation**: the Codex provider now tracks `api_error`
+  events across polls and surfaces `api_error_seen: true` in the
+  `TURN_BOUNDARY` payload, enabling the detector to classify the empty-reply
+  cause correctly.
+
 ## v8.0.7 (2026-06-30)
 
 ### CCB Mobile Notifications And Theme Stabilization

--- a/README.md
+++ b/README.md
@@ -780,6 +780,18 @@ v7 highlights:
 </details>
 
 <details>
+<summary><b>Unreleased</b> - Empty-Reply Diagnostics Split</summary>
+
+- Splits the generic `incomplete/task_complete_empty_reply` completion reason
+  into `model_empty_output`, `delivery_late_empty`, and `api_empty_after_error`
+  so senders can see why the recipient produced no reply.
+- Adds `empty_reply_reason` diagnostics to the empty-reply decision payload.
+- Surfaces `api_error_seen` in Codex `TURN_BOUNDARY` payloads when an `api_error`
+  event is observed during the turn.
+
+</details>
+
+<details>
 <summary><b>v8.0.6</b> - CCB Mobile Real Project Chat Stabilization</summary>
 
 - Improves Android CCB Mobile real-project pane-native chat, status recovery,

--- a/README_zh.md
+++ b/README_zh.md
@@ -752,6 +752,19 @@ v7 线重点：
 </details>
 
 <details>
+<summary><b>Unreleased</b> - 空回复诊断细化</summary>
+
+- 将泛化的 `incomplete/task_complete_empty_reply` 完成原因拆分为
+  `model_empty_output`（模型无输出）、`delivery_late_empty`（未看到请求
+  anchor 就收到 turn boundary，说明 prompt 未投递或 reader 绑定到旧日志）、
+  `api_empty_after_error`（turn 内出现 api_error 后空完成）。
+- 在空回复决策的 diagnostics 中新增 `empty_reply_reason`。
+- Codex provider 在 turn 内观察到 `api_error` 事件时，会在
+  `TURN_BOUNDARY` payload 中带上 `api_error_seen: true`。
+
+</details>
+
+<details>
 <summary><b>v8.0.6</b> - CCB Mobile 真实项目对话稳定性</summary>
 
 - 改进 Android CCB Mobile 真实项目 pane-native 对话、状态恢复、

--- a/lib/completion/detectors/protocol_turn.py
+++ b/lib/completion/detectors/protocol_turn.py
@@ -42,13 +42,14 @@ class ProtocolTurnDetector(BaseCompletionDetector):
         if reply:
             self._record_reply(item, reply, stable=True)
         elif not self._state.reply_started:
+            reason = self._classify_empty_boundary(item)
             self._set_terminal(
                 status=CompletionStatus.INCOMPLETE,
-                reason='task_complete_empty_reply',
+                reason=reason,
                 confidence=CompletionConfidence.EXACT,
                 finished_at=item.timestamp,
                 reply='',
-                diagnostics=self._empty_boundary_diagnostics(item),
+                diagnostics=self._empty_boundary_diagnostics(item, reason=reason),
             )
             return
         self._set_terminal(
@@ -59,18 +60,47 @@ class ProtocolTurnDetector(BaseCompletionDetector):
             reply=reply,
         )
 
-    def _empty_boundary_diagnostics(self, item: CompletionItem) -> dict:
+    def _classify_empty_boundary(self, item: CompletionItem) -> str:
+        if self._api_error_seen(item):
+            return 'api_empty_after_error'
+        if not self._state.anchor_seen:
+            return 'delivery_late_empty'
+        return 'model_empty_output'
+
+    def _api_error_seen(self, item: CompletionItem) -> bool:
+        value = item.payload.get('api_error_seen') or item.payload.get('error_seen')
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.strip().lower() in ('true', '1', 'yes')
+        return False
+
+    def _empty_boundary_diagnostics(self, item: CompletionItem, *, reason: str) -> dict:
         diagnostics = self._terminal_diagnostics_from_item(item)
-        diagnosis = (
-            'Provider protocol reported task_complete without assistant reply text; '
-            'inspect the protocol session log, pane state, and authentication/API output.'
-        )
+        diagnosis = self._empty_boundary_diagnosis(reason)
         diagnostics.setdefault('provider_terminal_reason', first_non_empty(item.payload, 'reason', 'completion_reason') or 'task_complete')
         diagnostics.setdefault('empty_reply', True)
+        diagnostics.setdefault('empty_reply_reason', reason)
         diagnostics.setdefault('error_type', 'empty_provider_reply')
         diagnostics.setdefault('message', diagnosis)
         diagnostics.setdefault('diagnosis', diagnosis)
         return diagnostics
+
+    def _empty_boundary_diagnosis(self, reason: str) -> str:
+        if reason == 'api_empty_after_error':
+            return (
+                'Provider reported an API error during the turn and then completed without assistant reply text; '
+                'inspect the protocol session log and authentication/API output.'
+            )
+        if reason == 'delivery_late_empty':
+            return (
+                'Provider turn boundary arrived before the request anchor was observed; '
+                'the prompt may not have been delivered or the reader was bound to stale history.'
+            )
+        return (
+            'Provider protocol reported task_complete without assistant reply text; '
+            'inspect the protocol session log, pane state, and authentication/API output.'
+        )
 
     def _complete_from_abort(self, item: CompletionItem) -> None:
         reply = first_non_empty(item.payload, 'last_agent_message', 'reply', 'text') or ''

--- a/lib/completion/detectors/session_boundary.py
+++ b/lib/completion/detectors/session_boundary.py
@@ -21,13 +21,14 @@ class SessionBoundaryDetector(BaseCompletionDetector):
             if reply:
                 self._record_reply(item, reply, stable=True)
             elif not self._state.reply_started:
+                reason = self._classify_empty_boundary(item)
                 self._set_terminal(
                     status=CompletionStatus.INCOMPLETE,
-                    reason='task_complete_empty_reply',
+                    reason=reason,
                     confidence=CompletionConfidence.OBSERVED,
                     finished_at=item.timestamp,
                     reply='',
-                    diagnostics=self._empty_boundary_diagnostics(item),
+                    diagnostics=self._empty_boundary_diagnostics(item, reason=reason),
                 )
                 return
             self._set_terminal(
@@ -61,15 +62,44 @@ class SessionBoundaryDetector(BaseCompletionDetector):
 
         self._set_pending()
 
-    def _empty_boundary_diagnostics(self, item: CompletionItem) -> dict:
+    def _classify_empty_boundary(self, item: CompletionItem) -> str:
+        if self._api_error_seen(item):
+            return 'api_empty_after_error'
+        if not self._state.anchor_seen:
+            return 'delivery_late_empty'
+        return 'model_empty_output'
+
+    def _api_error_seen(self, item: CompletionItem) -> bool:
+        value = item.payload.get('api_error_seen') or item.payload.get('error_seen')
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.strip().lower() in ('true', '1', 'yes')
+        return False
+
+    def _empty_boundary_diagnostics(self, item: CompletionItem, *, reason: str) -> dict:
         diagnostics = self._terminal_diagnostics_from_item(item)
-        diagnosis = (
-            'Provider session boundary reported completion without assistant reply text; '
-            'inspect the provider session log, pane state, and authentication/API output.'
-        )
+        diagnosis = self._empty_boundary_diagnosis(reason)
         diagnostics.setdefault('provider_terminal_reason', first_non_empty(item.payload, 'reason', 'completion_reason') or 'turn_duration')
         diagnostics.setdefault('empty_reply', True)
+        diagnostics.setdefault('empty_reply_reason', reason)
         diagnostics.setdefault('error_type', 'empty_provider_reply')
         diagnostics.setdefault('message', diagnosis)
         diagnostics.setdefault('diagnosis', diagnosis)
         return diagnostics
+
+    def _empty_boundary_diagnosis(self, reason: str) -> str:
+        if reason == 'api_empty_after_error':
+            return (
+                'Provider reported an API error during the turn and then completed without assistant reply text; '
+                'inspect the protocol session log and authentication/API output.'
+            )
+        if reason == 'delivery_late_empty':
+            return (
+                'Provider session boundary arrived before the request anchor was observed; '
+                'the prompt may not have been delivered or the reader was bound to stale history.'
+            )
+        return (
+            'Provider session boundary reported completion without assistant reply text; '
+            'inspect the protocol session log, pane state, and authentication/API output.'
+        )

--- a/lib/provider_backends/codex/execution.py
+++ b/lib/provider_backends/codex/execution.py
@@ -69,6 +69,7 @@ class CodexProviderAdapter:
             'last_assistant_message': submission.runtime_state.get('last_assistant_message'),
             'last_assistant_signature': submission.runtime_state.get('last_assistant_signature'),
             'session_path': submission.runtime_state.get('session_path'),
+            'api_error_seen': submission.runtime_state.get('api_error_seen'),
             'workspace_path': submission.runtime_state.get('workspace_path'),
             'delivery_state': submission.runtime_state.get('delivery_state'),
             'delivery_started_at': submission.runtime_state.get('delivery_started_at'),

--- a/lib/provider_backends/codex/execution_runtime/polling_runtime.py
+++ b/lib/provider_backends/codex/execution_runtime/polling_runtime.py
@@ -61,8 +61,20 @@ def process_entry_batch(submission, poll, entries, *, now: str) -> None:
             break
 
 
+def _is_api_error_entry(entry: dict[str, object]) -> bool:
+    if str(entry.get("type") or "").strip().lower() != "event_msg":
+        return False
+    payload = entry.get("payload") or {}
+    if not isinstance(payload, dict):
+        return False
+    return str(payload.get("type") or "").strip().lower() == "api_error"
+
+
 def process_entry(submission, poll, entry, *, now: str) -> None:
     update_binding_refs(poll, entry)
+    if _is_api_error_entry(entry):
+        poll.api_error_seen = True
+        return
     role = str(entry.get("role") or "").strip().lower()
     if role == "user":
         handle_user_entry(submission, poll, text=str(entry.get("text") or ""), now=now)

--- a/lib/provider_backends/codex/execution_runtime/state_machine_runtime/finalization.py
+++ b/lib/provider_backends/codex/execution_runtime/state_machine_runtime/finalization.py
@@ -30,6 +30,7 @@ def finalize_poll_result(
         "last_assistant_message": poll.last_assistant_message,
         "last_assistant_signature": poll.last_assistant_signature,
         "session_path": poll.session_path,
+        "api_error_seen": poll.api_error_seen,
     }
     if poll.anchor_seen and str(runtime_state.get("delivery_state") or "") == "pending_anchor":
         runtime_state["delivery_state"] = "accepted"

--- a/lib/provider_backends/codex/execution_runtime/state_machine_runtime/models.py
+++ b/lib/provider_backends/codex/execution_runtime/state_machine_runtime/models.py
@@ -21,6 +21,7 @@ class CodexPollState:
     last_assistant_message: str
     last_assistant_signature: str
     session_path: str
+    api_error_seen: bool = False
     items: list[CompletionItem] = field(default_factory=list)
     reached_terminal: bool = False
 
@@ -40,6 +41,7 @@ def build_poll_state(submission: ProviderSubmission) -> CodexPollState:
         last_assistant_message=str(submission.runtime_state.get("last_assistant_message") or ""),
         last_assistant_signature=str(submission.runtime_state.get("last_assistant_signature") or ""),
         session_path=str(submission.runtime_state.get("session_path") or ""),
+        api_error_seen=bool(submission.runtime_state.get("api_error_seen", False)),
     )
 
 
@@ -74,6 +76,7 @@ def apply_session_rotation(
     poll.last_final_answer = ""
     poll.last_assistant_message = ""
     poll.last_assistant_signature = ""
+    poll.api_error_seen = False
 
 
 __all__ = [

--- a/lib/provider_backends/codex/execution_runtime/state_machine_runtime/terminal_events_runtime.py
+++ b/lib/provider_backends/codex/execution_runtime/state_machine_runtime/terminal_events_runtime.py
@@ -76,6 +76,7 @@ def task_complete_payload(poll: CodexPollState) -> dict[str, object]:
     payload: dict[str, object] = {
         "reason": "task_complete",
         "last_agent_message": selected_reply(poll),
+        "api_error_seen": poll.api_error_seen,
     }
     add_binding_payload(payload, poll)
     return payload

--- a/test/test_codex_execution_polling.py
+++ b/test/test_codex_execution_polling.py
@@ -4,10 +4,14 @@ from types import SimpleNamespace
 
 from completion.models import CompletionItemKind, CompletionSourceKind
 from provider_backends.codex.execution_runtime.polling import poll_submission
+from provider_backends.codex.execution_runtime.polling_runtime import process_entry
 from provider_backends.codex.execution_runtime.state_machine_runtime import (
     CodexPollState,
     handle_assistant_entry,
     handle_terminal_entry,
+)
+from provider_backends.codex.execution_runtime.state_machine_runtime.terminal_events_runtime import (
+    task_complete_payload,
 )
 from provider_execution.base import ProviderSubmission
 
@@ -149,3 +153,62 @@ def test_handle_terminal_entry_emits_turn_aborted_payload() -> None:
     assert poll.items[0].payload["reason"] == "cancelled"
     assert poll.items[0].payload["status"] == "cancelled"
     assert poll.items[0].payload["error_message"] == "user cancelled"
+
+
+def test_process_entry_records_api_error_seen_before_anchor() -> None:
+    poll = CodexPollState(
+        request_anchor="job_1",
+        next_seq=1,
+        anchor_seen=False,
+        bound_turn_id="",
+        bound_task_id="",
+        reply_buffer="",
+        last_agent_message="",
+        last_final_answer="",
+        last_assistant_message="",
+        last_assistant_signature="",
+        session_path="/tmp/session.jsonl",
+        api_error_seen=False,
+    )
+
+    process_entry(
+        _submission(),
+        poll,
+        {
+            "type": "event_msg",
+            "payload": {"type": "api_error", "message": "rate limit exceeded"},
+        },
+        now="2026-04-06T00:01:00Z",
+    )
+
+    assert poll.api_error_seen is True
+    assert not poll.items
+
+
+def test_task_complete_payload_exposes_api_error_seen() -> None:
+    poll = CodexPollState(
+        request_anchor="job_1",
+        next_seq=1,
+        anchor_seen=True,
+        bound_turn_id="turn-1",
+        bound_task_id="task-1",
+        reply_buffer="",
+        last_agent_message="",
+        last_final_answer="",
+        last_assistant_message="",
+        last_assistant_signature="",
+        session_path="/tmp/session.jsonl",
+        api_error_seen=True,
+    )
+
+    handle_terminal_entry(
+        _submission(),
+        poll,
+        {"payload_type": "task_complete", "last_agent_message": None},
+        now="2026-04-06T00:01:00Z",
+    )
+
+    assert poll.reached_terminal is True
+    assert poll.items[0].kind is CompletionItemKind.TURN_BOUNDARY
+    assert poll.items[0].payload["api_error_seen"] is True
+    assert task_complete_payload(poll)["api_error_seen"] is True

--- a/test/test_v2_completion_detectors.py
+++ b/test/test_v2_completion_detectors.py
@@ -63,7 +63,7 @@ def test_protocol_turn_detector_waits_for_turn_boundary() -> None:
     assert decision.reply == 'done'
 
 
-def test_protocol_turn_detector_marks_empty_task_complete_incomplete() -> None:
+def test_protocol_turn_detector_marks_empty_task_complete_as_model_empty_output() -> None:
     detector = ProtocolTurnDetector()
     detector.bind(_ctx(), _cursor(0))
     detector.ingest(_item(CompletionItemKind.ANCHOR_SEEN, 1, '2026-03-18T00:00:01Z'))
@@ -79,17 +79,59 @@ def test_protocol_turn_detector_marks_empty_task_complete_incomplete() -> None:
     decision = detector.decision()
     assert decision.terminal is True
     assert decision.status is CompletionStatus.INCOMPLETE
-    assert decision.reason == 'task_complete_empty_reply'
+    assert decision.reason == 'model_empty_output'
     assert decision.confidence is CompletionConfidence.EXACT
     assert decision.reply == ''
     assert decision.provider_turn_ref == 'turn-empty'
     assert decision.diagnostics['provider_terminal_reason'] == 'task_complete'
     assert decision.diagnostics['empty_reply'] is True
+    assert decision.diagnostics['empty_reply_reason'] == 'model_empty_output'
     assert decision.diagnostics['error_type'] == 'empty_provider_reply'
     assert 'without assistant reply text' in decision.diagnostics['diagnosis']
 
 
-def test_session_boundary_detector_marks_empty_boundary_incomplete() -> None:
+def test_protocol_turn_detector_marks_empty_boundary_before_anchor_as_delivery_late_empty() -> None:
+    detector = ProtocolTurnDetector()
+    detector.bind(_ctx(), _cursor(0))
+    detector.ingest(
+        _item(
+            CompletionItemKind.TURN_BOUNDARY,
+            1,
+            '2026-03-18T00:00:01Z',
+            {'reason': 'task_complete', 'turn_id': 'turn-empty'},
+        )
+    )
+
+    decision = detector.decision()
+    assert decision.terminal is True
+    assert decision.status is CompletionStatus.INCOMPLETE
+    assert decision.reason == 'delivery_late_empty'
+    assert decision.diagnostics['empty_reply_reason'] == 'delivery_late_empty'
+    assert 'before the request anchor was observed' in decision.diagnostics['diagnosis']
+
+
+def test_protocol_turn_detector_marks_empty_boundary_after_api_error_as_api_empty_after_error() -> None:
+    detector = ProtocolTurnDetector()
+    detector.bind(_ctx(), _cursor(0))
+    detector.ingest(_item(CompletionItemKind.ANCHOR_SEEN, 1, '2026-03-18T00:00:01Z'))
+    detector.ingest(
+        _item(
+            CompletionItemKind.TURN_BOUNDARY,
+            2,
+            '2026-03-18T00:00:02Z',
+            {'reason': 'task_complete', 'turn_id': 'turn-empty', 'api_error_seen': True},
+        )
+    )
+
+    decision = detector.decision()
+    assert decision.terminal is True
+    assert decision.status is CompletionStatus.INCOMPLETE
+    assert decision.reason == 'api_empty_after_error'
+    assert decision.diagnostics['empty_reply_reason'] == 'api_empty_after_error'
+    assert 'API error' in decision.diagnostics['diagnosis']
+
+
+def test_session_boundary_detector_marks_empty_boundary_as_model_empty_output() -> None:
     detector = SessionBoundaryDetector()
     detector.bind(_ctx(), _cursor(0))
     detector.ingest(_item(CompletionItemKind.ANCHOR_SEEN, 1, '2026-03-18T00:00:01Z'))
@@ -105,12 +147,13 @@ def test_session_boundary_detector_marks_empty_boundary_incomplete() -> None:
     decision = detector.decision()
     assert decision.terminal is True
     assert decision.status is CompletionStatus.INCOMPLETE
-    assert decision.reason == 'task_complete_empty_reply'
+    assert decision.reason == 'model_empty_output'
     assert decision.confidence is CompletionConfidence.OBSERVED
     assert decision.reply == ''
     assert decision.provider_turn_ref == 'turn-empty'
     assert decision.diagnostics['provider_terminal_reason'] == 'assistant_end_turn'
     assert decision.diagnostics['empty_reply'] is True
+    assert decision.diagnostics['empty_reply_reason'] == 'model_empty_output'
     assert decision.diagnostics['error_type'] == 'empty_provider_reply'
     assert 'without assistant reply text' in decision.diagnostics['diagnosis']
 

--- a/test/test_v2_completion_tracker.py
+++ b/test/test_v2_completion_tracker.py
@@ -114,9 +114,10 @@ def test_completion_tracker_marks_empty_protocol_boundary_incomplete() -> None:
 
     assert terminal.decision.terminal is True
     assert terminal.decision.status is CompletionStatus.INCOMPLETE
-    assert terminal.decision.reason == 'task_complete_empty_reply'
+    assert terminal.decision.reason == 'delivery_late_empty'
     assert terminal.decision.reply == ''
     assert terminal.decision.diagnostics['empty_reply'] is True
+    assert terminal.decision.diagnostics['empty_reply_reason'] == 'delivery_late_empty'
     assert terminal.decision.diagnostics['error_type'] == 'empty_provider_reply'
 
 


### PR DESCRIPTION
Refines the generic `incomplete/task_complete_empty_reply` completion reason so senders can see why the recipient produced no reply.

- `model_empty_output` — anchor seen, model returned no assistant text.
- `delivery_late_empty` — turn boundary arrived before the request anchor was observed (prompt not delivered or reader bound to stale history).
- `api_empty_after_error` — provider observed an `api_error` event during the turn and then completed empty.

Also surfaces `api_error_seen` in Codex `TURN_BOUNDARY` payloads and adds regression tests for all three cases.