### PR TITLE
feat(mobile): support private LAN listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,8 @@ The phone app is a remote controller for real CCB projects running on a server. 
 
 Safety boundary:
 
-- The CCB gateway binds only to loopback, for example `127.0.0.1:8787`.
+- The CCB gateway binds to loopback by default, for example `127.0.0.1:8787`.
+- For direct LAN access, bind one specific private interface address (wildcard and public addresses are rejected): `ccb install mobile --route-provider lan --listen 192.168.31.155:8787`. The pairing URL is inferred from `--listen`; no forwarding process or `--public-url` is needed.
 - Remote access uses Tailscale Serve, not Tailscale Funnel.
 - CCB does not store Tailscale passwords, OAuth tokens, admin API tokens, or automatically modify tailnet ACLs/grants.
 - The phone receives only the scopes authorized by the pairing profile, such as view, content, terminal, file upload, and file download.

--- a/README/zh.md
+++ b/README/zh.md
@@ -221,7 +221,8 @@ CCB 8.3.1 已把 Flutter 版 CCB Mobile 源码放入 [`mobile/`](../mobile/)，�
 
 安全边界：
 
-- CCB gateway 只绑定 loopback，例如 `127.0.0.1:8787`。
+- CCB gateway 默认绑定 loopback，例如 `127.0.0.1:8787`。
+- 局域网直连时可绑定一个明确的私网网卡地址（拒绝通配地址和公网地址）：`ccb install mobile --route-provider lan --listen 192.168.31.155:8787`。配对 URL 会从 `--listen` 自动推导，无需额外转发进程或 `--public-url`。
 - 远程访问使用 Tailscale Serve，不启用 Tailscale Funnel。
 - CCB 不保存 Tailscale 密码、OAuth token、admin API token，也不会自动修改 tailnet ACL/grants。
 - 手机只获得 pairing profile 授权的 scope，例如 view、content、terminal、file upload 和 file download。

--- a/lib/cli/parser_runtime/commands.py
+++ b/lib/cli/parser_runtime/commands.py
@@ -112,7 +112,11 @@ def parse_mobile(tokens: list[str], *, project: str | None, error_type) -> Parse
     if action != 'serve':
         raise error_type('mobile only supports: serve, devices, revoke')
     parser = argparse.ArgumentParser(prog='ccb mobile serve', add_help=False)
-    parser.add_argument('--listen', default='127.0.0.1:8787')
+    parser.add_argument(
+        '--listen',
+        default='127.0.0.1:8787',
+        help='HOST:PORT; route-provider lan also accepts a specific private interface IP',
+    )
     parser.add_argument('--public-url', default=None)
     parser.add_argument(
         '--route-provider',

--- a/lib/cli/router.py
+++ b/lib/cli/router.py
@@ -72,7 +72,7 @@ def print_start_help(*, file=None) -> None:
               ccb config ui        Open the local project configuration panel.
               ccb maintenance status Show maintenance heartbeat config and stored status.
               ccb maintenance tick   Run one maintenance heartbeat diagnosis tick.
-              ccb mobile serve       Start the loopback CCB Mobile gateway for the current project.
+              ccb mobile serve       Start the CCB Mobile gateway for the current project.
               ccb mobile devices     List paired mobile devices for the current project.
               ccb mobile revoke <id> Revoke one paired mobile device locally.
               ccb agent add NAME:PROVIDER --role ROLE [--window NAME|--window-class CLASS] --hidden --json
@@ -404,10 +404,13 @@ _COMMAND_HELP = {
 
         CCB Mobile gateway:
           ccb mobile serve
-              Start the loopback, current-project HTTP gateway and emit a
-              short-lived pairing code.
+              Start the current-project HTTP gateway on loopback by default
+              and emit a short-lived pairing code.
           ccb mobile serve --listen 127.0.0.1:0
               Start on a dynamic loopback port.
+          ccb mobile serve --listen 192.168.31.155:8787 --route-provider lan
+              Bind one specific private interface for direct LAN access and
+              infer the pairing URL from the listen address.
           ccb mobile serve --listen 127.0.0.1:8787 --public-url https://mobile.example.com --route-provider cloudflare_tunnel
               Keep the gateway loopback-bound but emit Cloudflare route
               metadata in the pairing payload.
@@ -608,7 +611,11 @@ def _build_management_parser() -> argparse.ArgumentParser:
 
     install_parser = subparsers.add_parser("install", help="Install or activate optional CCB capabilities")
     install_parser.add_argument("target", nargs="?", help="'mobile' to start the server-wide CCB Mobile gateway")
-    install_parser.add_argument("--listen", default="127.0.0.1:8787")
+    install_parser.add_argument(
+        "--listen",
+        default="127.0.0.1:8787",
+        help="HOST:PORT; route-provider lan also accepts a specific private interface IP",
+    )
     install_parser.add_argument("--public-url", default=None)
     install_parser.add_argument(
         "--route-provider",

--- a/lib/cli/services/mobile.py
+++ b/lib/cli/services/mobile.py
@@ -39,7 +39,8 @@ class MobileGatewayServeHandle:
 
 
 def prepare_mobile_gateway(context, command) -> MobileGatewayServeHandle:
-    listen = parse_listen_address(command.listen)
+    route_provider = str(command.route_provider or 'lan').strip().lower() or 'lan'
+    listen = parse_listen_address(command.listen, allow_lan=route_provider == 'lan')
     push_sender, push_diagnostic, push_options = _push_sender_setup()
     service = MobileGatewayService(
         project_id=context.project.project_id,
@@ -55,7 +56,6 @@ def prepare_mobile_gateway(context, command) -> MobileGatewayServeHandle:
     host, port = server.server_address[:2]
     local_gateway_url = f'http://{host}:{port}'
     gateway_url = _public_gateway_url(command.public_url, fallback=local_gateway_url)
-    route_provider = str(command.route_provider or 'lan')
     pairing = service.ensure_reusable_pairing_payload(
         gateway_url=gateway_url,
         route_provider=route_provider,
@@ -107,7 +107,8 @@ def prepare_server_mobile_gateway(
     rotate_pairing: bool = False,
 ) -> MobileGatewayServeHandle:
     registry = project_registry or _running_server_project_registry()
-    listen = parse_listen_address(command.listen)
+    route_provider = str(command.route_provider or 'lan').strip().lower() or 'lan'
+    listen = parse_listen_address(command.listen, allow_lan=route_provider == 'lan')
     resolved_host_id = str(host_id or '').strip() or _server_host_id()
     state_dir = mobile_host_state_dir()
     default_project = registry.default_project
@@ -142,7 +143,6 @@ def prepare_server_mobile_gateway(
         host, port = server.server_address[:2]
         local_gateway_url = f'http://{host}:{port}'
         gateway_url = _public_gateway_url(command.public_url, fallback=local_gateway_url)
-        route_provider = str(command.route_provider or 'lan')
         pairing = (
             service.rotate_reusable_pairing_payload(
                 gateway_url=gateway_url,

--- a/lib/mobile_gateway/service.py
+++ b/lib/mobile_gateway/service.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 import hashlib
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import ipaddress
 import json
 import mimetypes
 from pathlib import Path
@@ -2124,7 +2125,7 @@ class MobileGatewayService:
         return 'unsupported_terminal_frame'
 
 
-def parse_listen_address(value: str | None) -> ListenAddress:
+def parse_listen_address(value: str | None, *, allow_lan: bool = False) -> ListenAddress:
     text = str(value or '').strip()
     if not text:
         return ListenAddress()
@@ -2140,7 +2141,12 @@ def parse_listen_address(value: str | None) -> ListenAddress:
     if port < 0 or port > 65535:
         raise ValueError('listen port must be between 0 and 65535')
     if not _is_loopback_host(host):
-        raise ValueError('mobile gateway only supports loopback listen addresses')
+        if not allow_lan:
+            raise ValueError('mobile gateway only supports loopback listen addresses for this route provider')
+        if not _is_private_lan_host(host):
+            raise ValueError(
+                'LAN mobile gateway listen address must be a specific private or link-local IP address'
+            )
     return ListenAddress(host=host, port=port)
 
 
@@ -2632,6 +2638,19 @@ def _project_health_refresh_failed(payload: dict[str, object]) -> bool:
 def _is_loopback_host(host: str) -> bool:
     normalized = host.strip().lower()
     return normalized in {'localhost', '127.0.0.1', '::1'}
+
+
+def _is_private_lan_host(host: str) -> bool:
+    try:
+        address = ipaddress.ip_address(host.strip())
+    except ValueError:
+        return False
+    return bool(
+        (address.is_private or address.is_link_local)
+        and not address.is_unspecified
+        and not address.is_multicast
+        and not address.is_reserved
+    )
 
 
 def _utc_now() -> str:

--- a/test/test_mobile_cli_service.py
+++ b/test/test_mobile_cli_service.py
@@ -232,6 +232,25 @@ def test_prepare_server_mobile_gateway_uses_running_projects(tmp_path: Path, mon
         handle.close()
 
 
+def test_prepare_server_mobile_gateway_rejects_lan_listener_for_tailnet(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr('cli.services.mobile.mobile_host_state_dir', lambda: tmp_path / 'mobile-state')
+    client = _FakeCcbdClient(project_id='proj-one', project_root='/srv/one', display_name='one')
+    registry = MobileGatewayProjectRegistry([
+        MobileGatewayProject('proj-one', Path('/srv/one'), lambda: client, display_name='one'),
+    ])
+
+    with pytest.raises(ValueError, match='loopback'):
+        prepare_server_mobile_gateway(
+            SimpleNamespace(
+                listen='192.168.31.155:8787',
+                public_url=None,
+                route_provider='tailnet',
+            ),
+            project_registry=registry,
+            host_id='host-test',
+        )
+
+
 def test_prepare_server_mobile_gateway_reports_redacted_push_sender_diagnostic(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/test/test_mobile_gateway_service.py
+++ b/test/test_mobile_gateway_service.py
@@ -400,12 +400,27 @@ def _server_registry_service(
     )
 
 
-def test_parse_listen_accepts_loopback_only() -> None:
+def test_parse_listen_defaults_to_loopback_only() -> None:
     assert parse_listen_address(None).text == '127.0.0.1:8787'
     assert parse_listen_address('127.0.0.1:0').text == '127.0.0.1:0'
     assert parse_listen_address('localhost:8787').text == 'localhost:8787'
     with pytest.raises(ValueError, match='loopback'):
-        parse_listen_address('0.0.0.0:8787')
+        parse_listen_address('192.168.31.155:8787')
+
+
+def test_parse_listen_accepts_specific_private_ip_for_lan() -> None:
+    assert (
+        parse_listen_address('192.168.31.155:8787', allow_lan=True).text
+        == '192.168.31.155:8787'
+    )
+    assert parse_listen_address('10.0.0.7:0', allow_lan=True).text == '10.0.0.7:0'
+    assert parse_listen_address('169.254.10.2:8787', allow_lan=True).text == '169.254.10.2:8787'
+
+
+@pytest.mark.parametrize('host', ('0.0.0.0', '8.8.8.8', 'mobile.example.com'))
+def test_parse_listen_rejects_non_specific_or_non_private_lan_host(host: str) -> None:
+    with pytest.raises(ValueError, match='specific private or link-local'):
+        parse_listen_address(f'{host}:8787', allow_lan=True)
 
 
 def test_health_and_projects_use_ccbd_without_exposing_tmux_socket() -> None:


### PR DESCRIPTION
## Summary

- allow `ccb mobile serve` and `ccb install mobile` to bind a specific private or link-local interface when `--route-provider lan` is selected
- infer the pairing URL directly from the LAN listen address, removing the need for a separate `socat` forwarder or `--public-url`
- retain loopback-only behavior for Tailnet, Cloudflare Tunnel, and relay routes, while rejecting wildcard, public, and hostname LAN listeners
- document the direct LAN command and add validation coverage

## Testing

- `python3 -m pytest -q test/test_v2_cli_parser.py test/test_v2_cli_router.py test/test_v2_cli_render.py -k mobile` (12 passed)
- `python3 -m pytest -q test/test_mobile_gateway_service.py -k parse_listen` (5 passed)
- `python3 -m pytest -q test/test_mobile_cli_service.py -k rejects_lan_listener` (1 passed)
- full mobile gateway/CLI/host suite before rebase: 133 passed