### PR TITLE
fix(kimi): drop K2.7 brand gate in input-ready detection (support Kim…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ GEMINI.md
 openspec
 *.log
 .hippocampus
+.DS_Store

--- a/lib/provider_backends/kimi/execution.py
+++ b/lib/provider_backends/kimi/execution.py
@@ -569,8 +569,8 @@ def _pane_snapshot(backend: object, pane_id: str, *, lines: int) -> str:
 def _pane_ready_for_input(content: str) -> bool:
     text = content or ""
     legacy_ready = "── input" in text and "agent (" in text
-    k27_ready = "│ >" in text and "K2.7 Code" in text and "context:" in text
-    return legacy_ready or k27_ready
+    prompt_ready = "│ >" in text and "context:" in text
+    return legacy_ready or prompt_ready
 
 
 def _observe_kimi_pane_turn(backend: object, pane_id: str, req_id: str) -> KimiTurnObservation | None:
@@ -664,7 +664,7 @@ def _looks_like_kimi_input_box_line(stripped: str) -> bool:
         return True
     if stripped.startswith("│ >"):
         return True
-    return "K2.7 Code" in stripped and "context:" in stripped
+    return "context:" in stripped
 
 
 def _looks_like_kimi_non_answer(text: str) -> bool:

--- a/lib/provider_backends/pane_quiet_support/execution.py
+++ b/lib/provider_backends/pane_quiet_support/execution.py
@@ -433,8 +433,8 @@ def _pane_ready_for_input(content: str, provider: str) -> bool:
         return True
     text = content or ""
     legacy_ready = "── input" in text and "agent (" in text
-    k27_ready = "│ >" in text and "K2.7 Code" in text and "context:" in text
-    return legacy_ready or k27_ready
+    prompt_ready = "│ >" in text and "context:" in text
+    return legacy_ready or prompt_ready
 
 
 def _send_prompt(backend: object, pane_id: str, prompt: str) -> str | None:

--- a/test/test_native_cli_completion.py
+++ b/test/test_native_cli_completion.py
@@ -185,6 +185,44 @@ def test_kimi_poll_uses_k27_pane_fallback_when_wire_log_missing(tmp_path: Path) 
     assert [item.kind for item in stable.items] == [CompletionItemKind.TURN_BOUNDARY]
 
 
+def test_kimi_poll_uses_v0231_pane_fallback_without_k27_brand(tmp_path: Path) -> None:
+    work_dir = tmp_path / "project"
+    work_dir.mkdir()
+    pane_text = (
+        "Welcome to Kimi Code!\n"
+        "Model: Doubao Coder Plus\n"
+        "✨ CCB_REQ_ID: job_native123\n"
+        "   Please answer one line.\n"
+        " ● The user wants a one-line response. I should reply exactly that.\n"
+        " ● KIMI_READY_OK after_reload\n"
+        "╭────────────────────────────────────────────────────────╮\n"
+        "│ >                                                      │\n"
+        "╰────────────────────────────────────────────────────────╯\n"
+        "yolo  Kimi Code thinking  /tmp/project  context: 0.1% (1/262.1k)\n"
+    )
+
+    first = KimiProviderAdapter().poll(
+        _submission(
+            provider="kimi",
+            source_kind=CompletionSourceKind.SESSION_EVENT_LOG,
+            work_dir=work_dir,
+            pane_text=pane_text,
+        ),
+        now="2026-06-13T00:00:05Z",
+    )
+
+    assert first is not None
+    assert first.decision is None
+    assert first.submission.reply == "KIMI_READY_OK after_reload"
+    assert first.submission.runtime_state["pane_fallback_observed"] is True
+
+    stable = KimiProviderAdapter().poll(first.submission, now="2026-06-13T00:00:16Z")
+
+    assert stable is not None
+    assert stable.decision is None
+    assert stable.submission.reply == "KIMI_READY_OK after_reload"
+
+
 def test_kimi_pane_fallback_does_not_complete_on_tool_progress(tmp_path: Path) -> None:
     work_dir = tmp_path / "project"
     work_dir.mkdir()

--- a/test/test_pane_quiet_support.py
+++ b/test/test_pane_quiet_support.py
@@ -164,6 +164,25 @@ def test_pane_quiet_poll_sends_deferred_kimi_prompt_with_k27_input_box() -> None
     assert result.submission.runtime_state["prompt_deferred_until_ready"] is False
 
 
+def test_pane_quiet_poll_sends_deferred_kimi_prompt_with_v0231_input_box() -> None:
+    text = (
+        "Welcome to Kimi Code!\n"
+        "╭────────────────────────────────────────────────────────╮\n"
+        "│ >                                                      │\n"
+        "╰────────────────────────────────────────────────────────╯\n"
+        "yolo  Kimi Code thinking  /tmp/project  context: 0.1% (1/262.1k)\n"
+    )
+    result = poll_submission(_submission(text, prompt_sent=False), now="2026-06-13T00:00:03Z")
+
+    assert result is not None
+    assert result.decision is None
+    backend = result.submission.runtime_state["backend"]
+    assert isinstance(backend, _Backend)
+    assert backend.sent_texts == ["pending prompt"]
+    assert result.submission.runtime_state["prompt_sent"] is True
+    assert result.submission.runtime_state["prompt_deferred_until_ready"] is False
+
+
 def test_pane_quiet_poll_reports_kimi_input_not_ready_timeout() -> None:
     result = poll_submission(_submission("Kimi is booting\n", prompt_sent=False), now="2026-06-13T00:02:00Z")
 


### PR DESCRIPTION
…i Code v0.23.1)

The kimi provider adapter refused to inject prompts into a healthy pane because its readiness gate required the literal string 'K2.7 Code' in the header. Kimi CLI v0.23.1 renamed the banner to 'Welcome to Kimi Code!' / model 'Doubao Coder Plus', so the gate never flipped and every turn ended with kimi_input_not_ready after the 60s timeout.

Drop the brand string from the readiness check in both _pane_ready_for_input variants and in _looks_like_kimi_input_box_line. The remaining structural signals ('| >' input row + 'context:' status row) are stable across versions and match the current CLI. Add v0.23.1 pane fixtures to test/test_pane_quiet_support.py and test/test_native_cli_completion.py; existing K2.7 fixtures still pass, confirming backward compatibility.