### PR TITLE
feat(pane-recovery): classify provider auth-revoked crashes with an actionable reason sidecar

### DIFF
--- a/lib/provider_backends/pane_log_support/lifecycle_common.py
+++ b/lib/provider_backends/pane_log_support/lifecycle_common.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import time
 from typing import Callable
 
@@ -7,6 +8,44 @@ from provider_core.tmux_ownership import (
     apply_session_tmux_identity,
     inspect_tmux_pane_ownership,
 )
+
+# Substrings that mark a pane crash as an *unrecoverable* provider auth failure:
+# restarting the pane will not fix it, the provider must be re-authenticated.
+# Matched case-insensitively against the captured crash log. Kept deliberately
+# specific to avoid classifying transient network 401s as auth revocation.
+_AUTH_REVOKED_SIGNATURES = (
+    'refresh token was revoked',
+    'log out and sign in again',
+    'please sign in again',
+    'run `codex login`',
+    'run codex login',
+    'you are not signed in',
+)
+
+_CRASH_REASON_DETAIL = {
+    'provider_auth_revoked': (
+        'Provider authentication was revoked or expired; the captured crash log '
+        'matched a re-authentication signature. Restarting the pane will not fix '
+        'this — re-authenticate the provider (e.g. run `codex login`) and remount.'
+    ),
+}
+
+
+def classify_crash_reason(text: str) -> str | None:
+    """Classify a captured pane crash log against known unrecoverable conditions.
+
+    Returns a short reason code (currently only ``'provider_auth_revoked'``) when
+    the crash is caused by a provider auth failure that a pane restart cannot
+    recover, otherwise ``None``. Pure and side-effect free so it can be unit
+    tested without a live pane.
+    """
+    if not text:
+        return None
+    haystack = text.lower()
+    for signature in _AUTH_REVOKED_SIGNATURES:
+        if signature in haystack:
+            return 'provider_auth_revoked'
+    return None
 
 
 def attach_pane_log(session, backend: object, pane_id: str) -> None:
@@ -40,17 +79,61 @@ def activate_rebound_pane(
     attach_pane_log_fn(session, backend, pane_id)
 
 
-def persist_crash_log(session, backend: object, pane_id: str) -> None:
+def persist_crash_log(session, backend: object, pane_id: str) -> str | None:
     saver = getattr(backend, 'save_crash_log', None)
     if not callable(saver):
-        return
+        return None
     try:
         runtime = session.runtime_dir
         runtime.mkdir(parents=True, exist_ok=True)
-        crash_log = runtime / f'pane-crash-{int(time.time())}.log'
+        ts = int(time.time())
+        crash_log = runtime / f'pane-crash-{ts}.log'
         saver(pane_id, str(crash_log), lines=1000)
+        return _persist_crash_reason(runtime, crash_log, ts)
+    except Exception:
+        return None
+
+
+def _persist_crash_reason(runtime, crash_log, ts: int) -> str | None:
+    """Classify the freshly captured crash log and, when it matches a known
+    unrecoverable condition, drop an actionable ``pane-crash-<ts>.reason.json``
+    sidecar next to it. Returns the reason code, or ``None`` when unclassified.
+
+    Best-effort: any failure here must not disrupt crash-log capture or the
+    downstream pane respawn, so all errors are swallowed.
+    """
+    try:
+        text = crash_log.read_text(encoding='utf-8', errors='ignore')
+    except Exception:
+        return None
+    reason = classify_crash_reason(text)
+    if reason is None:
+        return None
+    payload = {
+        'schema_version': 1,
+        'record_type': 'pane_crash_reason',
+        'reason': reason,
+        'detail': _CRASH_REASON_DETAIL.get(reason, ''),
+        'matched_signature': _matched_signature(text),
+        'crash_log': crash_log.name,
+        'detected_at': ts,
+    }
+    try:
+        reason_path = runtime / f'pane-crash-{ts}.reason.json'
+        reason_path.write_text(
+            json.dumps(payload, ensure_ascii=False) + '\n', encoding='utf-8'
+        )
     except Exception:
         pass
+    return reason
+
+
+def _matched_signature(text: str) -> str | None:
+    haystack = text.lower()
+    for signature in _AUTH_REVOKED_SIGNATURES:
+        if signature in haystack:
+            return signature
+    return None
 
 
 def pane_exists(backend: object, pane_id: str) -> bool:
@@ -80,6 +163,7 @@ __all__ = [
     'activate_rebound_pane',
     'attach_pane_log',
     'bind_session_to_pane',
+    'classify_crash_reason',
     'live_owned_pane',
     'pane_exists',
     'persist_crash_log',

--- a/test/test_pane_crash_reason.py
+++ b/test/test_pane_crash_reason.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from provider_backends.pane_log_support.lifecycle_common import (
+    classify_crash_reason,
+    persist_crash_log,
+)
+
+# Real captured text from a codex pane whose isolated OAuth refresh token was
+# revoked after a token rotation (the crash that surfaces to the user as a
+# generic "stale" pane).
+_REVOKED_CRASH = (
+    "• Ran sqlite3 -json ingest/index.db ...\n"
+    "■ Your access token could not be refreshed because your refresh token was "
+    "revoked. Please log out and sign in again.\n"
+)
+
+
+def test_classify_detects_revoked_refresh_token() -> None:
+    assert classify_crash_reason(_REVOKED_CRASH) == 'provider_auth_revoked'
+
+
+def test_classify_is_case_insensitive() -> None:
+    assert classify_crash_reason('REFRESH TOKEN WAS REVOKED') == 'provider_auth_revoked'
+
+
+def test_classify_ignores_ordinary_crash_and_empty() -> None:
+    assert classify_crash_reason('') is None
+    assert classify_crash_reason(None) is None  # type: ignore[arg-type]
+    assert classify_crash_reason('Traceback: KeyError foo\nExit code 1\n') is None
+    # A transient network 401 without a re-auth instruction must NOT be classified
+    # as revoked auth, so recovery still restarts the pane.
+    assert classify_crash_reason('HTTP 401 Unauthorized on /v1/models') is None
+
+
+def _fake_backend(captured_text: str) -> object:
+    def save_crash_log(pane_id, path, *, lines):  # noqa: ARG001
+        with open(path, 'w', encoding='utf-8') as handle:
+            handle.write(captured_text)
+
+    return SimpleNamespace(save_crash_log=save_crash_log)
+
+
+def test_persist_crash_log_writes_reason_sidecar_for_revoked_auth(tmp_path) -> None:
+    session = SimpleNamespace(runtime_dir=tmp_path)
+
+    reason = persist_crash_log(session, _fake_backend(_REVOKED_CRASH), '%4')
+
+    assert reason == 'provider_auth_revoked'
+    sidecars = list(tmp_path.glob('pane-crash-*.reason.json'))
+    assert len(sidecars) == 1
+    payload = json.loads(sidecars[0].read_text(encoding='utf-8'))
+    assert payload['reason'] == 'provider_auth_revoked'
+    assert payload['matched_signature'] == 'refresh token was revoked'
+    assert payload['crash_log'].endswith('.log')
+    assert 'codex login' in payload['detail']
+
+
+def test_persist_crash_log_writes_no_sidecar_for_ordinary_crash(tmp_path) -> None:
+    session = SimpleNamespace(runtime_dir=tmp_path)
+
+    reason = persist_crash_log(session, _fake_backend('Segmentation fault\n'), '%4')
+
+    assert reason is None
+    assert list(tmp_path.glob('pane-crash-*.reason.json')) == []
+    # the raw crash log is still captured
+    assert list(tmp_path.glob('pane-crash-*.log'))
+
+
+def test_persist_crash_log_noop_without_saver(tmp_path) -> None:
+    session = SimpleNamespace(runtime_dir=tmp_path)
+    assert persist_crash_log(session, SimpleNamespace(), '%4') is None


### PR DESCRIPTION
## Problem

When a pane-backed provider (e.g. `codex`) crashes because its OAuth **refresh token was revoked**, the recovery path in `respawn_existing_pane` captures the crash transcript via `persist_crash_log` and then immediately respawns the pane. A revoked token cannot be fixed by restarting, so the provider crashes again on the very next request. The user only sees a generic **"stale"** pane with no hint that re-authentication is required, and the pane enters a futile restart loop (I hit this on a long-lived daemon whose isolated codex home held a token that got rotated/revoked elsewhere).

The captured crash log makes the cause obvious, but nothing reads it. Real captured text:

```
■ Your access token could not be refreshed because your refresh token was revoked. Please log out and sign in again.
```

Grepping `lib/` confirms these re-auth signatures are currently unhandled anywhere.

## Change

Classify the freshly captured crash log for known **unrecoverable** re-authentication signatures and, on a match, drop an actionable `pane-crash-<ts>.reason.json` sidecar next to the crash log:

```json
{"schema_version":1,"record_type":"pane_crash_reason","reason":"provider_auth_revoked",
 "detail":"... Restarting the pane will not fix this — re-authenticate the provider (e.g. run `codex login`) and remount.",
 "matched_signature":"refresh token was revoked","crash_log":"pane-crash-<ts>.log","detected_at":<ts>}
```

`persist_crash_log` now **returns** the reason code so a follow-up can suppress the futile restart loop / surface it in status (see the companion issue).

## Why it's low-risk

- `classify_crash_reason` is a **pure, unit-tested** function — no live pane needed.
- Signatures are kept **specific** so a transient network `401` is not misclassified as revoked auth (recovery still restarts the pane in that case).
- Entirely **best-effort and exception-guarded**: classification/sidecar failures never disrupt crash capture or the downstream respawn. Restart behavior is unchanged by this PR.

## Tests

- New `test/test_pane_crash_reason.py` (6 cases: positive/case-insensitive/negative-empty/negative-401/sidecar-written/no-sidecar-for-ordinary/noop-without-saver) — all pass.
- Related existing suites (`test_pane_log_support_session`, `test_pane_log_communicator_state`, `test_ensure_pane_stale`, `test_codex_session_ensure_pane`) — 50 pass, no regression.
