### PR TITLE
修复 Codex 当前插件市场与缓存目录投影

### DIFF
--- a/lib/provider_profiles/codex_home_config.py
+++ b/lib/provider_profiles/codex_home_config.py
@@ -219,6 +219,13 @@ def materialize_codex_home_config(
             project_root=project_root,
             shared_cache_root=shared_cache_root,
         )
+        for relative in (Path('.tmp') / 'marketplaces', Path('plugins') / 'cache'):
+            route_projected_tree(
+                source_home / relative,
+                target_home / relative,
+                label=_CODEX_PLUGIN_PROJECTION_LABEL,
+                allow_unmarked_replace=True,
+            )
     memory_result = _materialize_codex_memory(
         source_home,
         target_home,

--- a/test/test_provider_profiles.py
+++ b/test/test_provider_profiles.py
@@ -1532,6 +1532,25 @@ def test_materialize_codex_profile_refreshes_plugin_projection_when_source_chang
     assert not (runtime_home / '.tmp' / 'plugins.sha').exists()
 
 
+def test_materialize_codex_home_projects_current_plugin_layout(tmp_path: Path) -> None:
+    source_home = tmp_path / 'source'
+    target_home = tmp_path / 'target'
+    marketplace_root = source_home / '.tmp' / 'marketplaces'
+    plugin_cache_root = source_home / 'plugins' / 'cache'
+    (marketplace_root / 'demo' / '.agents' / 'plugins').mkdir(parents=True)
+    (plugin_cache_root / 'demo' / 'demo' / '1.0.0' / '.codex-plugin').mkdir(parents=True)
+    (marketplace_root / 'demo' / '.agents' / 'plugins' / 'marketplace.json').write_text('{}\n', encoding='utf-8')
+    (plugin_cache_root / 'demo' / 'demo' / '1.0.0' / '.codex-plugin' / 'plugin.json').write_text(
+        '{}\n',
+        encoding='utf-8',
+    )
+
+    codex_home_config.materialize_codex_home_config(target_home, source_home=source_home)
+
+    assert (target_home / '.tmp' / 'marketplaces').resolve() == marketplace_root.resolve()
+    assert (target_home / 'plugins' / 'cache').resolve() == plugin_cache_root.resolve()
+
+
 def test_materialize_codex_profile_refreshes_plugin_projection_without_sha_marker(tmp_path: Path, monkeypatch) -> None:
     project_root = tmp_path / 'repo'
     source_home = tmp_path / 'system-codex-home'


### PR DESCRIPTION
## 改动摘要

- 在 Codex 启动前，将 `.tmp/marketplaces` 和 `plugins/cache` 投影到受管 Codex Home
- 用受管投影替换上次运行遗留的非受管目录
- 增加 Codex 当前插件目录布局的回归测试

## 现象

- 插件在普通 Codex Home 和 Orca runtime home 中均显示为 `installed, enabled`
- 新启动的 CCB Codex agent 已继承 `[marketplaces.*]` 和 `[plugins.*]` 配置，但启动时缺少第三方技能和 `SessionStart` Hook
- 一次实际复现中，Codex bridge 于 `19:08:56` 启动，`.tmp/marketplaces` 到 `19:09:05` 才出现，`plugins/cache` 到 `19:09:11` 才出现
- 懒加载完成后，`codex plugin list` 最终恢复正常，掩盖了启动阶段的失败，但首次 `SessionStart` Hook 已经错过

## 根因

CCB 继承了插件配置，却只投影旧版 `.tmp/plugins` bundle。当前 Codex 从 `.tmp/marketplaces` 读取第三方 marketplace，并从 `plugins/cache` 读取已安装插件。Codex 虽然能在启动后懒加载补齐这些目录，但此时首次 `SessionStart` Hook 已经错过。

## 结论

这是 CCB managed home 的启动权威目录不完整，不是 Orca worktree 或插件安装失败。`.tmp/marketplaces` 和 `plugins/cache` 必须在 Codex 进程启动前就存在；启动后的懒加载无法补救已经错过的生命周期 Hook。

## 测试

- `pytest -q test/test_provider_profiles.py`：113 项通过