### PR TITLE
docs: clarify inbound task reply routing

### DIFF
--- a/docs/manuals/user-guide/chapters/05-communication-workflows.tex
+++ b/docs/manuals/user-guide/chapters/05-communication-workflows.tex
@@ -33,6 +33,31 @@ ccb ask --chain archi collect evidence
 
 callback 不是同步等待。CCB 会记录 parent/child 关系，child 完成后把结果作为 continuation 任务送回 parent agent。
 
+\section{Inbound task completion 和 reply routing}
+
+当 agent 正在执行 CCB 投递的 inbound task 时，当前 provider turn 的 final
+就是该 task 的 completion 内容。CCB 会记录 terminal reply，并按原 message
+lineage 投递给 caller。Agent 不应再向 original caller 新开一个普通
+\cmd{ask} 汇报完成；这样会创建第二条任务，而不会终结当前 inbound turn。
+
+result-chain continuation 也遵循同一原则：parent agent 在 continuation 的
+当前 turn 直接给出 final，由 CCB 继续向上游路由。\cmd{--chain} 用于 parent
+确实需要 child 结果才能完成当前任务的场景；\cmd{--silence} 表示成功结果不需
+返回，它不是向 active job 发送 correction 的通道。
+
+当前版本没有 active-job follow-up。执行中的任务需要修正范围时，先取消旧
+job，再用修正后的完整请求重新提交。不要把 correction 作为普通新任务排在同
+一 agent 的 active job 后面。
+
+job 的 \src{completed} 只表示 provider execution 正常结束。它不等同于用户
+或 reviewer 已完成业务验收；业务完成度仍应根据 final 内容、产物和验证证据判
+断。
+
+CCB 在 agent materialization 时把 runtime coordination rules 写入 managed
+\src{AGENTS.md}、\src{CLAUDE.md} 或相应 provider memory。已经启动的 provider
+session 可能缓存旧指令；更新 \src{.ccb/ccb_memory.md} 或升级模板后，应启动新
+session 或重新 materialize，而不要假设现有会话会热加载。
+
 \section{长内容}
 
 长 request：

--- a/inherit_skills/claude_skills/ask/RUNTIME.md
+++ b/inherit_skills/claude_skills/ask/RUNTIME.md
@@ -39,10 +39,17 @@ Before every ask, decide:
 - Plain nested `ask` from an active CCB task is rejected; use `--chain` or `--silence`.
 - In `A --silence -> B`, B still runs an active job. B-to-C depends on whether B needs C's result.
 - In task chains, each needed-result hop uses `--chain`; CCB then propagates continuations.
+- Finish an inbound CCB task in its current turn. CCB routes that turn's terminal
+  result to the caller; do not open a new `ask` to report completion to the
+  original caller.
 - If the current task is a CCB result-chain continuation, answer the current task
   directly with the final result. Do not use `ask`, `--chain`, or
   `--silence` to send that final result to the original caller; CCB routes the
   continuation completion upstream.
+- `--silence` is not an active-job correction channel. Cancel and resubmit an
+  executing task when its scope must change.
+- A `completed` CCB job means provider execution ended normally; it does not by
+  itself prove business acceptance.
 - `ask get`, `pend`, `watch`, and `ping` are diagnostics-only commands for
   explicit debugging requests, not normal ask workflow tools.
 - Do not manually append output-policy text; `ask` injects reply guidance.

--- a/inherit_skills/claude_skills/ask/SKILL.md
+++ b/inherit_skills/claude_skills/ask/SKILL.md
@@ -45,10 +45,17 @@ Before every ask, decide:
 - Plain nested `ask` from an active CCB task is rejected; use `--chain` or `--silence`.
 - In `A --silence -> B`, B still runs an active job. B-to-C depends on whether B needs C's result.
 - In task chains, each needed-result hop uses `--chain`; CCB then propagates continuations.
+- Finish an inbound CCB task in its current turn. CCB routes that turn's terminal
+  result to the caller; do not open a new `ask` to report completion to the
+  original caller.
 - If the current task is a CCB result-chain continuation, answer the current task
   directly with the final result. Do not use `ask`, `--chain`, or
   `--silence` to send that final result to the original caller; CCB routes the
   continuation completion upstream.
+- `--silence` is not an active-job correction channel. Cancel and resubmit an
+  executing task when its scope must change.
+- A `completed` CCB job means provider execution ended normally; it does not by
+  itself prove business acceptance.
 - `ask get`, `pend`, `watch`, and `ping` are diagnostics-only commands for
   explicit debugging requests, not normal ask workflow tools.
 - Do not manually append output-policy text; `ask` injects reply guidance.

--- a/inherit_skills/claude_skills/ask/SKILL.md.powershell
+++ b/inherit_skills/claude_skills/ask/SKILL.md.powershell
@@ -45,10 +45,17 @@ Before every ask, decide:
 - Plain nested `ask` from an active CCB task is rejected; use `--chain` or `--silence`.
 - In `A --silence -> B`, B still runs an active job. B-to-C depends on whether B needs C's result.
 - In task chains, each needed-result hop uses `--chain`; CCB then propagates continuations.
+- Finish an inbound CCB task in its current turn. CCB routes that turn's terminal
+  result to the caller; do not open a new `ask` to report completion to the
+  original caller.
 - If the current task is a CCB result-chain continuation, answer the current task
   directly with the final result. Do not use `ask`, `--chain`, or
   `--silence` to send that final result to the original caller; CCB routes the
   continuation completion upstream.
+- `--silence` is not an active-job correction channel. Cancel and resubmit an
+  executing task when its scope must change.
+- A `completed` CCB job means provider execution ended normally; it does not by
+  itself prove business acceptance.
 - `ask get`, `pend`, `watch`, and `ping` are diagnostics-only commands for
   explicit debugging requests, not normal ask workflow tools.
 - Do not manually append output-policy text; `ask` injects reply guidance.

--- a/inherit_skills/codex_skills/ask/SKILL.md
+++ b/inherit_skills/codex_skills/ask/SKILL.md
@@ -45,10 +45,17 @@ Before every ask, decide:
 - Plain nested `ask` from an active CCB task is rejected; use `--chain` or `--silence`.
 - In `A --silence -> B`, B still runs an active job. B-to-C depends on whether B needs C's result.
 - In task chains, each needed-result hop uses `--chain`; CCB then propagates continuations.
+- Finish an inbound CCB task in its current turn. CCB routes that turn's terminal
+  result to the caller; do not open a new `ask` to report completion to the
+  original caller.
 - If the current task is a CCB result-chain continuation, answer the current task
   directly with the final result. Do not use `ask`, `--chain`, or
   `--silence` to send that final result to the original caller; CCB routes the
   continuation completion upstream.
+- `--silence` is not an active-job correction channel. Cancel and resubmit an
+  executing task when its scope must change.
+- A `completed` CCB job means provider execution ended normally; it does not by
+  itself prove business acceptance.
 - `ask get`, `pend`, `watch`, and `ping` are diagnostics-only commands for
   explicit debugging requests, not normal ask workflow tools.
 - Do not manually append output-policy text; `ask` injects reply guidance.

--- a/inherit_skills/droid_skills/ask.md
+++ b/inherit_skills/droid_skills/ask.md
@@ -38,10 +38,17 @@ Before every ask, decide:
 - Plain nested `ask` from an active CCB task is rejected; use `--chain` or `--silence`.
 - In `A --silence -> B`, B still runs an active job. B-to-C depends on whether B needs C's result.
 - In task chains, each needed-result hop uses `--chain`; CCB then propagates continuations.
+- Finish an inbound CCB task in its current turn. CCB routes that turn's terminal
+  result to the caller; do not open a new `ask` to report completion to the
+  original caller.
 - If the current task is a CCB result-chain continuation, answer the current task
   directly with the final result. Do not use `ask`, `--chain`, or
   `--silence` to send that final result to the original caller; CCB routes the
   continuation completion upstream.
+- `--silence` is not an active-job correction channel. Cancel and resubmit an
+  executing task when its scope must change.
+- A `completed` CCB job means provider execution ended normally; it does not by
+  itself prove business acceptance.
 - `ask get`, `pend`, `watch`, and `ping` are diagnostics-only commands for
   explicit debugging requests, not normal ask workflow tools.
 - Do not manually append output-policy text; `ask` injects reply guidance.

--- a/inherit_skills/droid_skills/ask/SKILL.md
+++ b/inherit_skills/droid_skills/ask/SKILL.md
@@ -45,10 +45,17 @@ Before every ask, decide:
 - Plain nested `ask` from an active CCB task is rejected; use `--chain` or `--silence`.
 - In `A --silence -> B`, B still runs an active job. B-to-C depends on whether B needs C's result.
 - In task chains, each needed-result hop uses `--chain`; CCB then propagates continuations.
+- Finish an inbound CCB task in its current turn. CCB routes that turn's terminal
+  result to the caller; do not open a new `ask` to report completion to the
+  original caller.
 - If the current task is a CCB result-chain continuation, answer the current task
   directly with the final result. Do not use `ask`, `--chain`, or
   `--silence` to send that final result to the original caller; CCB routes the
   continuation completion upstream.
+- `--silence` is not an active-job correction channel. Cancel and resubmit an
+  executing task when its scope must change.
+- A `completed` CCB job means provider execution ended normally; it does not by
+  itself prove business acceptance.
 - `ask get`, `pend`, `watch`, and `ping` are diagnostics-only commands for
   explicit debugging requests, not normal ask workflow tools.
 - Do not manually append output-policy text; `ask` injects reply guidance.

--- a/inherit_skills/gemini_skills/ask/SKILL.md
+++ b/inherit_skills/gemini_skills/ask/SKILL.md
@@ -45,10 +45,17 @@ Before every ask, decide:
 - Plain nested `ask` from an active CCB task is rejected; use `--chain` or `--silence`.
 - In `A --silence -> B`, B still runs an active job. B-to-C depends on whether B needs C's result.
 - In task chains, each needed-result hop uses `--chain`; CCB then propagates continuations.
+- Finish an inbound CCB task in its current turn. CCB routes that turn's terminal
+  result to the caller; do not open a new `ask` to report completion to the
+  original caller.
 - If the current task is a CCB result-chain continuation, answer the current task
   directly with the final result. Do not use `ask`, `--chain`, or
   `--silence` to send that final result to the original caller; CCB routes the
   continuation completion upstream.
+- `--silence` is not an active-job correction channel. Cancel and resubmit an
+  executing task when its scope must change.
+- A `completed` CCB job means provider execution ended normally; it does not by
+  itself prove business acceptance.
 - `ask get`, `pend`, `watch`, and `ping` are diagnostics-only commands for
   explicit debugging requests, not normal ask workflow tools.
 - Do not manually append output-policy text; `ask` injects reply guidance.

--- a/inherit_skills/grok_skills/ask/SKILL.md
+++ b/inherit_skills/grok_skills/ask/SKILL.md
@@ -43,10 +43,17 @@ Before every ask, decide:
 - Plain nested `ask` from an active CCB task is rejected; use `--chain` or `--silence`.
 - In `A --silence -> B`, B still runs an active job. B-to-C depends on whether B needs C's result.
 - In task chains, each needed-result hop uses `--chain`; CCB then propagates continuations.
+- Finish an inbound CCB task in its current turn. CCB routes that turn's terminal
+  result to the caller; do not open a new `ask` to report completion to the
+  original caller.
 - If the current task is a CCB result-chain continuation, answer the current task
   directly with the final result. Do not use `ask`, `--chain`, or
   `--silence` to send that final result to the original caller; CCB routes the
   continuation completion upstream.
+- `--silence` is not an active-job correction channel. Cancel and resubmit an
+  executing task when its scope must change.
+- A `completed` CCB job means provider execution ended normally; it does not by
+  itself prove business acceptance.
 - `ask get`, `pend`, `watch`, and `ping` are diagnostics-only commands for
   explicit debugging requests, not normal ask workflow tools.
 - Do not manually append output-policy text; `ask` injects reply guidance.

--- a/inherit_skills/kimi_skills/ask/SKILL.md
+++ b/inherit_skills/kimi_skills/ask/SKILL.md
@@ -45,10 +45,17 @@ Before every ask, decide:
 - Plain nested `ask` from an active CCB task is rejected; use `--chain` or `--silence`.
 - In `A --silence -> B`, B still runs an active job. B-to-C depends on whether B needs C's result.
 - In task chains, each needed-result hop uses `--chain`; CCB then propagates continuations.
+- Finish an inbound CCB task in its current turn. CCB routes that turn's terminal
+  result to the caller; do not open a new `ask` to report completion to the
+  original caller.
 - If the current task is a CCB result-chain continuation, answer the current task
   directly with the final result. Do not use `ask`, `--chain`, or
   `--silence` to send that final result to the original caller; CCB routes the
   continuation completion upstream.
+- `--silence` is not an active-job correction channel. Cancel and resubmit an
+  executing task when its scope must change.
+- A `completed` CCB job means provider execution ended normally; it does not by
+  itself prove business acceptance.
 - `ask get`, `pend`, `watch`, and `ping` are diagnostics-only commands for
   explicit debugging requests, not normal ask workflow tools.
 - Do not manually append output-policy text; `ask` injects reply guidance.

--- a/inherit_skills/mimo_skills/ask.md
+++ b/inherit_skills/mimo_skills/ask.md
@@ -40,10 +40,17 @@ Before every ask, decide:
 - Plain nested `ask` from an active CCB task is rejected; use `--chain` or `--silence`.
 - In `A --silence -> B`, B still runs an active job. B-to-C depends on whether B needs C's result.
 - In task chains, each needed-result hop uses `--chain`; CCB then propagates continuations.
+- Finish an inbound CCB task in its current turn. CCB routes that turn's terminal
+  result to the caller; do not open a new `ask` to report completion to the
+  original caller.
 - If the current task is a CCB result-chain continuation, answer the current task
   directly with the final result. Do not use `ask`, `--chain`, or
   `--silence` to send that final result to the original caller; CCB routes the
   continuation completion upstream.
+- `--silence` is not an active-job correction channel. Cancel and resubmit an
+  executing task when its scope must change.
+- A `completed` CCB job means provider execution ended normally; it does not by
+  itself prove business acceptance.
 - `ask get`, `pend`, `watch`, and `ping` are diagnostics-only commands for
   explicit debugging requests, not normal ask workflow tools.
 - Do not manually append output-policy text; `ask` injects reply guidance.

--- a/inherit_skills/opencode_skills/ask.md
+++ b/inherit_skills/opencode_skills/ask.md
@@ -40,10 +40,17 @@ Before every ask, decide:
 - Plain nested `ask` from an active CCB task is rejected; use `--chain` or `--silence`.
 - In `A --silence -> B`, B still runs an active job. B-to-C depends on whether B needs C's result.
 - In task chains, each needed-result hop uses `--chain`; CCB then propagates continuations.
+- Finish an inbound CCB task in its current turn. CCB routes that turn's terminal
+  result to the caller; do not open a new `ask` to report completion to the
+  original caller.
 - If the current task is a CCB result-chain continuation, answer the current task
   directly with the final result. Do not use `ask`, `--chain`, or
   `--silence` to send that final result to the original caller; CCB routes the
   continuation completion upstream.
+- `--silence` is not an active-job correction channel. Cancel and resubmit an
+  executing task when its scope must change.
+- A `completed` CCB job means provider execution ended normally; it does not by
+  itself prove business acceptance.
 - `ask get`, `pend`, `watch`, and `ping` are diagnostics-only commands for
   explicit debugging requests, not normal ask workflow tools.
 - Do not manually append output-policy text; `ask` injects reply guidance.

--- a/inherit_skills/qwen_skills/ask.md
+++ b/inherit_skills/qwen_skills/ask.md
@@ -40,10 +40,17 @@ Before every ask, decide:
 - Plain nested `ask` from an active CCB task is rejected; use `--chain` or `--silence`.
 - In `A --silence -> B`, B still runs an active job. B-to-C depends on whether B needs C's result.
 - In task chains, each needed-result hop uses `--chain`; CCB then propagates continuations.
+- Finish an inbound CCB task in its current turn. CCB routes that turn's terminal
+  result to the caller; do not open a new `ask` to report completion to the
+  original caller.
 - If the current task is a CCB result-chain continuation, answer the current task
   directly with the final result. Do not use `ask`, `--chain`, or
   `--silence` to send that final result to the original caller; CCB routes the
   continuation completion upstream.
+- `--silence` is not an active-job correction channel. Cancel and resubmit an
+  executing task when its scope must change.
+- A `completed` CCB job means provider execution ended normally; it does not by
+  itself prove business acceptance.
 - `ask get`, `pend`, `watch`, and `ping` are diagnostics-only commands for
   explicit debugging requests, not normal ask workflow tools.
 - Do not manually append output-policy text; `ask` injects reply guidance.

--- a/inherit_skills/zai_skills/ask.md
+++ b/inherit_skills/zai_skills/ask.md
@@ -40,10 +40,17 @@ Before every ask, decide:
 - Plain nested `ask` from an active CCB task is rejected; use `--chain` or `--silence`.
 - In `A --silence -> B`, B still runs an active job. B-to-C depends on whether B needs C's result.
 - In task chains, each needed-result hop uses `--chain`; CCB then propagates continuations.
+- Finish an inbound CCB task in its current turn. CCB routes that turn's terminal
+  result to the caller; do not open a new `ask` to report completion to the
+  original caller.
 - If the current task is a CCB result-chain continuation, answer the current task
   directly with the final result. Do not use `ask`, `--chain`, or
   `--silence` to send that final result to the original caller; CCB routes the
   continuation completion upstream.
+- `--silence` is not an active-job correction channel. Cancel and resubmit an
+  executing task when its scope must change.
+- A `completed` CCB job means provider execution ended normally; it does not by
+  itself prove business acceptance.
 - `ask get`, `pend`, `watch`, and `ping` are diagnostics-only commands for
   explicit debugging requests, not normal ask workflow tools.
 - Do not manually append output-policy text; `ask` injects reply guidance.

--- a/lib/project_memory/renderer.py
+++ b/lib/project_memory/renderer.py
@@ -16,7 +16,10 @@ EOF
 ```
 
 - During an active CCB ask task, use `ask --chain` when a child result is needed to finish the current task; use `ask --silence` only for independent no-result-needed work.
+- Finish an inbound CCB task in its current turn. CCB routes that turn's terminal result to the caller; do not open a new `ask` to report completion to the original caller.
 - During a CCB result-chain continuation, answer directly with the final result; do not use `ask`, `--chain`, or `--silence` to send that final result to the original caller.
+- `--silence` is not an active-job correction channel. If an executing task needs a scope correction, cancel and resubmit it.
+- A `completed` CCB job means provider execution ended normally; it does not by itself prove business acceptance.
 """
 
 

--- a/test/test_ask_skill_templates.py
+++ b/test/test_ask_skill_templates.py
@@ -51,9 +51,15 @@ def test_shell_ask_skill_templates_use_short_ask_command() -> None:
         assert 'Automatic spill for text over 4 KiB is a fallback' in text
         assert 'In `A --silence -> B`, B still runs an active job.' in text
         assert 'In task chains, each needed-result hop uses `--chain`' in text
+        assert 'Finish an inbound CCB task in its current turn.' in text
+        assert "CCB routes that turn's terminal" in text
+        assert 'do not open a new `ask` to report completion' in text
         assert 'If the current task is a CCB result-chain continuation' in text
         assert 'Do not use `ask`, `--chain`, or' in text
         assert 'continuation completion upstream' in text
+        assert '`--silence` is not an active-job correction channel.' in text
+        assert 'Cancel and resubmit an' in text
+        assert 'A `completed` CCB job means provider execution ended normally' in text
         assert 'command ask "$TARGET"' in text
         assert 'command ask --chain --artifact-reply "$TARGET"' in text
         legacy_chain_flag = '--' + 'call' + 'back'
@@ -92,9 +98,15 @@ def test_powershell_ask_skill_template_uses_short_ask_command() -> None:
     assert 'Automatic spill for text over 4 KiB is a fallback' in text
     assert 'In `A --silence -> B`, B still runs an active job.' in text
     assert 'In task chains, each needed-result hop uses `--chain`' in text
+    assert 'Finish an inbound CCB task in its current turn.' in text
+    assert "CCB routes that turn's terminal" in text
+    assert 'do not open a new `ask` to report completion' in text
     assert 'If the current task is a CCB result-chain continuation' in text
     assert 'Do not use `ask`, `--chain`, or' in text
     assert 'continuation completion upstream' in text
+    assert '`--silence` is not an active-job correction channel.' in text
+    assert 'Cancel and resubmit an' in text
+    assert 'A `completed` CCB job means provider execution ended normally' in text
     assert '@("--chain", "--artifact-reply", "$TARGET")' in text
     legacy_chain_flag = '--' + 'call' + 'back'
     assert legacy_chain_flag not in text

--- a/test/test_project_memory.py
+++ b/test/test_project_memory.py
@@ -292,8 +292,14 @@ def test_materialize_runtime_memory_bundle_writes_generated_bundle(tmp_path: Pat
     assert 'CCB `ask` is submit-only' in text
     assert 'Do not wait, poll, or run `pend`/`watch`/`ping`' in text
     assert 'use `ask --chain` when a child result is needed' in text
+    assert 'Finish an inbound CCB task in its current turn' in text
+    assert "CCB routes that turn's terminal result to the caller" in text
+    assert 'do not open a new `ask` to report completion to the original caller' in text
     assert 'During a CCB result-chain continuation, answer directly with the final result' in text
     assert 'do not use `ask`, `--chain`, or `--silence`' in text
+    assert '`--silence` is not an active-job correction channel' in text
+    assert 'cancel and resubmit it' in text
+    assert 'A `completed` CCB job means provider execution ended normally' in text
     assert '## CCB Shared Project Memory' in text
     assert 'shared ask rules' in text
     assert text.index('## CCB Runtime Coordination Rules') < text.index('## CCB Shared Project Memory')


### PR DESCRIPTION
## Summary

- document how an inbound task's current-turn final is routed back to its caller
- warn agents not to open a second `ask` merely to report completion
- clarify `--chain`, `--silence`, correction, and provider-vs-business completion semantics
- project the same rules into managed provider memory and every bundled ask skill

## Why

An agent can finish practical work, return to its prompt, and separately message the original caller without terminalizing the inbound turn. That leaves the original job and mailbox head active. Clear runtime instructions reduce this failure mode while the daemon-side orphan diagnostics in #260 are designed separately.

The user guide also explains that managed `AGENTS.md`/`CLAUDE.md` content is materialized for provider sessions and should not be assumed to hot-reload into an existing session.

Related: #260, #261

## Validation

- `/home/calvin/tmp/claude_codex_bridge/.venv/bin/python -m pytest -q test/test_ask_skill_templates.py test/test_project_memory.py`
  - `17 passed`
- `/home/calvin/tmp/claude_codex_bridge/.venv/bin/python -m pytest -q test/test_provider_memory_external_matrix.py test/test_provider_memory_external_context.py test/test_project_memory_real_context.py`
  - `1 passed, 2 skipped`
- `git diff --check`

PDF generation was not run because `latexmk` is not installed in the test environment.
