### PR TITLE
feat(providers): add grok (xAI grok CLI) as a native_cli provider

### DIFF
--- a/lib/provider_backends/grok/__init__.py
+++ b/lib/provider_backends/grok/__init__.py
@@ -1,0 +1,18 @@
+from provider_core.contracts import ProviderBackend
+
+from .execution import build_execution_adapter
+from .launcher import build_runtime_launcher
+from .manifest import build_manifest
+from .session import build_session_binding
+
+
+def build_backend() -> ProviderBackend:
+    return ProviderBackend(
+        manifest=build_manifest(),
+        execution_adapter=build_execution_adapter(),
+        session_binding=build_session_binding(),
+        runtime_launcher=build_runtime_launcher(),
+    )
+
+
+__all__ = ["build_backend", "build_session_binding"]

--- a/lib/provider_backends/grok/execution.py
+++ b/lib/provider_backends/grok/execution.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from provider_backends.native_cli_support import (
+    NativeCliExecutionConfig,
+    NativeCliExecutionRequest,
+    NativeCliObservation,
+    NativeCliSubprocessAdapter,
+)
+from provider_core.runtime_shared import provider_start_parts
+
+
+def build_execution_adapter() -> NativeCliSubprocessAdapter:
+    return NativeCliSubprocessAdapter(
+        NativeCliExecutionConfig(
+            provider="grok",
+            session_filename=".grok-session",
+            command_builder=_build_command,
+            env_builder=None,
+            observer=observe_grok_output,
+            output_kind="stdout",
+            mode="grok_run",
+            start_failed_reason="grok_run_start_failed",
+            failed_reason="grok_run_failed",
+            empty_reason="grok_empty_reply",
+            run_error_reason="grok_run_error",
+            complete_reason="grok_run_stop",
+            process_exit_complete_reason="grok_run_exit",
+            timeout_reason="grok_run_timeout",
+        )
+    )
+
+
+def _build_command(request: NativeCliExecutionRequest) -> list[str]:
+    # grok headless single-turn: prints one aggregated JSON object to stdout and exits.
+    #   { "text": ..., "stopReason": ..., "sessionId": ..., "requestId": ..., "thought": ... }
+    cmd = [
+        *provider_start_parts("grok"),
+        "-p",
+        request.prompt,
+        "--cwd",
+        str(request.work_dir),
+        "--output-format",
+        "json",
+    ]
+    # Fast-review knob: let the ask/headless path run a lighter model/effort than
+    # the interactive pane's default (grok-4.5 xhigh). E.g. grok-composer-2.5-fast.
+    # session_data wins over env so a future launcher change can make it per-agent;
+    # env (CCB_GROK_MODEL / CCB_GROK_EFFORT) works today. Unset → grok's own default.
+    model = _setting(request, "grok_model", "CCB_GROK_MODEL")
+    if model:
+        cmd += ["-m", model]
+    effort = _setting(request, "grok_effort", "CCB_GROK_EFFORT")
+    if effort:
+        cmd += ["--reasoning-effort", effort]
+    return cmd
+
+
+def _setting(request: NativeCliExecutionRequest, session_key: str, env_key: str) -> str | None:
+    val = str(request.session_data.get(session_key) or "").strip()
+    if val:
+        return val
+    return str(os.environ.get(env_key) or "").strip() or None
+
+
+def observe_grok_output(path: Path) -> NativeCliObservation:
+    if not path or not path.is_file():
+        return NativeCliObservation()
+    try:
+        raw = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        return NativeCliObservation(error=f"read_stdout_failed:{exc}")
+
+    stripped = raw.strip()
+    if not stripped:
+        # Process has not flushed the final JSON object yet; keep waiting.
+        return NativeCliObservation()
+
+    try:
+        obj = json.loads(stripped)
+    except json.JSONDecodeError:
+        # Partial write mid-run, or non-JSON diagnostic noise on stdout.
+        # Return empty so polling keeps waiting for the terminal flush; the
+        # process-exit path decides completion once the file is whole.
+        return NativeCliObservation()
+
+    if not isinstance(obj, dict):
+        return NativeCliObservation()
+
+    text = _coerce_text(obj.get("text")).strip()
+    turn_ref = _first_str(obj, ("requestId", "sessionId"))
+    stop_reason = _coerce_text(obj.get("stopReason")).strip()
+
+    error = ""
+    err_field = obj.get("error")
+    if err_field:
+        error = _coerce_text(err_field).strip() or "grok_error"
+    elif not text and stop_reason and stop_reason.lower() not in {"endturn", "end_turn", "stop", "done"}:
+        # Terminated without a reply for a non-normal reason (e.g. refusal, cap).
+        error = f"grok_stop_{stop_reason.lower()}"
+
+    return NativeCliObservation(
+        text=text,
+        turn_ref=turn_ref,
+        completed_at=None,
+        error=error,
+    )
+
+
+def _coerce_text(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        return "".join(_coerce_text(item) for item in value)
+    if isinstance(value, dict):
+        for key in ("text", "content", "value", "message", "reply", "answer", "output", "response"):
+            nested = value.get(key)
+            text = _coerce_text(nested)
+            if text:
+                return text
+        return ""
+    if value is None:
+        return ""
+    return str(value)
+
+
+def _first_str(obj: dict[str, Any], keys: tuple[str, ...]) -> str | None:
+    for key in keys:
+        raw = obj.get(key)
+        if isinstance(raw, str) and raw.strip():
+            return raw.strip()
+    return None
+
+
+__all__ = ["build_execution_adapter", "observe_grok_output"]

--- a/lib/provider_backends/grok/launcher.py
+++ b/lib/provider_backends/grok/launcher.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from provider_backends.native_cli_support import NativeCliLaunchConfig, build_native_cli_runtime_launcher
+from provider_core.contracts import ProviderRuntimeLauncher
+
+
+def build_runtime_launcher() -> ProviderRuntimeLauncher:
+    # NOTE: home_env is intentionally None. grok reads its auth/config from the
+    # real ~/.grok (auth.json); redirecting HOME into a CCB-managed state dir
+    # would leave the interactive pane unauthenticated.
+    return build_native_cli_runtime_launcher(
+        NativeCliLaunchConfig(
+            provider="grok",
+            home_env=None,
+            visible_args_builder=_grok_visible_args,
+        )
+    )
+
+
+def _grok_visible_args(prepared_state: dict[str, object]) -> tuple[str, ...]:
+    workspace = _path_from_prepared(prepared_state, "workspace_path")
+    return ("--cwd", str(workspace))
+
+
+def _path_from_prepared(prepared_state: dict[str, object], key: str) -> Path:
+    raw = str(prepared_state.get(key) or "").strip()
+    if not raw:
+        raise RuntimeError(f"grok launch requires {key} in prepared_state")
+    return Path(raw).expanduser()
+
+
+__all__ = ["build_runtime_launcher"]

--- a/lib/provider_backends/grok/manifest.py
+++ b/lib/provider_backends/grok/manifest.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from provider_backends.native_cli_support import build_native_cli_manifest
+from provider_core.manifests import ProviderManifest
+
+
+def build_manifest() -> ProviderManifest:
+    return build_native_cli_manifest(provider="grok", supports_subagents=True)
+
+
+__all__ = ["build_manifest"]

--- a/lib/provider_backends/grok/session.py
+++ b/lib/provider_backends/grok/session.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from provider_backends.native_cli_support.session import (
+    build_native_session_binding,
+    compute_session_key,
+    find_project_session_file as _find_project_session_file,
+    load_native_project_session,
+)
+from provider_core.contracts import ProviderSessionBinding
+
+
+def find_project_session_file(work_dir: Path, instance: Optional[str] = None) -> Optional[Path]:
+    return _find_project_session_file(work_dir, provider="grok", session_filename=".grok-session", instance=instance)
+
+
+def load_project_session(work_dir: Path, instance: Optional[str] = None):
+    return load_native_project_session(work_dir, provider="grok", session_filename=".grok-session", instance=instance)
+
+
+def build_session_binding() -> ProviderSessionBinding:
+    return build_native_session_binding(provider="grok", session_filename=".grok-session")
+
+
+__all__ = ["build_session_binding", "compute_session_key", "find_project_session_file", "load_project_session"]

--- a/lib/provider_core/pathing.py
+++ b/lib/provider_core/pathing.py
@@ -22,6 +22,7 @@ PROVIDER_SESSION_FILENAMES = {
     'kiro': '.kiro-session',
     'pi': '.pi-session',
     'zai': '.zai-session',
+    'grok': '.grok-session',
 }
 
 

--- a/lib/provider_core/registry_runtime/builtin_backends.py
+++ b/lib/provider_core/registry_runtime/builtin_backends.py
@@ -17,6 +17,7 @@ OPTIONAL_PROVIDER_NAMES = (
     "kiro",
     "pi",
     "zai",
+    "grok",
 )
 
 
@@ -30,6 +31,7 @@ def build_builtin_backends(*, include_optional: bool = True) -> list[ProviderBac
     from provider_backends.deepseek import build_backend as build_deepseek_backend
     from provider_backends.droid import build_backend as build_droid_backend
     from provider_backends.gemini import build_backend as build_gemini_backend
+    from provider_backends.grok import build_backend as build_grok_backend
     from provider_backends.kiro import build_backend as build_kiro_backend
     from provider_backends.kimi import build_backend as build_kimi_backend
     from provider_backends.mimo import build_backend as build_mimo_backend
@@ -58,6 +60,7 @@ def build_builtin_backends(*, include_optional: bool = True) -> list[ProviderBac
             build_kiro_backend(),
             build_pi_backend(),
             build_zai_backend(),
+            build_grok_backend(),
         ])
     return backends
 

--- a/lib/provider_core/runtime_shared.py
+++ b/lib/provider_core/runtime_shared.py
@@ -21,6 +21,7 @@ _PROVIDER_START_ENV_VARS = {
     'kiro': 'KIRO_START_CMD',
     'pi': 'PI_START_CMD',
     'zai': 'ZAI_START_CMD',
+    'grok': 'GROK_START_CMD',
 }
 
 _PROVIDER_DEFAULT_EXECUTABLES = {
@@ -40,6 +41,7 @@ _PROVIDER_DEFAULT_EXECUTABLES = {
     'kiro': 'kiro-cli',
     'pi': 'pi',
     'zai': 'zai',
+    'grok': 'grok',
 }
 
 PROVIDER_COMMAND_PLACEHOLDER = '{command}'

--- a/lib/provider_core/runtime_specs.py
+++ b/lib/provider_core/runtime_specs.py
@@ -78,6 +78,7 @@ CRUSH_RUNTIME_SPEC = _provider_runtime_spec("crush")
 KIRO_RUNTIME_SPEC = _provider_runtime_spec("kiro")
 PI_RUNTIME_SPEC = _provider_runtime_spec("pi")
 ZAI_RUNTIME_SPEC = _provider_runtime_spec("zai")
+GROK_RUNTIME_SPEC = _provider_runtime_spec("grok")
 
 CODEX_CLIENT_SPEC = _client_spec(
     provider_key="codex",
@@ -147,6 +148,10 @@ ZAI_CLIENT_SPEC = _client_spec(
     provider_key="zai",
     session_filename=".zai-session",
 )
+GROK_CLIENT_SPEC = _client_spec(
+    provider_key="grok",
+    session_filename=".grok-session",
+)
 
 RUNTIME_SPECS_BY_PROVIDER = {
     "codex": CODEX_RUNTIME_SPEC,
@@ -166,6 +171,7 @@ RUNTIME_SPECS_BY_PROVIDER = {
     "kiro": KIRO_RUNTIME_SPEC,
     "pi": PI_RUNTIME_SPEC,
     "zai": ZAI_RUNTIME_SPEC,
+    "grok": GROK_RUNTIME_SPEC,
 }
 
 CLIENT_SPECS_BY_PROVIDER = {
@@ -186,6 +192,7 @@ CLIENT_SPECS_BY_PROVIDER = {
     "kiro": KIRO_CLIENT_SPEC,
     "pi": PI_CLIENT_SPEC,
     "zai": ZAI_CLIENT_SPEC,
+    "grok": GROK_CLIENT_SPEC,
 }
 
 
@@ -228,6 +235,8 @@ __all__ = [
     "DROID_RUNTIME_SPEC",
     "GEMINI_CLIENT_SPEC",
     "GEMINI_RUNTIME_SPEC",
+    "GROK_CLIENT_SPEC",
+    "GROK_RUNTIME_SPEC",
     "KIMI_CLIENT_SPEC",
     "KIMI_RUNTIME_SPEC",
     "KIRO_CLIENT_SPEC",

--- a/test/test_grok_provider.py
+++ b/test/test_grok_provider.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from provider_backends.grok.execution import _build_command, observe_grok_output
+from provider_backends.native_cli_support import NativeCliExecutionRequest
+
+
+class _Job:
+    pass
+
+
+def _req(prompt: str = "review this", work_dir: str = "/tmp/wd", session_data: dict | None = None) -> NativeCliExecutionRequest:
+    return NativeCliExecutionRequest(
+        provider="grok",
+        job=_Job(),
+        work_dir=Path(work_dir),
+        session_data=session_data or {},
+        prompt=prompt,
+        request_anchor="job_grok_1",
+    )
+
+
+def test_grok_command_builds_headless_json_invocation(monkeypatch) -> None:
+    monkeypatch.delenv("CCB_GROK_MODEL", raising=False)
+    monkeypatch.delenv("CCB_GROK_EFFORT", raising=False)
+    cmd = _build_command(_req(prompt="hello", work_dir="/tmp/repo"))
+    assert "-p" in cmd and cmd[cmd.index("-p") + 1] == "hello"
+    assert cmd[cmd.index("--cwd") + 1] == "/tmp/repo"
+    assert cmd[cmd.index("--output-format") + 1] == "json"
+    # No model/effort injected by default -> grok uses its own config default.
+    assert "-m" not in cmd
+    assert "--reasoning-effort" not in cmd
+
+
+def test_grok_command_injects_model_and_effort_from_env(monkeypatch) -> None:
+    monkeypatch.setenv("CCB_GROK_MODEL", "grok-composer-2.5-fast")
+    monkeypatch.setenv("CCB_GROK_EFFORT", "low")
+    cmd = _build_command(_req())
+    assert cmd[cmd.index("-m") + 1] == "grok-composer-2.5-fast"
+    assert cmd[cmd.index("--reasoning-effort") + 1] == "low"
+
+
+def test_grok_command_session_data_overrides_env(monkeypatch) -> None:
+    monkeypatch.setenv("CCB_GROK_MODEL", "grok-composer-2.5-fast")
+    monkeypatch.setenv("CCB_GROK_EFFORT", "low")
+    cmd = _build_command(_req(session_data={"grok_model": "grok-4.5", "grok_effort": "xhigh"}))
+    assert cmd[cmd.index("-m") + 1] == "grok-4.5"
+    assert cmd[cmd.index("--reasoning-effort") + 1] == "xhigh"
+
+
+def test_grok_observer_extracts_text_from_aggregated_json(tmp_path: Path) -> None:
+    out = tmp_path / "grok.out"
+    out.write_text(
+        json.dumps(
+            {
+                "text": "alpha beta gamma",
+                "stopReason": "EndTurn",
+                "sessionId": "ses-1",
+                "requestId": "req-1",
+                "thought": "internal reasoning that must not leak into the reply",
+            }
+        ),
+        encoding="utf-8",
+    )
+    obs = observe_grok_output(out)
+    assert obs.error == ""
+    assert obs.text == "alpha beta gamma"
+    assert obs.turn_ref == "req-1"
+
+
+def test_grok_observer_preserves_multiline_text(tmp_path: Path) -> None:
+    out = tmp_path / "grok.out"
+    out.write_text(
+        json.dumps({"text": "Apple\nBanana\nOrange", "stopReason": "EndTurn", "requestId": "r"}),
+        encoding="utf-8",
+    )
+    obs = observe_grok_output(out)
+    assert obs.text == "Apple\nBanana\nOrange"
+
+
+def test_grok_observer_empty_text_is_not_error(tmp_path: Path) -> None:
+    out = tmp_path / "grok.out"
+    out.write_text(json.dumps({"text": "", "stopReason": "EndTurn", "requestId": "r"}), encoding="utf-8")
+    obs = observe_grok_output(out)
+    assert obs.text == ""
+    assert obs.error == ""
+
+
+def test_grok_observer_partial_json_waits_without_error(tmp_path: Path) -> None:
+    # Mid-flush: the process has not yet written the whole aggregated object.
+    out = tmp_path / "grok.out"
+    out.write_text('{"text": "half', encoding="utf-8")
+    obs = observe_grok_output(out)
+    assert obs.text == ""
+    assert obs.error == ""
+
+
+def test_grok_observer_missing_file_is_empty(tmp_path: Path) -> None:
+    obs = observe_grok_output(tmp_path / "does-not-exist.out")
+    assert obs.text == ""
+    assert obs.error == ""

--- a/test/test_v2_execution_registry.py
+++ b/test/test_v2_execution_registry.py
@@ -24,6 +24,7 @@ def test_execution_registry_can_build_core_only_registry() -> None:
         'kiro',
         'pi',
         'zai',
+        'grok',
     }
     assert registry.get('codex') is not None
     assert registry.get('claude') is not None
@@ -41,4 +42,5 @@ def test_execution_registry_can_build_core_only_registry() -> None:
     assert registry.get('kiro') is None
     assert registry.get('pi') is None
     assert registry.get('zai') is None
+    assert registry.get('grok') is None
     assert registry.get('fake') is None

--- a/test/test_v2_provider_catalog.py
+++ b/test/test_v2_provider_catalog.py
@@ -39,6 +39,7 @@ def test_default_provider_catalog_contains_expected_profiles() -> None:
         'kiro',
         'pi',
         'zai',
+        'grok',
     }
     codex = catalog.resolve_completion_manifest('codex', RuntimeMode.PANE_BACKED)
     assert codex.completion_family is CompletionFamily.PROTOCOL_TURN
@@ -72,7 +73,7 @@ def test_default_provider_catalog_contains_expected_profiles() -> None:
     assert mimo.completion_source_kind is CompletionSourceKind.STRUCTURED_RESULT_STREAM
     assert mimo.supports_observed_completion is True
     assert mimo.supports_anchor_binding is True
-    for provider in ('qwen', 'cursor', 'copilot', 'crush', 'kiro', 'pi', 'zai'):
+    for provider in ('qwen', 'cursor', 'copilot', 'crush', 'kiro', 'pi', 'zai', 'grok'):
         native = catalog.resolve_completion_manifest(provider, RuntimeMode.PANE_BACKED)
         assert native.completion_family is CompletionFamily.STRUCTURED_RESULT
         assert native.completion_source_kind is CompletionSourceKind.STRUCTURED_RESULT_STREAM
@@ -134,4 +135,5 @@ def test_provider_catalog_can_build_core_only_catalog() -> None:
         'kiro',
         'pi',
         'zai',
+        'grok',
     }

--- a/test/test_v2_provider_core_registry.py
+++ b/test/test_v2_provider_core_registry.py
@@ -48,6 +48,7 @@ def test_default_session_binding_map_uses_backend_owned_entries() -> None:
         'kiro',
         'pi',
         'zai',
+        'grok',
     }
     assert bindings['codex'].session_id_attr == 'codex_session_id'
     assert bindings['opencode'].session_path_attr == 'session_file'
@@ -62,6 +63,7 @@ def test_default_session_binding_map_uses_backend_owned_entries() -> None:
     assert bindings['kiro'].session_path_attr == 'kiro_session_path'
     assert bindings['pi'].session_path_attr == 'pi_session_path'
     assert bindings['zai'].session_path_attr == 'zai_session_path'
+    assert bindings['grok'].session_path_attr == 'grok_session_path'
 
 
 def test_default_runtime_launcher_map_uses_backend_owned_entries() -> None:
@@ -84,6 +86,7 @@ def test_default_runtime_launcher_map_uses_backend_owned_entries() -> None:
         'kiro',
         'pi',
         'zai',
+        'grok',
     }
     assert launchers['codex'].launch_mode == 'codex_tmux'
     assert launchers['gemini'].launch_mode == 'simple_tmux'
@@ -98,6 +101,7 @@ def test_default_runtime_launcher_map_uses_backend_owned_entries() -> None:
     assert launchers['kiro'].launch_mode == 'simple_tmux'
     assert launchers['pi'].launch_mode == 'simple_tmux'
     assert launchers['zai'].launch_mode == 'simple_tmux'
+    assert launchers['grok'].launch_mode == 'simple_tmux'
 
 
 def test_session_filename_for_agent_follows_agent_first_naming() -> None:
@@ -114,3 +118,4 @@ def test_session_filename_for_agent_follows_agent_first_naming() -> None:
     assert session_filename_for_agent('kiro', 'kiro1') == '.kiro-kiro1-session'
     assert session_filename_for_agent('pi', 'pi1') == '.pi-pi1-session'
     assert session_filename_for_agent('zai', 'zai1') == '.zai-zai1-session'
+    assert session_filename_for_agent('grok', 'grok1') == '.grok-grok1-session'


### PR DESCRIPTION
Registers the xAI official grok CLI (~/.grok, grok-4.5) as an optional native_cli provider, modeled on the zai backend with three grok-specific differences:

- Auth: launcher uses home_env=None and execution uses env_builder=None so grok reads its credentials from the real ~/.grok/auth.json. Redirecting HOME into a CCB-managed state dir (as HOME-isolated native_cli providers do) would leave grok unauthenticated.
- Observer: grok's `--output-format json` prints a single aggregated object ({text, stopReason, sessionId, requestId, thought}), not the JSONL event stream other native_cli providers emit. observe_grok_output json.loads the whole stdout and extracts `text`.
- Fast-review knob: _build_command injects `-m <model> --reasoning-effort <effort>` from session_data (per-agent) or CCB_GROK_MODEL / CCB_GROK_EFFORT env, falling back to grok's own default when unset. Lets a review agent run e.g. grok-composer-2.5-fast instead of grok-4.5 xhigh.

Registration touches the same points as any other provider: runtime_specs (runtime + client spec), runtime_shared (GROK_START_CMD + default executable), registry_runtime/builtin_backends (OPTIONAL list + import + build), and pathing (PROVIDER_SESSION_FILENAMES — omitting this makes session_filename_for_agent('grok', ...) raise at agent startup).

storage_classification/_NATIVE_CLI_PROVIDERS is intentionally left unchanged: that set classifies HOME-redirected provider state, which does not apply to grok (it owns ~/.grok directly).

Tests: new test_grok_provider.py covers command construction, model/effort injection precedence, and the aggregated-json observer (normal / multiline / empty / partial-flush / missing file). Existing provider-list assertions in test_v2_provider_catalog, test_v2_execution_registry, and test_v2_provider_core_registry are updated to include grok. grok is deliberately NOT added to the test_native_cli_provider_execution parametrize: its single-object json output differs from the shared JSONL stub, so its command and observer are covered directly instead.