### PR TITLE
Auto-consume empty cancellation notices

### DIFF
--- a/lib/message_bureau/control_queue_runtime/ack.py
+++ b/lib/message_bureau/control_queue_runtime/ack.py
@@ -71,7 +71,7 @@ def _head_event(service, agent_name: str, *, inbound_event_id: str | None):
     )
     if direct_head is not None and direct_head.inbound_event_id == requested_event_id:
         if direct_head.event_type is InboundEventType.TASK_REPLY:
-            return _validate_reply_head(direct_head)
+            return _validate_reply_head(service, direct_head)
         if direct_head.event_type is InboundEventType.TASK_REQUEST:
             return direct_head
 
@@ -82,19 +82,22 @@ def _head_event(service, agent_name: str, *, inbound_event_id: str | None):
     requested_event_id = requested_event_id or head.inbound_event_id
     if head.inbound_event_id != requested_event_id:
         raise ValueError(f'ack requires head event: {head.inbound_event_id}')
-    return _validate_reply_head(head)
+    return _validate_reply_head(service, head)
 
 
-def _validate_reply_head(head):
+def _validate_reply_head(service, head):
     if head.event_type is not InboundEventType.TASK_REPLY:
         raise ValueError(
             f'ack only supports task_reply or terminal task_request head events; found: {head.event_type.value}'
         )
     delivery_job_id = delivery_job_id_from_payload(head.payload_ref)
     if delivery_job_id:
+        attempt = _reply_attempt(service, head)
+        source_job_id = getattr(attempt, 'job_id', None) or 'unknown'
         raise ValueError(
-            'ack is not allowed after automatic reply delivery has been scheduled: '
-            f'{delivery_job_id}'
+            f'ack is not allowed for task_reply event {head.inbound_event_id}: '
+            f'automatic reply delivery has been scheduled as job {delivery_job_id} '
+            f'for source job {source_job_id}; wait for automatic delivery or inspect the delivery job'
         )
     return head
 

--- a/lib/message_bureau/facade_recording_terminal_replies.py
+++ b/lib/message_bureau/facade_recording_terminal_replies.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from ccbd.api_models import JobRecord
+from ccbd.api_models import JobRecord, JobStatus
 from completion.models import CompletionDecision
 from message_bureau.reply_payloads import compose_reply_payload
 from mailbox_kernel import InboundEventRecord, InboundEventStatus, InboundEventType
@@ -30,7 +30,27 @@ def record_reply(
 
     reply_text = delivered_reply_text(job, decision)
     reply_artifact = _reply_artifact_from_decision(decision)
+    empty_cancel_notice = (
+        job.status is JobStatus.CANCELLED
+        and not reply_text.strip()
+        and reply_artifact is None
+    )
     reply_id = new_id('rep')
+    diagnostics = {
+        'reason': decision.reason,
+        'status': job.status.value,
+        'provider_turn_ref': decision.provider_turn_ref,
+        'decision_diagnostics': dict(decision.diagnostics or {}),
+        'silence_on_success': bool(job.request.silence_on_success),
+    }
+    if empty_cancel_notice:
+        diagnostics.update(
+            {
+                'notice': True,
+                'notice_kind': 'cancelled',
+                'delivery_mode': 'auto_consumed_control_notice',
+            }
+        )
     service._reply_store.append(
         ReplyRecord(
             reply_id=reply_id,
@@ -40,27 +60,31 @@ def record_reply(
             terminal_status=reply_status_for_job(job.status),
             reply=reply_text,
             reply_artifact=reply_artifact,
-            diagnostics={
-                'reason': decision.reason,
-                'status': job.status.value,
-                'provider_turn_ref': decision.provider_turn_ref,
-                'decision_diagnostics': dict(decision.diagnostics or {}),
-                'silence_on_success': bool(job.request.silence_on_success),
-            },
+            diagnostics=diagnostics,
             finished_at=finished_at,
         )
     )
 
     caller_mailbox = mailbox_actor(service, job.request.from_actor) if deliver_to_caller else None
     if caller_mailbox is not None:
-        queue_reply_delivery(
-            service,
-            caller_mailbox=caller_mailbox,
-            message_id=attempt.message_id,
-            attempt_id=attempt.attempt_id,
-            reply_id=reply_id,
-            finished_at=finished_at,
-        )
+        if empty_cancel_notice:
+            _record_consumed_completion_notice(
+                service,
+                caller_mailbox=caller_mailbox,
+                message_id=attempt.message_id,
+                attempt_id=attempt.attempt_id,
+                reply_id=reply_id,
+                finished_at=finished_at,
+            )
+        else:
+            queue_reply_delivery(
+                service,
+                caller_mailbox=caller_mailbox,
+                message_id=attempt.message_id,
+                attempt_id=attempt.attempt_id,
+                reply_id=reply_id,
+                finished_at=finished_at,
+            )
 
     refresh_message_state(service, attempt.message_id, updated_at=finished_at)
     return reply_id
@@ -163,6 +187,32 @@ def queue_reply_delivery(
         queue_delta=1,
         pending_reply_delta=1,
         updated_at=finished_at,
+    )
+
+
+def _record_consumed_completion_notice(
+    service,
+    *,
+    caller_mailbox: str,
+    message_id: str,
+    attempt_id: str,
+    reply_id: str,
+    finished_at: str,
+) -> None:
+    service._inbound_store.append(
+        InboundEventRecord(
+            inbound_event_id=new_id('iev'),
+            agent_name=caller_mailbox,
+            event_type=InboundEventType.COMPLETION_NOTICE,
+            message_id=message_id,
+            attempt_id=attempt_id,
+            payload_ref=compose_reply_payload(reply_id),
+            priority=10,
+            status=InboundEventStatus.CONSUMED,
+            created_at=finished_at,
+            started_at=finished_at,
+            finished_at=finished_at,
+        )
     )
 
 

--- a/test/test_v2_message_bureau_dispatcher_integration.py
+++ b/test/test_v2_message_bureau_dispatcher_integration.py
@@ -5,6 +5,7 @@ from dataclasses import replace
 from pathlib import Path
 import subprocess
 import threading
+from types import SimpleNamespace
 
 import pytest
 
@@ -33,6 +34,7 @@ from completion.models import (
     CompletionItem,
     CompletionItemKind,
     CompletionSourceKind,
+    CompletionState,
     CompletionStatus,
 )
 from completion.tracker import CompletionTrackerService
@@ -594,6 +596,112 @@ def test_dispatcher_routes_reply_into_registered_caller_mailbox(tmp_path: Path) 
     assert queue_summary['agent']['queue_depth'] == 1
     assert queue_summary['agent']['pending_reply_count'] == 1
     assert 'queued_events' not in queue_summary['agent']
+
+
+def test_dispatcher_records_empty_cancel_as_consumed_completion_notice(tmp_path: Path) -> None:
+    project_root = tmp_path / 'repo-empty-cancel-notice'
+    ctx = _bootstrap_test_project(project_root)
+    layout = PathLayout(project_root)
+    config = _provider_config('codex', 'claude')
+    registry = AgentRegistry(layout, config)
+    registry.upsert(_runtime('codex', project_id=ctx.project_id, layout=layout, pid=101))
+    registry.upsert(_runtime('claude', project_id=ctx.project_id, layout=layout, pid=102))
+    dispatcher = JobDispatcher(layout, config, registry, clock=lambda: '2026-03-30T00:00:00Z')
+
+    receipt = dispatcher.submit(
+        MessageEnvelope(
+            project_id=ctx.project_id,
+            to_agent='codex',
+            from_actor='claude',
+            body='cancel without output',
+            task_id='task-empty-cancel',
+            reply_to=None,
+            message_type='ask',
+            delivery_scope=DeliveryScope.SINGLE,
+        )
+    )
+    job_id = receipt.jobs[0].job_id
+    dispatcher.tick()
+
+    dispatcher.cancel(job_id)
+    dispatcher.cancel(job_id)
+
+    attempt = AttemptStore(layout).get_latest_by_job_id(job_id)
+    assert attempt is not None
+    assert attempt.attempt_state is AttemptState.CANCELLED
+    replies = ReplyStore(layout).list_message(attempt.message_id)
+    assert len(replies) == 1
+    assert replies[0].terminal_status is ReplyTerminalStatus.CANCELLED
+    assert replies[0].reply == ''
+    assert replies[0].diagnostics['notice'] is True
+    assert replies[0].diagnostics['notice_kind'] == 'cancelled'
+    assert replies[0].diagnostics['delivery_mode'] == 'auto_consumed_control_notice'
+
+    caller_events = InboundEventStore(layout).list_agent('claude')
+    assert len(caller_events) == 1
+    assert caller_events[0].event_type is InboundEventType.COMPLETION_NOTICE
+    assert caller_events[0].status is InboundEventStatus.CONSUMED
+    assert caller_events[0].started_at == '2026-03-30T00:00:00Z'
+    assert caller_events[0].finished_at == '2026-03-30T00:00:00Z'
+    assert MailboxStore(layout).load('claude') is None
+    assert dispatcher.queue('claude')['agent']['queue_depth'] == 0
+
+    trace = dispatcher.trace(job_id)
+    assert any(event['event_type'] == 'completion_notice' for event in trace['events'])
+    assert trace['replies'][0]['notice'] is True
+    assert trace['replies'][0]['notice_kind'] == 'cancelled'
+
+
+def test_dispatcher_delivers_cancelled_reply_when_partial_output_exists(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path / 'repo-partial-cancel-reply'
+    ctx = _bootstrap_test_project(project_root)
+    layout = PathLayout(project_root)
+    config = _provider_config('codex', 'claude')
+    registry = AgentRegistry(layout, config)
+    registry.upsert(_runtime('codex', project_id=ctx.project_id, layout=layout, pid=101))
+    registry.upsert(_runtime('claude', project_id=ctx.project_id, layout=layout, pid=102))
+    dispatcher = JobDispatcher(layout, config, registry, clock=lambda: '2026-03-30T00:00:00Z')
+
+    receipt = dispatcher.submit(
+        MessageEnvelope(
+            project_id=ctx.project_id,
+            to_agent='codex',
+            from_actor='claude',
+            body='cancel after partial output',
+            task_id='task-partial-cancel',
+            reply_to=None,
+            message_type='ask',
+            delivery_scope=DeliveryScope.SINGLE,
+        )
+    )
+    job_id = receipt.jobs[0].job_id
+    dispatcher.tick()
+    snapshot = SimpleNamespace(
+        state=CompletionState(anchor_seen=True, reply_started=True, provider_turn_ref='turn-partial'),
+        latest_decision=_decision(status=CompletionStatus.CANCELLED, reply='partial before cancellation'),
+    )
+    monkeypatch.setattr(dispatcher._snapshot_writer, 'load', lambda _job_id: snapshot)
+
+    dispatcher.cancel(job_id)
+
+    attempt = AttemptStore(layout).get_latest_by_job_id(job_id)
+    assert attempt is not None
+    replies = ReplyStore(layout).list_message(attempt.message_id)
+    assert len(replies) == 1
+    assert replies[0].terminal_status is ReplyTerminalStatus.CANCELLED
+    assert replies[0].reply == 'partial before cancellation'
+    assert replies[0].diagnostics.get('notice') is not True
+    caller_events = InboundEventStore(layout).list_agent('claude')
+    assert len(caller_events) == 1
+    assert caller_events[0].event_type is InboundEventType.TASK_REPLY
+    assert caller_events[0].status is InboundEventStatus.QUEUED
+    mailbox = MailboxStore(layout).load('claude')
+    assert mailbox is not None
+    assert mailbox.queue_depth == 1
+    assert mailbox.pending_reply_count == 1
 
 
 def test_dispatcher_silence_hides_success_reply_body_for_caller_mailbox(tmp_path: Path) -> None:
@@ -4729,10 +4837,16 @@ def test_dispatcher_ack_rejects_reply_after_auto_delivery_is_scheduled(tmp_path:
     dispatcher.tick()
     dispatcher.complete(reply_job_id, _decision(reply='reply for claude'))
 
-    dispatcher.tick()
+    inbound_event_id = dispatcher.inbox('claude')['head']['inbound_event_id']
+    started = dispatcher.tick()
+    delivery_job = next(job for job in started if job.request.message_type == 'reply_delivery')
 
-    with pytest.raises(ValueError, match='automatic reply delivery has been scheduled'):
+    with pytest.raises(ValueError, match='automatic reply delivery has been scheduled') as exc_info:
         dispatcher.ack_reply('claude')
+    message = str(exc_info.value)
+    assert inbound_event_id in message
+    assert reply_job_id in message
+    assert delivery_job.job_id in message
 
 
 def test_dispatcher_tick_auto_consumes_reply_delivery_head_with_execution_service(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Represent `cancelled + empty reply` as a durable, already-consumed `completion_notice` instead of an ordinary queued `task_reply`.

This keeps cancellation completion observable without making the caller agent execute an empty reply-delivery turn or blocking its single-lane mailbox.

## Changes

- preserve the terminal job, cancelled attempt, `ReplyRecord`, and trace lineage;
- tag the empty cancelled reply as a `cancelled` control notice;
- append a consumed `COMPLETION_NOTICE` event for traceability without changing caller mailbox depth or pending-reply count;
- retain the existing `TASK_REPLY` delivery path when cancellation captured meaningful partial output or a reply artifact;
- make ack conflicts identify the inbound event, source job, and automatic delivery job;
- cover repeated cancel idempotency.

The completion-on-cancel invariant from #112 remains intact.

## Verification

- `78 passed` — full message-bureau dispatcher integration file
- `15 passed` — message-bureau control queue tests
- dispatcher cancel subset passed
- socket inbox/ack/reply-delivery subset passed
- `python -m py_compile` for changed Python modules and tests
- `git diff --check`

Closes #263.
