### PR TITLE
Pluggable terminal backend (1/2): widen TerminalBackend ABC + construction factory

### DIFF
--- a/lib/ccbd/handlers/project_clear.py
+++ b/lib/ccbd/handlers/project_clear.py
@@ -4,7 +4,7 @@ import subprocess
 import time
 
 from agents.models import normalize_agent_name
-from terminal_runtime import TmuxBackend
+from terminal_runtime.backend_selection import make_terminal_backend
 
 OPENCODE_CLEAR_SUBMIT_DELAY_S = 0.3
 
@@ -15,7 +15,7 @@ def build_project_clear_context_handler(app):
         namespace = app.project_namespace.load()
         if namespace is None:
             raise RuntimeError('project namespace is not mounted')
-        backend = TmuxBackend(socket_path=namespace.tmux_socket_path)
+        backend = make_terminal_backend(socket_path=namespace.tmux_socket_path)
         results = tuple(_clear_agent_context(app, backend=backend, agent_name=name) for name in agent_names)
         statuses = {str(item.get('status') or '') for item in results}
         return {

--- a/lib/ccbd/handlers/project_restart.py
+++ b/lib/ccbd/handlers/project_restart.py
@@ -10,7 +10,7 @@ from provider_core.registry import build_default_session_binding_map
 from provider_core.session_binding_evidence_runtime.loading import binding_search_roots, load_provider_session
 from rolepacks.runtime_lookup import load_installed_role, tree_digest
 from rolepacks.sources import installed_role_metadata
-from terminal_runtime import TmuxBackend
+from terminal_runtime.backend_selection import make_terminal_backend
 
 
 RESTART_PANES_REASON = 'manual_restart_panes'
@@ -268,7 +268,7 @@ def restart_project_agent_panes_in_place(app, *, agent_names: tuple[str, ...]) -
     namespace = app.project_namespace.load()
     if namespace is None:
         raise RuntimeError('project namespace is not mounted')
-    backend = TmuxBackend(socket_path=namespace.tmux_socket_path)
+    backend = make_terminal_backend(socket_path=namespace.tmux_socket_path)
     results: list[dict[str, object]] = []
     for agent_name in agent_names:
         results.append(_restart_agent_pane(app, backend=backend, agent_name=str(agent_name)))

--- a/lib/ccbd/services/project_namespace_runtime/slot_replacement.py
+++ b/lib/ccbd/services/project_namespace_runtime/slot_replacement.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from terminal_runtime import TmuxBackend
+from terminal_runtime.backend_selection import make_terminal_backend
 from terminal_runtime.tmux_identity import apply_ccb_pane_identity
 
 from ..project_namespace import ProjectNamespaceController
@@ -88,9 +88,9 @@ def relabel_project_slot_pane(
     if not pane_text.startswith('%'):
         return
     try:
-        backend = TmuxBackend(socket_path=context.tmux_socket_path)
+        backend = make_terminal_backend(socket_path=context.tmux_socket_path)
     except TypeError:
-        backend = TmuxBackend()
+        backend = make_terminal_backend()
     apply_ccb_pane_identity(
         backend,
         pane_text,

--- a/lib/cli/services/layout.py
+++ b/lib/cli/services/layout.py
@@ -28,6 +28,7 @@ from ccbd.services.project_namespace_runtime.backend import (
 )
 from ccbd.services.project_namespace_runtime.remove_patch_agents import reflow_window_after_agent_change
 from terminal_runtime import TmuxBackend
+from terminal_runtime.backend_selection import make_terminal_backend
 from terminal_runtime.tmux_identity import apply_ccb_pane_identity
 
 from .daemon import ping_local_state
@@ -535,7 +536,7 @@ def _run_layout_smoke(context, command, windows) -> dict[str, object]:
     context.paths.ensure_runtime_state_root()
     socket_path = _smoke_socket_path(context)
     session_name = _session_name(context, command)
-    backend = TmuxBackend(socket_path=str(socket_path))
+    backend = make_terminal_backend(socket_path=str(socket_path))
     kill_server(backend)
     observed: list[dict[str, object]] = []
     try:
@@ -598,7 +599,7 @@ def _run_layout_dynamic_smoke(context, command, names: tuple[str, ...]) -> dict[
     context.paths.ensure_runtime_state_root()
     socket_path = _smoke_socket_path(context)
     session_name = _session_name(context, command)
-    backend = TmuxBackend(socket_path=str(socket_path))
+    backend = make_terminal_backend(socket_path=str(socket_path))
     kill_server(backend)
     events: list[dict[str, object]] = []
     pane_by_name: dict[str, str] = {}

--- a/lib/cli/services/layout_status.py
+++ b/lib/cli/services/layout_status.py
@@ -7,7 +7,7 @@ import shutil
 from agents.config_loader import load_project_config
 from agents.store import AgentRuntimeStore
 from ccbd.services.project_namespace_state import ProjectNamespaceStateStore
-from terminal_runtime import TmuxBackend
+from terminal_runtime.backend_selection import make_terminal_backend
 
 from .agent_status_diagnostics import (
     agent_kind,
@@ -248,7 +248,7 @@ def _observe_project_namespace(namespace: dict[str, object]) -> dict[str, object
     session_name = _optional_text(namespace.get('tmux_session_name'))
     if socket_path is None or session_name is None:
         return {'observe_status': 'skipped', 'reason': 'namespace_tmux_scope_missing'}
-    backend = TmuxBackend(socket_path=socket_path)
+    backend = make_terminal_backend(socket_path=socket_path)
     try:
         result = backend._tmux_run(
             [

--- a/lib/cli/services/start.py
+++ b/lib/cli/services/start.py
@@ -8,7 +8,7 @@ from agents.config_loader import load_project_config
 from ccbd.services.project_namespace import ProjectNamespaceController
 from ccbd.services.project_namespace_runtime import build_namespace_topology_plan
 from ccbd.services.project_namespace_runtime.materialize_topology import refresh_topology_sidebar_helpers
-from terminal_runtime import TmuxBackend
+from terminal_runtime.backend_selection import make_terminal_backend
 
 from .daemon import ensure_daemon_started
 from .daemon_runtime.policy import STARTUP_TRANSACTION_TIMEOUT_S
@@ -106,7 +106,7 @@ def _refresh_running_sidebar_helpers(context) -> dict[str, object]:
         topology_plan = build_namespace_topology_plan(
             load_project_config(context.project.project_root).config
         )
-        backend = TmuxBackend(socket_path=namespace.tmux_socket_path)
+        backend = make_terminal_backend(socket_path=namespace.tmux_socket_path)
         refreshed = refresh_topology_sidebar_helpers(
             controller,
             backend,

--- a/lib/cli/services/tmux_start_layout.py
+++ b/lib/cli/services/tmux_start_layout.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from agents.models import ProjectConfig, ProjectLayoutPlan, build_project_layout_plan
 from cli.context import CliContext
 from terminal_runtime import TmuxBackend
+from terminal_runtime.backend_selection import make_terminal_backend
 from terminal_runtime.placeholders import pane_placeholder_cmd
 from terminal_runtime.tmux_identity import apply_ccb_pane_identity
 
@@ -28,7 +29,7 @@ def prepare_tmux_start_layout(
     if not targets:
         return TmuxStartLayout(cmd_pane_id=None, agent_panes={})
 
-    backend = tmux_backend or TmuxBackend()
+    backend = tmux_backend or make_terminal_backend()
     resolved_root_pane_id = root_pane_id or backend.get_current_pane_id()
     resolved_layout_plan = layout_plan or build_project_layout_plan(
         config,

--- a/lib/cli/services/tmux_ui_runtime/helpers.py
+++ b/lib/cli/services/tmux_ui_runtime/helpers.py
@@ -10,9 +10,9 @@ _LEGACY_BIN_DIR = Path.home() / '.local' / 'bin'
 
 def build_tmux_backend(socket_path: str):
     try:
-        from terminal_runtime import TmuxBackend
+        from terminal_runtime.backend_selection import make_terminal_backend
 
-        return TmuxBackend(socket_path=socket_path)
+        return make_terminal_backend(socket_path=socket_path)
     except Exception:
         return None
 

--- a/lib/provider_backends/codex/bridge_runtime/session.py
+++ b/lib/provider_backends/codex/bridge_runtime/session.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from terminal_runtime import TmuxBackend
+from terminal_runtime.backend_selection import make_terminal_backend
 
 
 class TerminalCodexSession:
@@ -8,7 +8,7 @@ class TerminalCodexSession:
 
     def __init__(self, pane_id: str):
         self.pane_id = pane_id
-        self.backend = TmuxBackend()
+        self.backend = make_terminal_backend()
 
     def send(self, text: str) -> None:
         command = text.replace('\r', ' ').replace('\n', ' ').strip()

--- a/lib/terminal_runtime/backend_selection.py
+++ b/lib/terminal_runtime/backend_selection.py
@@ -6,6 +6,20 @@ from dataclasses import dataclass
 from typing import Callable
 
 from terminal_runtime.layouts import LayoutResult, create_tmux_auto_layout
+from terminal_runtime.tmux_backend import TmuxBackend
+
+
+def make_terminal_backend(
+    terminal_type=None,
+    *,
+    socket_name=None,
+    socket_path=None,
+):
+    if terminal_type in (None, 'tmux'):
+        return TmuxBackend(socket_name=socket_name, socket_path=socket_path)
+    if terminal_type == 'herdr':
+        raise NotImplementedError('herdr terminal backend lands in PR #2')
+    raise ValueError(f'unsupported terminal backend: {terminal_type}')
 
 
 @dataclass
@@ -20,6 +34,8 @@ class TerminalBackendSelection:
         selected = terminal_type or self.detect_terminal_fn()
         if selected == 'tmux':
             self.cached_backend = self.tmux_backend_factory()
+        elif selected == 'herdr':
+            raise NotImplementedError('herdr terminal backend lands in PR #2')
         return self.cached_backend
 
     def get_backend_for_session(self, session_data: dict) -> object:
@@ -53,7 +69,13 @@ class TerminalLayoutService:
         percent: int = 50,
         set_markers: bool = True,
         marker_prefix: str = 'CCB',
+        terminal_type: str | None = None,
     ) -> LayoutResult:
+        selected = terminal_type or 'tmux'
+        if selected == 'herdr':
+            raise NotImplementedError('herdr terminal backend lands in PR #2')
+        if selected != 'tmux':
+            raise ValueError(f'unsupported terminal backend: {selected}')
         env = self.env if self.env is not None else os.environ
         return create_tmux_auto_layout(
             providers,

--- a/lib/terminal_runtime/backend_types.py
+++ b/lib/terminal_runtime/backend_types.py
@@ -1,28 +1,126 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Optional
 
 
 class TerminalBackend(ABC):
     @abstractmethod
+    def create_pane(
+        self,
+        cmd: str,
+        cwd: str,
+        direction: str = 'right',
+        percent: int = 50,
+        parent_pane: Optional[str] = None,
+    ) -> str: ...
+
+    @abstractmethod
+    def split_pane(
+        self,
+        parent_pane_id: str,
+        direction: str,
+        percent: int,
+        cmd: str | None = None,
+        cwd: str | None = None,
+    ) -> str: ...
+
+    @abstractmethod
+    def respawn_pane(
+        self,
+        pane_id: str,
+        *,
+        cmd: str,
+        cwd: str | None = None,
+        stderr_log_path: str | None = None,
+        remain_on_exit: bool = True,
+    ) -> None: ...
+
+    @abstractmethod
     def send_text(self, pane_id: str, text: str) -> None: ...
 
     @abstractmethod
-    def is_alive(self, pane_id: str) -> bool: ...
-
-    @abstractmethod
-    def kill_pane(self, pane_id: str) -> None: ...
+    def send_key(self, pane_id: str, key: str) -> bool: ...
 
     @abstractmethod
     def activate(self, pane_id: str) -> None: ...
 
     @abstractmethod
-    def create_pane(
+    def kill_pane(self, pane_id: str) -> None: ...
+
+    @abstractmethod
+    def is_alive(self, pane_id: str) -> bool: ...
+
+    @abstractmethod
+    def pane_exists(self, pane_id: str) -> bool: ...
+
+    @abstractmethod
+    def get_current_pane_id(self) -> str: ...
+
+    @abstractmethod
+    def find_pane_by_title_marker(self, marker: str) -> Optional[str]: ...
+
+    @abstractmethod
+    def find_pane_by_user_options(self, expected: dict[str, str]) -> Optional[str]: ...
+
+    @abstractmethod
+    def list_panes_by_user_options(self, expected: dict[str, str]) -> list[str]: ...
+
+    @abstractmethod
+    def describe_pane(
         self,
-        cmd: str,
-        cwd: str,
-        direction: str = "right",
-        percent: int = 50,
-        parent_pane: Optional[str] = None,
-    ) -> str: ...
+        pane_id: str,
+        *,
+        user_options: tuple[str, ...] = (),
+    ) -> dict[str, str] | None: ...
+
+    @abstractmethod
+    def set_pane_title(self, pane_id: str, title: str) -> None: ...
+
+    @abstractmethod
+    def set_pane_user_option(self, pane_id: str, name: str, value: str) -> None: ...
+
+    def set_pane_style(
+        self,
+        pane_id: str,
+        *,
+        border_style: str | None = None,
+        active_border_style: str | None = None,
+    ) -> None:
+        pass
+
+    @abstractmethod
+    def set_pane_identity(
+        self,
+        pane_id: str,
+        *,
+        title: str,
+        user_options: dict[str, str],
+        border_style: str | None = None,
+        active_border_style: str | None = None,
+    ) -> None: ...
+
+    @abstractmethod
+    def get_pane_content(self, pane_id: str, lines: int = 20) -> Optional[str]: ...
+
+    @abstractmethod
+    def get_text(self, pane_id: str, lines: int = 20) -> Optional[str]: ...
+
+    @abstractmethod
+    def pane_log_path(self, pane_id: str) -> Optional[Path]: ...
+
+    @abstractmethod
+    def ensure_pane_log(self, pane_id: str) -> Optional[Path]: ...
+
+    def refresh_pane_logs(self) -> None:
+        pass
+
+    def save_crash_log(
+        self,
+        pane_id: str,
+        crash_log_path: str,
+        *,
+        lines: int = 1000,
+    ) -> None:
+        pass

--- a/test/test_ccbd_project_clear.py
+++ b/test/test_ccbd_project_clear.py
@@ -65,7 +65,7 @@ def _app(
 
 def test_project_clear_context_handler_sends_provider_clear_to_all_agent_panes(monkeypatch) -> None:
     backend = _FakeBackend()
-    monkeypatch.setattr(project_clear, 'TmuxBackend', lambda *, socket_path: backend)
+    monkeypatch.setattr(project_clear, 'make_terminal_backend', lambda *, socket_path: backend)
     handler = build_project_clear_context_handler(
         _app(
             runtimes={
@@ -97,7 +97,7 @@ def test_project_clear_context_handler_sends_provider_clear_to_all_agent_panes(m
 
 def test_project_clear_context_handler_targets_requested_agents_once(monkeypatch) -> None:
     backend = _FakeBackend()
-    monkeypatch.setattr(project_clear, 'TmuxBackend', lambda *, socket_path: backend)
+    monkeypatch.setattr(project_clear, 'make_terminal_backend', lambda *, socket_path: backend)
     handler = build_project_clear_context_handler(
         _app(
             runtimes={
@@ -122,7 +122,7 @@ def test_project_clear_context_handler_targets_requested_agents_once(monkeypatch
 
 def test_project_clear_context_handler_delays_opencode_submit(monkeypatch) -> None:
     backend = _FakeBackend()
-    monkeypatch.setattr(project_clear, 'TmuxBackend', lambda *, socket_path: backend)
+    monkeypatch.setattr(project_clear, 'make_terminal_backend', lambda *, socket_path: backend)
     monkeypatch.setattr(
         project_clear.time,
         'sleep',
@@ -162,7 +162,7 @@ def test_project_clear_context_handler_delays_opencode_submit(monkeypatch) -> No
 
 def test_project_clear_context_handler_skips_missing_runtime_or_pane(monkeypatch) -> None:
     backend = _FakeBackend(existing_panes={'%1'})
-    monkeypatch.setattr(project_clear, 'TmuxBackend', lambda *, socket_path: backend)
+    monkeypatch.setattr(project_clear, 'make_terminal_backend', lambda *, socket_path: backend)
     handler = build_project_clear_context_handler(
         _app(
             runtimes={
@@ -189,7 +189,7 @@ def test_project_clear_context_handler_rejects_unknown_target() -> None:
 
 def test_project_clear_context_handler_blocks_active_or_queued_agent(monkeypatch) -> None:
     backend = _FakeBackend()
-    monkeypatch.setattr(project_clear, 'TmuxBackend', lambda *, socket_path: backend)
+    monkeypatch.setattr(project_clear, 'make_terminal_backend', lambda *, socket_path: backend)
     state = SimpleNamespace(
         active_job=lambda agent_name: 'job_active' if agent_name == 'agent1' else None,
         queue_depth=lambda agent_name: 2 if agent_name == 'agent1' else 0,

--- a/test/test_ccbd_runtime_refresh.py
+++ b/test/test_ccbd_runtime_refresh.py
@@ -168,7 +168,7 @@ def test_refresh_provider_binding_replaces_missing_project_pane_inside_workspace
         lambda **kwargs: replacement_context,
     )
     monkeypatch.setattr(
-        'ccbd.services.project_namespace_runtime.slot_replacement.TmuxBackend',
+        'ccbd.services.project_namespace_runtime.slot_replacement.make_terminal_backend',
         lambda socket_path=None: backend,
     )
 

--- a/test/test_layout_status_cli.py
+++ b/test/test_layout_status_cli.py
@@ -439,7 +439,7 @@ main = "main:fake, helper:fake"
                 )
             )
 
-    monkeypatch.setattr(layout_status_service, 'TmuxBackend', FakeTmuxBackend)
+    monkeypatch.setattr(layout_status_service, 'make_terminal_backend', FakeTmuxBackend)
     monkeypatch.setattr(layout_status_service.shutil, 'which', lambda _name: '/usr/bin/tmux')
     monkeypatch.setattr(
         layout_status_service,

--- a/test/test_terminal_runtime_backend_selection.py
+++ b/test/test_terminal_runtime_backend_selection.py
@@ -1,7 +1,14 @@
 from __future__ import annotations
 
+import pytest
+
 import terminal_runtime.backend_selection as backend_selection_module
-from terminal_runtime.backend_selection import TerminalBackendSelection, TerminalLayoutService
+from terminal_runtime.backend_selection import (
+    TerminalBackendSelection,
+    TerminalLayoutService,
+    make_terminal_backend,
+)
+from terminal_runtime.tmux_backend import TmuxBackend
 
 
 class _FakeBackend:
@@ -49,6 +56,37 @@ def test_backend_selection_uses_session_terminal_field() -> None:
     assert selection.get_pane_id_from_session({'tmux_session': '%old'}) == '%old'
 
 
+@pytest.mark.parametrize('terminal_type', [None, 'tmux'])
+def test_make_terminal_backend_returns_tmux_backend(terminal_type) -> None:
+    assert isinstance(make_terminal_backend(terminal_type), TmuxBackend)
+
+
+def test_make_terminal_backend_rejects_unimplemented_herdr_backend() -> None:
+    with pytest.raises(
+        NotImplementedError,
+        match='herdr terminal backend lands in PR #2',
+    ):
+        make_terminal_backend('herdr')
+
+
+def test_backend_selection_rejects_unimplemented_herdr_backend() -> None:
+    selection = TerminalBackendSelection(
+        detect_terminal_fn=lambda: 'tmux',
+        tmux_backend_factory=lambda: _FakeBackend('tmux'),
+    )
+
+    with pytest.raises(
+        NotImplementedError,
+        match='herdr terminal backend lands in PR #2',
+    ):
+        selection.get_backend('herdr')
+
+
+def test_tmux_backend_satisfies_terminal_backend_abstract_contract() -> None:
+    assert TmuxBackend.__abstractmethods__ == frozenset()
+    assert isinstance(TmuxBackend(), TmuxBackend)
+
+
 def test_terminal_layout_service_delegates_to_runtime_layout() -> None:
     backend = _FakeBackend('tmux')
     captured: dict[str, object] = {}
@@ -81,3 +119,16 @@ def test_terminal_layout_service_delegates_to_runtime_layout() -> None:
     assert captured['backend'] is backend
     assert captured['detached_session_name'] == 'ccb-demo-1'
     assert captured['inside_tmux'] is True
+
+
+def test_terminal_layout_service_rejects_unimplemented_herdr_backend() -> None:
+    service = TerminalLayoutService(
+        tmux_backend_factory=lambda: _FakeBackend('tmux'),
+        detached_session_name_fn=lambda **kwargs: 'ccb-demo-1',
+    )
+
+    with pytest.raises(
+        NotImplementedError,
+        match='herdr terminal backend lands in PR #2',
+    ):
+        service.create_auto_layout([], cwd='/tmp/demo', terminal_type='herdr')

--- a/test/test_v2_start_service.py
+++ b/test/test_v2_start_service.py
@@ -132,7 +132,7 @@ def test_foreground_start_refreshes_sidebar_with_current_cli_when_daemon_is_reus
         lambda config: topology_plan,
     )
     monkeypatch.setattr(
-        'cli.services.start.TmuxBackend',
+        'cli.services.start.make_terminal_backend',
         lambda *, socket_path: seen.setdefault('backend_socket', socket_path) and backend,
     )
 

--- a/test/test_v2_tmux_start_layout.py
+++ b/test/test_v2_tmux_start_layout.py
@@ -59,7 +59,7 @@ def test_prepare_tmux_start_layout_uses_current_pane_as_cmd_anchor(monkeypatch, 
             }
             return mapping[(direction, str(parent_pane_id))]
 
-    monkeypatch.setattr(tmux_start_layout, 'TmuxBackend', FakeTmuxBackend)
+    monkeypatch.setattr(tmux_start_layout, 'make_terminal_backend', FakeTmuxBackend)
 
     layout = tmux_start_layout.prepare_tmux_start_layout(
         ctx,
@@ -105,7 +105,7 @@ def test_prepare_tmux_start_layout_uses_explicit_percent_hint(monkeypatch, tmp_p
             split_calls.append((parent_pane_id, direction, percent))
             return '%1'
 
-    monkeypatch.setattr(tmux_start_layout, 'TmuxBackend', FakeTmuxBackend)
+    monkeypatch.setattr(tmux_start_layout, 'make_terminal_backend', FakeTmuxBackend)
 
     layout = tmux_start_layout.prepare_tmux_start_layout(
         ctx,
@@ -161,7 +161,7 @@ def test_prepare_tmux_start_layout_assigns_slot_stable_styles(monkeypatch, tmp_p
             }
             return mapping[(direction, str(parent_pane_id))]
 
-    monkeypatch.setattr(tmux_start_layout, 'TmuxBackend', FakeTmuxBackend)
+    monkeypatch.setattr(tmux_start_layout, 'make_terminal_backend', FakeTmuxBackend)
 
     layout = tmux_start_layout.prepare_tmux_start_layout(
         ctx,
@@ -212,7 +212,7 @@ def test_prepare_tmux_start_layout_uses_root_pane_for_first_agent_when_cmd_disab
         ) -> str:
             raise AssertionError('single-agent no-cmd layout should reuse root pane')
 
-    monkeypatch.setattr(tmux_start_layout, 'TmuxBackend', FakeTmuxBackend)
+    monkeypatch.setattr(tmux_start_layout, 'make_terminal_backend', FakeTmuxBackend)
 
     layout = tmux_start_layout.prepare_tmux_start_layout(
         ctx,
@@ -273,7 +273,7 @@ def test_prepare_tmux_start_layout_creates_split_panes_with_placeholder(monkeypa
             live_panes.add(pane_id)
             return pane_id
 
-    monkeypatch.setattr(tmux_start_layout, 'TmuxBackend', FakeTmuxBackend)
+    monkeypatch.setattr(tmux_start_layout, 'make_terminal_backend', FakeTmuxBackend)
 
     layout = tmux_start_layout.prepare_tmux_start_layout(
         ctx,


### PR DESCRIPTION
Prep refactor for a pluggable terminal backend, per #276 (herdr backend + the Windows interest you raised). **No behavior change** — tmux stays the default and the only implementation.

This is **PR 1 of 2**. PR 2 adds `HerdrBackend` on top of this seam.

## What changes

- **Widen `TerminalBackend`** (`terminal_runtime/backend_types.py`) from 5 methods to the full contract `TmuxBackend` actually exposes — **21 `@abstractmethod` + 3 safe no-op defaults** (`set_pane_style`, `refresh_pane_logs`, `save_crash_log`) — so a second backend shares one typed interface. Signatures were copied verbatim from `TmuxBackend`; a conformance test asserts `TmuxBackend.__abstractmethods__` is empty.
- **Single construction point** `make_terminal_backend()` (`terminal_runtime/backend_selection.py`); all **11** direct `TmuxBackend(...)` call sites now route through it (kwargs preserved).
- **`herdr` selector branch** (stub → `NotImplementedError`) added to the factory, `TerminalBackendSelection.get_backend`, and `TerminalLayoutService.create_auto_layout`. tmux paths are unchanged.

## Why widen the ABC (the open question from #276)

The ABC declared only 5 methods, but callers rely on ~24 of `TmuxBackend`'s. Widening to the real contract gives `HerdrBackend` (and a future Windows-native backend) one typed interface to implement, instead of duck-typing against `TmuxBackend`'s de-facto surface. If you'd prefer a narrower ABC or a different split, I'm happy to adjust — this PR is meant to settle that shape **before** the herdr implementation lands.

## Testing

- Seam suite green: **340 tests** across `test_terminal_runtime_backend_selection`, `test_tmux_backend`, `test_detect_terminal`, `test_terminal_runtime_layouts`, `test_v2_tmux_start_layout`, `test_ccbd_project_clear`, the layout CLIs, the `*_session_ensure_pane` tests, etc. (the live-smoke ones need a real tmux).
- New tests: factory returns `TmuxBackend` for `tmux`/`None` and raises for `herdr`; selector + layout `herdr` stubs raise; `TmuxBackend` ↔ ABC conformance.

## Scope

Touches only `terminal_runtime/*`, the 11 construction sites, and tests. No changes to the mailbox / lease / recovery / coordination layers — reply capture is session-file based, so those are backend-agnostic and unaffected.
