### PR TITLE
Add persistent Config UI settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,20 @@ A blank project starts light: CCB opens one `main` window with a single agent na
 
 Click the **⚙ Settings** icon at the top-left of the CCB sidebar to open the local configuration control panel. You can also run `ccb config ui` from the project directory.
 
+#### Persistent local Config UI access
+
+The Config UI always binds to loopback. To use a stable local port and token, configure a token **source** in `.ccb/ccb.config`; never put a literal token in that file:
+
+```toml
+[config_ui]
+port = 43123
+token_env = "CCB_CONFIG_UI_TOKEN"
+# Or use this instead of token_env:
+# token_file = ".ccb/config-ui.token"
+```
+
+`--port` remains a one-run override. `token_file` must be project-relative, non-symlinked, and owner-only (`chmod 600 .ccb/config-ui.token` on POSIX). Without a token source, CCB keeps the existing random token and ephemeral-port behavior. The CLI prints only the loopback URL and token source, never the token value.
+
 <p align="center">
   <img src="assets/readme_v7/config-control-panel.png" alt="CCB configuration control panel editing the default demo agent" width="960">
 </p>

--- a/README/zh.md
+++ b/README/zh.md
@@ -117,6 +117,20 @@ mkdir -p .ccb
 
 点击 CCB sidebar 左上角的 **⚙ 设置** 图标即可打开本地配置控制面；也可以在项目目录运行 `ccb config ui`。
 
+#### 固化本地 Config UI 访问
+
+Config UI 始终只绑定 loopback。若需要固定本地端口和 token，请在 `.ccb/ccb.config` 中配置 token 的**来源**，不要将 token 明文写入该文件：
+
+```toml
+[config_ui]
+port = 43123
+token_env = "CCB_CONFIG_UI_TOKEN"
+# 或使用下面这一项替代 token_env：
+# token_file = ".ccb/config-ui.token"
+```
+
+`--port` 仍可覆盖单次启动端口。`token_file` 必须是项目内相对路径、不能是符号链接，并且在 POSIX 上应仅允许文件所有者读取（`chmod 600 .ccb/config-ui.token`）。未配置 token 来源时，CCB 保持原有的随机 token 与临时端口行为。CLI 只输出 loopback URL 和 token 来源，不会输出 token 值。
+
 <p align="center">
   <img src="../assets/readme_v7/config-control-panel.png" alt="CCB 配置控制面正在编辑默认 demo agent" width="960">
 </p>

--- a/lib/agents/config_loader_runtime/common.py
+++ b/lib/agents/config_loader_runtime/common.py
@@ -26,6 +26,7 @@ ALLOWED_TOP_LEVEL_KEYS = {
     'entry_window',
     'maintenance',
     'loop',
+    'config_ui',
 }
 ALLOWED_PROVIDER_PROFILE_KEYS = {
     'mode',

--- a/lib/agents/config_loader_runtime/io_runtime/documents.py
+++ b/lib/agents/config_loader_runtime/io_runtime/documents.py
@@ -19,7 +19,7 @@ from ..defaults import build_default_project_config
 from ..parsing import validate_project_config
 from ..paths import project_config_path, user_default_config_path
 
-_ALLOWED_HYBRID_TOP_LEVEL_KEYS = {'agents', 'maintenance', 'loop'}
+_ALLOWED_HYBRID_TOP_LEVEL_KEYS = {'agents', 'maintenance', 'loop', 'config_ui'}
 _HYBRID_HEADER_OWNED_AGENT_KEYS = {'provider', 'workspace_mode'}
 
 
@@ -278,6 +278,8 @@ def _merge_hybrid_overlay(
         merged['maintenance'] = overlay_document['maintenance']
     if 'loop' in overlay_document:
         merged['loop'] = overlay_document['loop']
+    if 'config_ui' in overlay_document:
+        merged['config_ui'] = overlay_document['config_ui']
     return merged
 
 

--- a/lib/agents/config_loader_runtime/parsing_runtime/validation.py
+++ b/lib/agents/config_loader_runtime/parsing_runtime/validation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from pathlib import Path
+import re
 from typing import Any
 
 from agents.config_loader_runtime.role_lookup import RoleLookupError, installed_role_default_agent_name, looks_like_role_id, normalize_role_id
@@ -27,6 +28,8 @@ from .loop_capacity import parse_loop_capacity
 from .topology import agents_from_topology_windows, parse_sidebar, parse_sidebar_view, parse_tool_windows, parse_topology_windows
 
 _MAINTENANCE_TOP_LEVEL_KEYS = {'heartbeat'}
+_CONFIG_UI_KEYS = {'port', 'token_env', 'token_file'}
+_ENVIRONMENT_VARIABLE_NAME = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')
 _MAINTENANCE_HEARTBEAT_KEYS = {
     'enabled',
     'assessor',
@@ -73,6 +76,7 @@ def validate_project_config(
         project_root=resolved_project_root,
     )
     _validate_document_shape(document)
+    validate_config_ui_settings(document.get('config_ui'))
     windows = parse_topology_windows(document.get('windows'))
     tool_windows = parse_tool_windows(document.get('tool_windows'))
     _validate_topology_presence(document, windows=windows, tool_windows=tool_windows)
@@ -114,6 +118,30 @@ def _validate_document_shape(document: dict[str, Any]) -> None:
         )
     if document.get('version') != 2:
         raise ConfigValidationError('version must be 2')
+
+
+def validate_config_ui_settings(value: object) -> dict[str, object]:
+    if value is None:
+        return {}
+    settings = expect_mapping(value, field_name='config_ui')
+    unknown = sorted(set(settings) - _CONFIG_UI_KEYS)
+    if unknown:
+        raise ConfigValidationError(
+            f'config_ui contains unknown fields: {", ".join(unknown)}'
+        )
+    port = settings.get('port')
+    if port is not None and (isinstance(port, bool) or not isinstance(port, int) or not 0 <= port <= 65535):
+        raise ConfigValidationError('config_ui.port must be an integer between 0 and 65535')
+    for key in ('token_env', 'token_file'):
+        if key in settings:
+            value = expect_string(settings[key], field_name=f'config_ui.{key}').strip()
+            if not value:
+                raise ConfigValidationError(f'config_ui.{key} must not be empty')
+            if key == 'token_env' and not _ENVIRONMENT_VARIABLE_NAME.fullmatch(value):
+                raise ConfigValidationError('config_ui.token_env must be a valid environment variable name')
+    if 'token_env' in settings and 'token_file' in settings:
+        raise ConfigValidationError('config_ui.token_env and config_ui.token_file are mutually exclusive')
+    return dict(settings)
 
 
 def _parse_default_agents(document: dict[str, Any]) -> tuple[str, ...]:

--- a/lib/agents/config_loader_runtime/parsing_runtime/workflow_v3.py
+++ b/lib/agents/config_loader_runtime/parsing_runtime/workflow_v3.py
@@ -36,7 +36,7 @@ from .provider_profiles import parse_provider_profile
 from .topology import parse_sidebar, parse_sidebar_view, parse_tool_windows
 
 
-_TOP_LEVEL_KEYS = frozenset({'version', 'workflow', 'ui', 'tool_windows', 'maintenance'})
+_TOP_LEVEL_KEYS = frozenset({'version', 'workflow', 'ui', 'tool_windows', 'maintenance', 'config_ui'})
 _FORBIDDEN_STATIC_KEYS = frozenset({'windows', 'agents', 'default_agents', 'layout', 'cmd_enabled', 'loop'})
 _WORKFLOW_KEYS = frozenset(
     {'mode', 'profile', 'entry_role', 'defaults', 'provider_defaults', 'runtime', 'resident', 'dynamic'}
@@ -234,6 +234,9 @@ def _validate_top_level(document: dict[str, Any]) -> None:
     unknown = sorted(set(document) - _TOP_LEVEL_KEYS)
     if unknown:
         _fail('v3_unknown_field', unknown[0], f'unknown top-level field: {unknown[0]}')
+    from .validation import validate_config_ui_settings
+
+    validate_config_ui_settings(document.get('config_ui'))
 
 
 def _parse_defaults(value: object) -> dict[str, dict[str, object]]:

--- a/lib/cli/models_start.py
+++ b/lib/cli/models_start.py
@@ -227,7 +227,7 @@ class ParsedConfigValidateCommand:
 class ParsedConfigUiCommand:
     project: str | None
     no_open: bool = False
-    port: int = 0
+    port: int | None = None
     kind: str = 'config-ui'
 
 

--- a/lib/cli/parser_runtime/commands.py
+++ b/lib/cli/parser_runtime/commands.py
@@ -1089,19 +1089,19 @@ def parse_config(tokens: list[str], *, project: str | None, error_type):
     if action == 'ui':
         parser = argparse.ArgumentParser(prog='ccb config ui', add_help=False)
         parser.add_argument('--no-open', dest='no_open', action='store_true')
-        parser.add_argument('--port', type=int, default=0)
+        parser.add_argument('--port', type=int)
         namespace = parse_args(
             parser,
             tokens[1:],
             error_message='invalid config ui command',
             error_type=error_type,
         )
-        if not 0 <= int(namespace.port) <= 65535:
+        if namespace.port is not None and not 0 <= int(namespace.port) <= 65535:
             raise error_type('config ui --port must be between 0 and 65535')
         return ParsedConfigUiCommand(
             project=project,
             no_open=bool(namespace.no_open),
-            port=int(namespace.port),
+            port=int(namespace.port) if namespace.port is not None else None,
         )
     raise error_type('config supports: validate, effective, migrate, ui')
 

--- a/lib/cli/phase2_runtime/handlers_start.py
+++ b/lib/cli/phase2_runtime/handlers_start.py
@@ -61,7 +61,10 @@ def handle_config_ui(context, command, out, services) -> int:
     if callable(flush):
         flush()
     if not command.no_open and not services.open_config_ui_url(handle.url):
-        services.write_lines(out, ('browser_open: failed; open the URL above manually',))
+        services.write_lines(
+            out,
+            ('browser_open: failed; use the configured token source with the loopback URL above',),
+        )
         if callable(flush):
             flush()
     try:

--- a/lib/cli/services/config_ui.py
+++ b/lib/cli/services/config_ui.py
@@ -31,6 +31,7 @@ from agents.models import parse_layout_spec
 from cli.context import CliContext
 from cli.models import ParsedConfigUiCommand, ParsedReloadCommand
 from cli.output import atomic_write_text
+from cli.services.config_ui_settings import resolve_config_ui_settings
 from provider_core.registry import CORE_PROVIDER_NAMES, OPTIONAL_PROVIDER_NAMES
 from provider_model_shortcuts import supported_provider_model_shortcuts
 from provider_profiles import supported_provider_api_shortcuts, validate_provider_runtime_home_uniqueness
@@ -79,6 +80,7 @@ def prepare_config_ui(
     page = page_path.read_bytes()
     project_root = context.project.project_root.resolve()
     config_path = project_root / '.ccb' / 'ccb.config'
+    settings = resolve_config_ui_settings(project_root=project_root, cli_port=command.port)
     session_payload = json.dumps(
         {
             'schema_version': 2,
@@ -93,7 +95,7 @@ def prepare_config_ui(
         config_ui_provider_capabilities(project_root=project_root),
         ensure_ascii=False,
     ).encode('utf-8')
-    access_token = token or secrets.token_urlsafe(24)
+    access_token = token if token is not None else settings.token or secrets.token_urlsafe(24)
     last_activity = [time.monotonic()]
     if reload_action is None:
         from .reload import reload_config
@@ -113,7 +115,7 @@ def prepare_config_ui(
         token=access_token,
         last_activity=last_activity,
     )
-    server = ThreadingHTTPServer(('127.0.0.1', command.port), handler)
+    server = ThreadingHTTPServer(('127.0.0.1', settings.port), handler)
     server.daemon_threads = True
     host, port = server.server_address[:2]
     url = f'http://{host}:{port}/?token={access_token}'
@@ -121,7 +123,9 @@ def prepare_config_ui(
         url=url,
         summary={
             'config_ui_status': 'serving',
-            'url': url,
+            'url': f'http://{host}:{port}/',
+            'bind': 'loopback',
+            'token_source': 'injected' if token is not None else settings.token_source,
             'project_root': str(project_root),
             'config_path': str(config_path),
             'mode': 'editor',
@@ -857,6 +861,8 @@ def _editor_payload(
     )
     if isinstance(raw_document.get('maintenance'), dict):
         canonical_document['maintenance'] = raw_document['maintenance']
+    if isinstance(raw_document.get('config_ui'), dict):
+        canonical_document['config_ui'] = raw_document['config_ui']
     raw_ui = raw_document.get('ui')
     if isinstance(raw_ui, dict) and isinstance(raw_ui.get('sidebar'), dict):
         canonical_ui = canonical_document.setdefault('ui', {})

--- a/lib/cli/services/config_ui_settings.py
+++ b/lib/cli/services/config_ui_settings.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import os
+import re
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+
+from agents.config_loader import ConfigValidationError
+from agents.config_loader_runtime.io_runtime import parse_config_document_text
+from agents.config_loader_runtime.parsing_runtime.validation import validate_config_ui_settings
+
+_ENV_NAME = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')
+
+
+@dataclass(frozen=True)
+class ResolvedConfigUiSettings:
+    port: int
+    token: str | None
+    token_source: str
+
+
+def resolve_config_ui_settings(
+    *,
+    project_root: Path,
+    cli_port: int | None,
+    environ: dict[str, str] | None = None,
+) -> ResolvedConfigUiSettings:
+    config_path = project_root / '.ccb' / 'ccb.config'
+    raw: dict[str, object] = {}
+    if config_path.is_file():
+        document = parse_config_document_text(
+            config_path.read_text(encoding='utf-8'),
+            path=config_path,
+            project_root=project_root,
+        )
+        raw = validate_config_ui_settings(document.get('config_ui'))
+
+    configured_port = int(raw.get('port', 0))
+    port = configured_port if cli_port is None else int(cli_port)
+    if 'token_env' in raw:
+        name = str(raw['token_env']).strip()
+        if not _ENV_NAME.fullmatch(name):
+            raise ConfigValidationError('config_ui.token_env must be a valid environment variable name')
+        value = (os.environ if environ is None else environ).get(name)
+        if value is None or not value:
+            raise ConfigValidationError('the configured Config UI token environment variable is unset or empty')
+        return ResolvedConfigUiSettings(port=port, token=value, token_source='environment')
+    if 'token_file' in raw:
+        token_path = _secure_token_path(project_root, str(raw['token_file']))
+        value = token_path.read_text(encoding='utf-8').rstrip('\r\n')
+        if not value:
+            raise ConfigValidationError('the configured Config UI token file is empty')
+        return ResolvedConfigUiSettings(port=port, token=value, token_source='file')
+    return ResolvedConfigUiSettings(port=port, token=None, token_source='ephemeral')
+
+
+def _secure_token_path(project_root: Path, configured_path: str) -> Path:
+    relative = Path(configured_path).expanduser()
+    if relative.is_absolute():
+        raise ConfigValidationError('config_ui.token_file must be project-relative')
+    root = project_root.resolve()
+    candidate = root / relative
+    if candidate.is_symlink():
+        raise ConfigValidationError('config_ui.token_file must not be a symbolic link')
+    try:
+        resolved = candidate.resolve(strict=True)
+    except (FileNotFoundError, RuntimeError) as exc:
+        raise ConfigValidationError('the configured Config UI token file is unavailable') from exc
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise ConfigValidationError('config_ui.token_file must stay within the project') from exc
+    file_stat = resolved.stat()
+    if not stat.S_ISREG(file_stat.st_mode):
+        raise ConfigValidationError('config_ui.token_file must be a regular file')
+    if os.name == 'posix' and file_stat.st_mode & 0o077:
+        raise ConfigValidationError('config_ui.token_file must have owner-only permissions (0600)')
+    return resolved
+
+
+__all__ = ['ResolvedConfigUiSettings', 'resolve_config_ui_settings']

--- a/test/test_config_ui.py
+++ b/test/test_config_ui.py
@@ -22,6 +22,8 @@ from cli.services.config_ui import (
     open_config_ui_url,
     prepare_config_ui,
 )
+from cli.services.config_ui_settings import resolve_config_ui_settings
+from agents.config_loader import ConfigValidationError
 
 
 def _context(project_root: Path):
@@ -88,6 +90,9 @@ def test_config_ui_serves_token_guarded_page_and_project_session(tmp_path: Path)
         token='test-token',
         idle_timeout_s=0.3,
     )
+    assert 'test-token' not in json.dumps(handle.summary)
+    assert handle.summary['url'].endswith('/')
+    assert handle.summary['bind'] == 'loopback'
     time.sleep(0.35)
     thread = threading.Thread(target=handle.serve_forever)
     thread.start()
@@ -140,6 +145,154 @@ def test_config_ui_serves_token_guarded_page_and_project_session(tmp_path: Path)
         thread.join(timeout=2)
         handle.close()
     assert not thread.is_alive()
+
+
+def test_config_ui_uses_project_port_and_environment_token(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = tmp_path / 'repo'
+    config_path = project_root / '.ccb' / 'ccb.config'
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        '''version = 2
+entry_window = "main"
+
+[windows]
+main = "agent1:codex"
+
+[config_ui]
+port = 43123
+token_env = "CCB_CONFIG_UI_TEST_TOKEN"
+''',
+        encoding='utf-8',
+    )
+    monkeypatch.setenv('CCB_CONFIG_UI_TEST_TOKEN', 'stable-secret')
+    page = tmp_path / 'index.html'
+    page.write_text('<!doctype html><title>settings</title>', encoding='utf-8')
+
+    handle = prepare_config_ui(
+        _context(project_root),
+        ParsedConfigUiCommand(project=None),
+        asset_path=page,
+    )
+    try:
+        assert urlparse(handle.url).port == 43123
+        assert parse_qs(urlparse(handle.url).query)['token'] == ['stable-secret']
+        assert handle.summary['token_source'] == 'environment'
+        assert 'stable-secret' not in json.dumps(handle.summary)
+    finally:
+        handle.close()
+
+
+def test_config_ui_cli_port_overrides_project_port(tmp_path: Path) -> None:
+    project_root = tmp_path / 'repo'
+    config_path = project_root / '.ccb' / 'ccb.config'
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        '''version = 2
+entry_window = "main"
+
+[windows]
+main = "agent1:codex"
+
+[config_ui]
+port = 43123
+''',
+        encoding='utf-8',
+    )
+
+    resolved = resolve_config_ui_settings(project_root=project_root, cli_port=0)
+
+    assert resolved.port == 0
+    assert resolved.token is None
+    assert resolved.token_source == 'ephemeral'
+
+
+def test_config_ui_reads_owner_only_project_token_file(tmp_path: Path) -> None:
+    project_root = tmp_path / 'repo'
+    config_path = project_root / '.ccb' / 'ccb.config'
+    token_path = project_root / '.ccb' / 'config-ui.token'
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        '''version = 2
+entry_window = "main"
+
+[windows]
+main = "agent1:codex"
+
+[config_ui]
+token_file = ".ccb/config-ui.token"
+''',
+        encoding='utf-8',
+    )
+    token_path.write_text('file-secret\n', encoding='utf-8')
+    token_path.chmod(0o600)
+
+    resolved = resolve_config_ui_settings(project_root=project_root, cli_port=None)
+
+    assert resolved.token == 'file-secret'
+    assert resolved.token_source == 'file'
+
+
+@pytest.mark.parametrize(
+    ('config_ui', 'message'),
+    [
+        ('token = "must-not-be-accepted"', 'unknown fields: token'),
+        ('token_env = "TOKEN"\ntoken_file = ".ccb/token"', 'mutually exclusive'),
+        ('token_env = "not-a-valid-name"', 'valid environment variable name'),
+        ('port = 70000', 'between 0 and 65535'),
+    ],
+)
+def test_config_ui_rejects_unsafe_project_settings(
+    tmp_path: Path,
+    config_ui: str,
+    message: str,
+) -> None:
+    project_root = tmp_path / 'repo'
+    config_path = project_root / '.ccb' / 'ccb.config'
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        f'''version = 2
+entry_window = "main"
+
+[windows]
+main = "agent1:codex"
+
+[config_ui]
+{config_ui}
+''',
+        encoding='utf-8',
+    )
+
+    with pytest.raises(ConfigValidationError, match=message) as exc_info:
+        resolve_config_ui_settings(project_root=project_root, cli_port=None)
+    assert 'must-not-be-accepted' not in str(exc_info.value)
+
+
+def test_config_ui_rejects_insecure_token_file_without_leaking_contents(tmp_path: Path) -> None:
+    project_root = tmp_path / 'repo'
+    config_path = project_root / '.ccb' / 'ccb.config'
+    token_path = project_root / '.ccb' / 'config-ui.token'
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        '''version = 2
+entry_window = "main"
+
+[windows]
+main = "agent1:codex"
+
+[config_ui]
+token_file = ".ccb/config-ui.token"
+''',
+        encoding='utf-8',
+    )
+    token_path.write_text('do-not-leak', encoding='utf-8')
+    token_path.chmod(0o644)
+
+    with pytest.raises(ConfigValidationError, match='owner-only permissions') as exc_info:
+        resolve_config_ui_settings(project_root=project_root, cli_port=None)
+    assert 'do-not-leak' not in str(exc_info.value)
 
 
 def test_config_ui_uses_builtin_demo_config_when_project_config_is_missing(

--- a/test/test_v2_phase2_entrypoint.py
+++ b/test/test_v2_phase2_entrypoint.py
@@ -310,7 +310,9 @@ def test_phase2_config_ui_opens_and_serves_project_panel(monkeypatch, tmp_path: 
         url = 'http://127.0.0.1:43210/?token=test'
         summary = {
             'config_ui_status': 'serving',
-            'url': url,
+            'url': 'http://127.0.0.1:43210/',
+            'bind': 'loopback',
+            'token_source': 'ephemeral',
             'project_root': str(project_root),
         }
 
@@ -337,13 +339,14 @@ def test_phase2_config_ui_opens_and_serves_project_panel(monkeypatch, tmp_path: 
     assert code == 0, stderr
     assert seen == {
         'project_root': project_root.resolve(),
-        'port': 0,
+        'port': None,
         'opened_url': _FakeHandle.url,
         'served': True,
         'closed': True,
     }
     assert 'config_ui_status: serving' in stdout
-    assert f'url: {_FakeHandle.url}' in stdout
+    assert 'url: http://127.0.0.1:43210/' in stdout
+    assert _FakeHandle.url not in stdout
     assert (project_root / '.ccb' / 'ccb.config').exists() is False
 
 


### PR DESCRIPTION
## Summary
- add validated project-level `[config_ui]` port and token-source settings
- keep Config UI loopback-only and prevent token leakage in normal CLI output
- document environment and owner-only token-file configuration

## Security
- literal tokens in project config are rejected
- token files must be project-relative, regular, non-symlinked, and owner-only on POSIX
- `--port` remains a per-run override

## Validation
- `uv run --with pytest pytest test/test_config_ui.py test/test_v2_cli_parser.py test/test_v2_phase2_entrypoint.py`
- `uv run --with pytest pytest -q test/test_v3_config_loader.py test/test_config_ui.py`

Fixes #272