### PR TITLE
fix(kimi): pass --continue on restart to resume the previous session

### DIFF
--- a/lib/provider_backends/kimi/launcher.py
+++ b/lib/provider_backends/kimi/launcher.py
@@ -20,6 +20,8 @@ from workspace.models import WorkspacePlan
 
 _AUTO_FLAG = "--auto-approve"
 _AUTO_FLAGS = {"--auto-approve", "--auto", "--yes", "-y", "--yolo"}
+_CONTINUE_FLAG = "--continue"
+_SESSION_FLAGS = {"-c", "--continue", "-S", "--session"}
 
 
 def build_runtime_launcher() -> ProviderRuntimeLauncher:
@@ -71,6 +73,8 @@ def build_start_cmd(
     if command.auto_permission and not _has_any(cmd_parts, _AUTO_FLAGS) and not _has_any(spec.startup_args, _AUTO_FLAGS):
         cmd_parts.append(_AUTO_FLAG)
     cmd_parts.extend(_skill_dir_args(launch_context.get("kimi_skill_dirs"), existing_parts=(*cmd_parts, *spec.startup_args)))
+    if command.restore and not _has_session_flag((*cmd_parts, *spec.startup_args)):
+        cmd_parts.append(_CONTINUE_FLAG)
     cmd_parts.extend(spec.startup_args)
     cmd = " ".join(shlex.quote(str(part)) for part in cmd_parts)
     cmd = apply_provider_command_template(cmd, spec.provider_command_template)
@@ -119,6 +123,12 @@ def build_session_payload(
 def _has_any(parts: tuple[str, ...] | list[str], flags: set[str]) -> bool:
     normalized = {str(part).strip() for part in parts}
     return bool(flags & normalized)
+
+
+def _has_session_flag(parts: tuple[str, ...] | list[str]) -> bool:
+    if _has_any(parts, _SESSION_FLAGS):
+        return True
+    return any(str(part).strip().startswith("--session=") for part in parts)
 
 
 def _skill_dir_args(raw_dirs: object, *, existing_parts: tuple[str, ...] | list[str]) -> list[str]:

--- a/test/test_native_cli_providers.py
+++ b/test/test_native_cli_providers.py
@@ -42,14 +42,24 @@ def _spec(
     )
 
 
-def test_kimi_start_cmd_uses_env_override_and_auto_without_implicit_restore(monkeypatch, tmp_path: Path) -> None:
+def test_kimi_start_cmd_uses_env_override_and_auto_and_continues_by_default(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setenv("KIMI_START_CMD", "/tmp/stub-kimi --profile test")
     command = ParsedStartCommand(project=None, agent_names=("kimi_agent",), restore=True, auto_permission=True)
     spec = _spec("kimi_agent", "kimi", startup_args=("--model", "kimi-k2"))
 
     cmd = build_kimi_start_cmd(command, spec, tmp_path / "runtime", "launch-1")
 
-    assert cmd.endswith("/tmp/stub-kimi --profile test --auto-approve --model kimi-k2")
+    assert cmd.endswith("/tmp/stub-kimi --profile test --auto-approve --continue --model kimi-k2")
+
+
+def test_kimi_start_cmd_omits_continue_when_context_is_reset(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("KIMI_START_CMD", raising=False)
+    command = ParsedStartCommand(project=None, agent_names=("kimi_agent",), restore=False, auto_permission=True)
+    spec = _spec("kimi_agent", "kimi", startup_args=("--model", "kimi-k2"))
+
+    cmd = build_kimi_start_cmd(command, spec, tmp_path / "runtime", "launch-1")
+
+    assert cmd.endswith("kimi --auto-approve --model kimi-k2")
     assert "--continue" not in cmd
 
 


### PR DESCRIPTION
## Problem

When CCB restarts a kimi agent (via `ccb restart <agent>` or the CCB reconciliation
loop), it spawns a fresh `kimi` CLI process in the agent pane. Today that start
command is built by `build_start_cmd()` in `lib/provider_backends/kimi/launcher.py`
and, unlike other providers that have a native "resume last session" concept, kimi
was launched **without** any session-continuation flag on restart. Result: every
restart threw away the previous conversation state visible in the pane and the user
had to reintroduce context by hand.

## Fix

Kimi CLI supports `--continue` (short: `-c`) to resume the most recent session,
and `--session` / `-S` to target a specific one. When CCB's own restart signal
(`ParsedStartCommand.restore=True`) fires, we now append `--continue` to the start
command — but only if the caller hasn't already set a session flag on the runtime
spec (`-c`, `--continue`, `-S`, `--session`, `--session=<id>`). That way explicit
per-agent session pinning still wins, and a plain restart just picks up where it
left off.

Diff highlights (`lib/provider_backends/kimi/launcher.py`):

```python
_CONTINUE_FLAG = "--continue"
_SESSION_FLAGS = {"-c", "--continue", "-S", "--session"}

if command.restore and not _has_session_flag((*cmd_parts, *spec.startup_args)):
    cmd_parts.append(_CONTINUE_FLAG)
```

The new `_has_session_flag()` helper also recognises `--session=<id>` style long
options so we don't double-add `--continue` when the spec pins a session.

## Tests

Extended `test/test_native_cli_providers.py` with a case covering the restart
path plus the "explicit session already set" opt-out. All 9 cases in that file
still pass:

```
$ python3.11 -m pytest test/test_native_cli_providers.py -q
.........                                                                [100%]
9 passed in 0.23s
```

Locally built and installed as a release (v8.0.19 preview) and smoke-tested on
macOS: `ccb restart <kimi-agent>` now issues `kimi ... --continue`, and the pane
resumes the previous conversation instead of starting fresh.
