### PR TITLE
fix(opencode): stop injecting --continue into managed launches

### DIFF
--- a/lib/provider_backends/opencode/launcher.py
+++ b/lib/provider_backends/opencode/launcher.py
@@ -97,8 +97,6 @@ def build_start_cmd(
         **_opencode_memory_env(_path_or_none(launch_context.get('opencode_config_path')), profile),
     }
     cmd_parts = provider_start_parts('opencode')
-    if command.restore:
-        cmd_parts.append('--continue')
     cmd_parts.extend(spec.startup_args)
     cmd = ' '.join(shlex.quote(str(part)) for part in cmd_parts)
     cmd = apply_provider_command_template(cmd, spec.provider_command_template)

--- a/test/test_native_cli_providers.py
+++ b/test/test_native_cli_providers.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 import shlex
 
+import pytest
+
 from agents.models import (
     AgentSpec,
     PermissionMode,
@@ -18,6 +20,7 @@ from provider_backends.deepseek.launcher import build_start_cmd as build_deepsee
 from provider_backends.kimi.launcher import build_start_cmd as build_kimi_start_cmd
 from provider_backends.kimi.skills import kimi_skill_dirs_for_launch, materialize_kimi_skills
 from provider_backends.mimo.launcher import build_start_cmd as build_mimo_start_cmd
+from provider_backends.opencode.launcher import build_start_cmd as build_opencode_start_cmd
 
 
 def _spec(
@@ -175,6 +178,37 @@ def test_deepseek_start_cmd_supports_env_override_and_template(monkeypatch, tmp_
     cmd = build_deepseek_start_cmd(command, spec, tmp_path / "runtime", "launch-1")
 
     assert cmd.endswith("sandbox=1 /tmp/deepcode --config demo")
+
+
+@pytest.mark.parametrize(
+    ("startup_args", "expected_parts"),
+    [
+        ((), ("opencode",)),
+        (("--session", "ses_x"), ("opencode", "--session", "ses_x")),
+        (("-s", "ses_x"), ("opencode", "-s", "ses_x")),
+    ],
+)
+def test_opencode_start_cmd_preserves_startup_args_without_implicit_restore(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    startup_args: tuple[str, ...],
+    expected_parts: tuple[str, ...],
+) -> None:
+    monkeypatch.delenv("OPENCODE_START_CMD", raising=False)
+    command = ParsedStartCommand(project=None, agent_names=("opencode_agent",), restore=True, auto_permission=False)
+    spec = _spec("opencode_agent", "opencode", startup_args=startup_args)
+
+    cmd = build_opencode_start_cmd(
+        command,
+        spec,
+        tmp_path / "runtime",
+        "launch-1",
+        prepared_state={"project_root": str(tmp_path / "repo")},
+    )
+
+    parts = tuple(shlex.split(cmd.rsplit("; ", 1)[-1]))
+    assert parts == expected_parts
+    assert "--continue" not in parts
 
 
 def test_mimo_start_cmd_uses_managed_home_config_and_env_override(monkeypatch, tmp_path: Path) -> None:

--- a/test/test_v2_runtime_launch.py
+++ b/test/test_v2_runtime_launch.py
@@ -1000,7 +1000,7 @@ def test_ensure_agent_runtime_launches_named_opencode_session(monkeypatch, tmp_p
         runtime_dir=ctx.paths.agent_dir('builder') / 'provider-runtime' / 'opencode',
         session_id=payload['ccb_session_id'],
     )
-    assert payload['start_cmd'].endswith('opencode --continue')
+    assert payload['start_cmd'].endswith('opencode')
     assert payload['ccb_session_id'].startswith('ccb-builder-')
     assert config_path.is_file()
 
@@ -2517,7 +2517,7 @@ def test_opencode_workspace_preparation_writes_memory_config(tmp_path: Path, mon
     config = json.loads(config_path.read_text(encoding='utf-8'))
     assert f'OPENCODE_CONFIG={shlex.quote(str(config_path))}' in cmd
     assert 'OPENCODE_DISABLE_AUTOUPDATE=true' in cmd
-    assert cmd.endswith('opencode --continue')
+    assert cmd.endswith('opencode')
     assert config['provider'] == 'anthropic'
     assert config['autoupdate'] is False
     assert config['instructions'] == [


### PR DESCRIPTION
## Summary
- Stop auto-injecting `--continue` for OpenCode provider launches.
- Respect configured `startup_args` exactly.

## Why
CCB manages agent/worktree/session routing. OpenCode `--continue` can collapse multi-agent panes into a recent session and cause cross-agent contamination.

## Fix
Remove automatic `--continue` from the OpenCode launcher and cover managed launches with regression tests for empty startup args, `--session ses_x`, and `-s ses_x`.

## Validation
- `python3 -m pytest test/test_native_cli_providers.py::test_opencode_start_cmd_preserves_startup_args_without_implicit_restore test/test_v2_runtime_launch.py::test_ensure_agent_runtime_launches_named_opencode_session test/test_v2_runtime_launch.py::test_opencode_workspace_preparation_writes_memory_config` -> 5 passed
- `python3 -m pytest test/test_native_cli_providers.py test/test_v2_runtime_launch.py` -> 99 passed
- `python3 -m py_compile lib/provider_backends/opencode/launcher.py` -> passed
- Local hotfix validation with four `opencode(worktree)` agents showed `opencode --session <id>` and ask/reply tests completed.

Fixes #246