### PR TITLE
feat(mobile): add automatic app updates

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -215,6 +215,7 @@ jobs:
           }
           print(json.dumps(manifest, indent=2, sort_keys=False))
           PY
+          cp "dist-release/ccb-mobile-${TAG_NAME}.json" "dist-release/ccb-mobile-latest.json"
 
       - name: Upload mobile workflow artifacts
         uses: actions/upload-artifact@v4
@@ -223,6 +224,7 @@ jobs:
           path: |
             dist-release/ccb-mobile-${{ github.event.inputs.tag || github.ref_name }}.apk
             dist-release/ccb-mobile-${{ github.event.inputs.tag || github.ref_name }}.json
+            dist-release/ccb-mobile-latest.json
           if-no-files-found: error
 
   publish:
@@ -256,6 +258,7 @@ jobs:
           test -f ccb-macos-universal.tar.gz
           test -f "ccb-mobile-${TAG_NAME}.apk"
           test -f "ccb-mobile-${TAG_NAME}.json"
+          test -f "ccb-mobile-latest.json"
           sha256sum ccb-*.tar.gz ccb-mobile-*.apk ccb-mobile-*.json | sort -k2 > SHA256SUMS
           sha256sum -c SHA256SUMS
           notes_file="$GITHUB_WORKSPACE/docs/releases/${TAG_NAME}.md"
@@ -275,6 +278,6 @@ jobs:
               --title "$TAG_NAME" \
               --notes-file "$notes_file"
           fi
-          gh release upload "$TAG_NAME" ccb-linux-x86_64.tar.gz ccb-macos-universal.tar.gz "ccb-mobile-${TAG_NAME}.apk" "ccb-mobile-${TAG_NAME}.json" SHA256SUMS \
+          gh release upload "$TAG_NAME" ccb-linux-x86_64.tar.gz ccb-macos-universal.tar.gz "ccb-mobile-${TAG_NAME}.apk" "ccb-mobile-${TAG_NAME}.json" ccb-mobile-latest.json SHA256SUMS \
             --repo "$GITHUB_REPOSITORY" \
             --clobber

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -18,6 +18,16 @@ CCB Mobile v8.3.1 is published as an Android APK:
 - Server setup entrypoint: `ccb update mobile`
 - App source: [`app/`](app/)
 
+### Android app updates
+
+The Android app checks the latest GitHub release after startup and also exposes
+a manual **Check for updates** action in the connection settings. When GitHub
+is unreachable, release metadata and APK downloads fall back to `gh-proxy.com`,
+`ghfast.top`, and `ghproxy.net`, in that order. The downloaded APK must match
+the size and SHA-256 digest in the release manifest before Android's installer
+is opened. Android still requires the user to approve the signed APK update;
+the app does not perform silent installation.
+
 The app is designed for real server-side CCB projects, not a demo-only flow.
 It connects to the server-wide mobile gateway, lists mounted CCB projects,
 renders agent transcripts, sends pane-native text input, opens terminal views,

--- a/mobile/app/android/app/src/main/AndroidManifest.xml
+++ b/mobile/app/android/app/src/main/AndroidManifest.xml
@@ -1,9 +1,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_REMOTE_MESSAGING" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <uses-feature android:name="android.hardware.camera" android:required="false" />
 
     <application

--- a/mobile/app/lib/app/app_update.dart
+++ b/mobile/app/lib/app/app_update.dart
@@ -1,6 +1,22 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:open_filex/open_filex.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
 const ccbMobileDefaultVersion = '8.3.1+8030001';
 const ccbMobileDefaultApkDownloadUrl =
-    'https://github.com/bfly123/claude_code_bridge/releases/latest';
+    'https://github.com/SeemSeam/claude_codex_bridge/releases/latest';
+const ccbMobileReleaseApiUrl =
+    'https://api.github.com/repos/SeemSeam/claude_codex_bridge/releases/latest';
+const ccbMobileLatestManifestUrl =
+    'https://github.com/SeemSeam/claude_codex_bridge/releases/latest/download/ccb-mobile-latest.json';
+const ccbMobileJsdelivrVersionsUrl =
+    'https://data.jsdelivr.com/v1/package/gh/SeemSeam/claude_codex_bridge';
+const _ccbMobileGithubReleasePath =
+    '/SeemSeam/claude_codex_bridge/releases/';
 
 const ccbMobileCurrentVersion = String.fromEnvironment(
   'CCB_MOBILE_VERSION',
@@ -12,6 +28,12 @@ const ccbMobileApkDownloadUrl = String.fromEnvironment(
   defaultValue: ccbMobileDefaultApkDownloadUrl,
 );
 
+const ccbMobileGithubProxyPrefixes = <String>[
+  'https://gh-proxy.com/',
+  'https://ghfast.top/',
+  'https://ghproxy.net/',
+];
+
 class CcbMobileUpdateInfo {
   const CcbMobileUpdateInfo({
     this.version = ccbMobileCurrentVersion,
@@ -20,4 +42,484 @@ class CcbMobileUpdateInfo {
 
   final String version;
   final String apkDownloadUrl;
+}
+
+class CcbMobileRelease {
+  const CcbMobileRelease({
+    required this.version,
+    required this.versionCode,
+    required this.apkDownloadUrl,
+    required this.sha256,
+    required this.sizeBytes,
+    required this.releasePageUrl,
+  });
+
+  final String version;
+  final int versionCode;
+  final String apkDownloadUrl;
+  final String sha256;
+  final int sizeBytes;
+  final String releasePageUrl;
+}
+
+class CcbMobileUpdateCheckResult {
+  const CcbMobileUpdateCheckResult({required this.currentVersion, this.release});
+
+  final String currentVersion;
+  final CcbMobileRelease? release;
+
+  bool get updateAvailable => release != null;
+}
+
+class CcbMobileUpdateException implements Exception {
+  const CcbMobileUpdateException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+typedef CcbMobileUpdateBytesFetcher = Future<List<int>> Function(
+  Uri uri,
+  int maxBytes,
+);
+typedef CcbMobileUpdateFileDownloader = Future<void> Function(
+  Uri uri,
+  File target,
+  int maxBytes,
+);
+
+class CcbMobileUpdateService {
+  CcbMobileUpdateService({
+    this.currentVersion = ccbMobileCurrentVersion,
+    List<String>? proxyPrefixes,
+    CcbMobileUpdateBytesFetcher? fetchBytes,
+    CcbMobileUpdateFileDownloader? downloadFile,
+    Future<Directory> Function()? downloadDirectory,
+  }) : proxyPrefixes = proxyPrefixes ?? ccbMobileGithubProxyPrefixes,
+       _fetchBytes = fetchBytes ?? _httpGetBytes,
+       _downloadFile = downloadFile ?? _httpDownloadFile,
+       _downloadDirectory = downloadDirectory ?? getTemporaryDirectory;
+
+  final String currentVersion;
+  final List<String> proxyPrefixes;
+  final CcbMobileUpdateBytesFetcher _fetchBytes;
+  final CcbMobileUpdateFileDownloader _downloadFile;
+  final Future<Directory> Function() _downloadDirectory;
+
+  Future<CcbMobileUpdateCheckResult> checkForUpdate() async {
+    Object? lastError;
+    try {
+      final uri = Uri.parse(ccbMobileReleaseApiUrl);
+      final releasePayload = _jsonObject(
+        await _fetchBytes(uri, 2 * 1024 * 1024),
+        source: uri,
+      );
+      _validateGithubReleasePayload(releasePayload);
+      final release = await _releaseFromGithubPayload(releasePayload);
+      return _checkResult(release);
+    } catch (error) {
+      lastError = error;
+    }
+    for (final uri in _sourceUris(ccbMobileLatestManifestUrl)) {
+      try {
+        final manifest = _jsonObject(
+          await _fetchBytes(uri, 256 * 1024),
+          source: uri,
+        );
+        final version = _requiredVersion(
+          manifest['version'],
+          'release version',
+        );
+        final release = _parseManifest(
+          manifest,
+          expectedVersion: version,
+          releasePageUrl: ccbMobileDefaultApkDownloadUrl,
+        );
+        return _checkResult(release);
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    try {
+      final versionsUri = Uri.parse(ccbMobileJsdelivrVersionsUrl);
+      final versionsPayload = _jsonObject(
+        await _fetchBytes(versionsUri, 256 * 1024),
+        source: versionsUri,
+      );
+      final version = _latestReleaseVersion(versionsPayload);
+      final manifestUrl =
+          'https://github.com/SeemSeam/claude_codex_bridge/releases/download/v$version/ccb-mobile-v$version.json';
+      for (final uri in _sourceUris(manifestUrl)) {
+        try {
+          final manifest = _jsonObject(
+            await _fetchBytes(uri, 256 * 1024),
+            source: uri,
+          );
+          final release = _parseManifest(
+            manifest,
+            expectedVersion: version,
+            releasePageUrl:
+                'https://github.com/SeemSeam/claude_codex_bridge/releases/tag/v$version',
+          );
+          return _checkResult(release);
+        } catch (error) {
+          lastError = error;
+        }
+      }
+    } catch (error) {
+      lastError = error;
+    }
+    throw CcbMobileUpdateException(
+      'Unable to check the CCB Mobile release: ${lastError ?? 'no update source available'}',
+    );
+  }
+
+  Future<File> downloadApk(CcbMobileRelease release) async {
+    Object? lastError;
+    final directory = await _downloadDirectory();
+    await directory.create(recursive: true);
+    final file = File(
+      p.join(directory.path, 'ccb-mobile-v${release.version}.apk'),
+    );
+    for (final uri in _sourceUris(release.apkDownloadUrl)) {
+      try {
+        await _downloadFile(uri, file, _maximumApkBytes(release));
+        if (release.sizeBytes > 0 && await file.length() != release.sizeBytes) {
+          throw const CcbMobileUpdateException('Downloaded APK size mismatch');
+        }
+        final actualDigest = (await sha256.bind(file.openRead()).first).toString();
+        if (actualDigest.toLowerCase() != release.sha256.toLowerCase()) {
+          throw const CcbMobileUpdateException('Downloaded APK checksum mismatch');
+        }
+        return file;
+      } catch (error) {
+        lastError = error;
+        if (await file.exists()) {
+          await file.delete();
+        }
+      }
+    }
+    throw CcbMobileUpdateException(
+      'Unable to download the CCB Mobile APK: ${lastError ?? 'no download source available'}',
+    );
+  }
+
+  Future<CcbMobileRelease> _releaseFromGithubPayload(
+    Map<String, Object?> payload,
+  ) async {
+    final tag = _requiredText(payload['tag_name'], 'release tag');
+    final version = _requiredVersion(
+      tag.startsWith('v') ? tag.substring(1) : tag,
+      'release version',
+    );
+    final assets = payload['assets'];
+    if (assets is! List) {
+      throw const FormatException('release assets are missing');
+    }
+    final manifestName = 'ccb-mobile-$tag.json';
+    final manifestUrl = _assetUrl(assets, manifestName);
+    Object? lastError;
+    for (final uri in _sourceUris(manifestUrl)) {
+      try {
+        final manifest = _jsonObject(
+          await _fetchBytes(uri, 256 * 1024),
+          source: uri,
+        );
+        return _parseManifest(
+          manifest,
+          expectedVersion: version,
+          releasePageUrl:
+              _optionalGithubUrl(payload['html_url']) ??
+              ccbMobileDefaultApkDownloadUrl,
+        );
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    throw CcbMobileUpdateException(
+      'Unable to load the mobile release manifest: $lastError',
+    );
+  }
+
+  CcbMobileRelease _parseManifest(
+    Map<String, Object?> manifest, {
+    required String expectedVersion,
+    required String releasePageUrl,
+  }) {
+    if (manifest['schema_version'] != 1 ||
+        manifest['version']?.toString() != expectedVersion) {
+      throw const FormatException('mobile release manifest version mismatch');
+    }
+    final android = manifest['android'];
+    if (android is! Map ||
+        android['application_id'] != 'io.ccb.mobile.ccb_mobile') {
+      throw const FormatException('mobile release manifest is not for this app');
+    }
+    final sha = _requiredText(android['sha256'], 'APK checksum').toLowerCase();
+    if (!RegExp(r'^[0-9a-f]{64}$').hasMatch(sha)) {
+      throw const FormatException('invalid APK checksum');
+    }
+    final versionName = _requiredText(
+      android['version_name'],
+      'Android version',
+    );
+    if (versionName != expectedVersion) {
+      throw const FormatException('Android version does not match release tag');
+    }
+    final apkUrl = _requiredCcbReleaseUrl(android['download_url'], 'APK URL');
+    if (!Uri.parse(apkUrl).path.endsWith('/ccb-mobile-v$expectedVersion.apk')) {
+      throw const FormatException('APK URL does not match release tag');
+    }
+    return CcbMobileRelease(
+      version: versionName,
+      versionCode: _requiredInt(android['version_code'], 'Android version code'),
+      apkDownloadUrl: apkUrl,
+      sha256: sha,
+      sizeBytes: _requiredInt(android['size_bytes'], 'APK size'),
+      releasePageUrl: releasePageUrl,
+    );
+  }
+
+  bool _isNewer(CcbMobileRelease release) {
+    final currentCode = _buildCode(currentVersion);
+    if (currentCode != null) {
+      return release.versionCode > currentCode;
+    }
+    return compareCcbMobileVersions(release.version, currentVersion) > 0;
+  }
+
+  CcbMobileUpdateCheckResult _checkResult(CcbMobileRelease release) =>
+      CcbMobileUpdateCheckResult(
+        currentVersion: currentVersion,
+        release: _isNewer(release) ? release : null,
+      );
+
+  Iterable<Uri> _sourceUris(String original) sync* {
+    final uri = Uri.parse(original);
+    if (!_isAllowedGithubUri(uri)) {
+      throw FormatException('update URL is not an allowed GitHub URL: $uri');
+    }
+    yield uri;
+    for (final prefix in proxyPrefixes) {
+      final normalized = prefix.endsWith('/') ? prefix : '$prefix/';
+      final proxyUri = Uri.parse('$normalized$original');
+      if (proxyUri.scheme != 'https' || proxyUri.userInfo.isNotEmpty) {
+        throw FormatException('update proxy must use HTTPS: $prefix');
+      }
+      yield proxyUri;
+    }
+  }
+}
+
+String _latestReleaseVersion(Map<String, Object?> payload) {
+  final versions = payload['versions'];
+  if (versions is! List) {
+    throw const FormatException('jsDelivr release versions are missing');
+  }
+  for (final value in versions) {
+    final version = value?.toString().trim() ?? '';
+    if (RegExp(r'^\d+\.\d+\.\d+$').hasMatch(version)) {
+      return version;
+    }
+  }
+  throw const FormatException('jsDelivr has no valid release version');
+}
+
+void _validateGithubReleasePayload(Map<String, Object?> payload) {
+  final tag = _requiredText(payload['tag_name'], 'release tag');
+  final assets = payload['assets'];
+  if (assets is! List) {
+    throw const FormatException('release assets are missing');
+  }
+  _assetUrl(assets, 'ccb-mobile-$tag.json');
+}
+
+Future<void> installCcbMobileApk(File apk) async {
+  final result = await OpenFilex.open(
+    apk.path,
+    type: 'application/vnd.android.package-archive',
+  );
+  if (result.type != ResultType.done) {
+    throw CcbMobileUpdateException(result.message);
+  }
+}
+
+int compareCcbMobileVersions(String left, String right) {
+  final leftParts = _versionParts(left);
+  final rightParts = _versionParts(right);
+  final length = leftParts.length > rightParts.length
+      ? leftParts.length
+      : rightParts.length;
+  for (var index = 0; index < length; index += 1) {
+    final leftValue = index < leftParts.length ? leftParts[index] : 0;
+    final rightValue = index < rightParts.length ? rightParts[index] : 0;
+    if (leftValue != rightValue) {
+      return leftValue.compareTo(rightValue);
+    }
+  }
+  return 0;
+}
+
+List<int> _versionParts(String value) => value
+    .split('+')
+    .first
+    .split('.')
+    .map((part) => int.tryParse(part) ?? 0)
+    .toList(growable: false);
+
+int? _buildCode(String value) {
+  final parts = value.split('+');
+  return parts.length == 2 ? int.tryParse(parts.last) : null;
+}
+
+int _maximumApkBytes(CcbMobileRelease release) {
+  const hardLimit = 256 * 1024 * 1024;
+  if (release.sizeBytes <= 0 || release.sizeBytes > hardLimit) {
+    throw const FormatException('APK size is outside the allowed range');
+  }
+  return release.sizeBytes + 1;
+}
+
+Map<String, Object?> _jsonObject(List<int> bytes, {required Uri source}) {
+  final decoded = jsonDecode(utf8.decode(bytes));
+  if (decoded is! Map) {
+    throw FormatException('expected a JSON object from $source');
+  }
+  return {for (final entry in decoded.entries) entry.key.toString(): entry.value};
+}
+
+String _assetUrl(List<Object?> assets, String expectedName) {
+  for (final asset in assets) {
+    if (asset is Map && asset['name'] == expectedName) {
+      return _requiredCcbReleaseUrl(
+        asset['browser_download_url'],
+        expectedName,
+      );
+    }
+  }
+  throw FormatException('release asset is missing: $expectedName');
+}
+
+String _requiredText(Object? value, String name) {
+  final text = value?.toString().trim() ?? '';
+  if (text.isEmpty) {
+    throw FormatException('$name is missing');
+  }
+  return text;
+}
+
+String _requiredVersion(Object? value, String name) {
+  final version = _requiredText(value, name);
+  if (!RegExp(r'^\d+\.\d+\.\d+$').hasMatch(version)) {
+    throw FormatException('$name is invalid');
+  }
+  return version;
+}
+
+int _requiredInt(Object? value, String name) {
+  final parsed = value is int ? value : int.tryParse(value?.toString() ?? '');
+  if (parsed == null || parsed < 0) {
+    throw FormatException('$name is invalid');
+  }
+  return parsed;
+}
+
+String _requiredGithubUrl(Object? value, String name) {
+  final text = _requiredText(value, name);
+  final uri = Uri.parse(text);
+  if (!_isAllowedGithubUri(uri)) {
+    throw FormatException('$name is not an allowed GitHub URL');
+  }
+  return text;
+}
+
+String _requiredCcbReleaseUrl(Object? value, String name) {
+  final text = _requiredGithubUrl(value, name);
+  final uri = Uri.parse(text);
+  if (uri.host != 'github.com' ||
+      !uri.path.startsWith(_ccbMobileGithubReleasePath)) {
+    throw FormatException('$name is not a CCB Mobile release URL');
+  }
+  return text;
+}
+
+String? _optionalGithubUrl(Object? value) {
+  final text = value?.toString().trim() ?? '';
+  if (text.isEmpty) {
+    return null;
+  }
+  final uri = Uri.tryParse(text);
+  return uri != null && _isAllowedGithubUri(uri) ? text : null;
+}
+
+bool _isAllowedGithubUri(Uri uri) =>
+    uri.scheme == 'https' &&
+    (uri.host == 'github.com' || uri.host == 'api.github.com');
+
+Future<List<int>> _httpGetBytes(Uri uri, int maxBytes) async {
+  final client = HttpClient()..connectionTimeout = const Duration(seconds: 8);
+  try {
+    final request = await client.getUrl(uri).timeout(const Duration(seconds: 10));
+    request.headers.set(HttpHeaders.acceptHeader, 'application/json, */*');
+    request.headers.set(
+      HttpHeaders.userAgentHeader,
+      'CCB-Mobile/$ccbMobileCurrentVersion',
+    );
+    final response = await request.close().timeout(const Duration(seconds: 15));
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      await response.drain<void>();
+      throw HttpException('HTTP ${response.statusCode}', uri: uri);
+    }
+    if (response.contentLength > maxBytes) {
+      await response.drain<void>();
+      throw const CcbMobileUpdateException('Update response is too large');
+    }
+    final bytes = <int>[];
+    await for (final chunk in response.timeout(const Duration(seconds: 30))) {
+      bytes.addAll(chunk);
+      if (bytes.length > maxBytes) {
+        throw const CcbMobileUpdateException('Update response is too large');
+      }
+    }
+    return bytes;
+  } finally {
+    client.close(force: true);
+  }
+}
+
+Future<void> _httpDownloadFile(Uri uri, File target, int maxBytes) async {
+  final client = HttpClient()..connectionTimeout = const Duration(seconds: 8);
+  IOSink? sink;
+  try {
+    final request = await client.getUrl(uri).timeout(const Duration(seconds: 10));
+    request.headers.set(HttpHeaders.acceptHeader, 'application/octet-stream');
+    request.headers.set(
+      HttpHeaders.userAgentHeader,
+      'CCB-Mobile/$ccbMobileCurrentVersion',
+    );
+    final response = await request.close().timeout(const Duration(seconds: 15));
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      await response.drain<void>();
+      throw HttpException('HTTP ${response.statusCode}', uri: uri);
+    }
+    if (response.contentLength > maxBytes) {
+      await response.drain<void>();
+      throw const CcbMobileUpdateException('APK response is too large');
+    }
+    sink = target.openWrite();
+    var received = 0;
+    await for (final chunk in response.timeout(const Duration(seconds: 30))) {
+      received += chunk.length;
+      if (received > maxBytes) {
+        throw const CcbMobileUpdateException('APK response is too large');
+      }
+      sink.add(chunk);
+    }
+    await sink.flush();
+  } finally {
+    await sink?.close();
+    client.close(force: true);
+  }
 }

--- a/mobile/app/lib/app/ccb_mobile_app.dart
+++ b/mobile/app/lib/app/ccb_mobile_app.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
@@ -8,6 +9,7 @@ import '../l10n/ccb_mobile_localizations.dart';
 import '../pairing/gateway_pairing.dart';
 import '../repository/fake_mobile_ccb_repository.dart';
 import 'app_theme.dart';
+import 'app_update.dart';
 import 'background_connection.dart';
 
 class CcbMobileApp extends StatefulWidget {
@@ -17,6 +19,10 @@ class CcbMobileApp extends StatefulWidget {
     this.backgroundConnectionPreferenceStore,
     this.backgroundConnectionPlatform,
     this.profileStore,
+    this.updateService,
+    this.automaticUpdateCheck = true,
+    this.androidPlatformOverride,
+    this.installApk = installCcbMobileApk,
     super.key,
   });
 
@@ -26,12 +32,17 @@ class CcbMobileApp extends StatefulWidget {
   backgroundConnectionPreferenceStore;
   final BackgroundConnectionPlatform? backgroundConnectionPlatform;
   final GatewayHostProfileStore? profileStore;
+  final CcbMobileUpdateService? updateService;
+  final bool automaticUpdateCheck;
+  final bool? androidPlatformOverride;
+  final Future<void> Function(File apk) installApk;
 
   @override
   State<CcbMobileApp> createState() => _CcbMobileAppState();
 }
 
 class _CcbMobileAppState extends State<CcbMobileApp> {
+  final GlobalKey<NavigatorState> _navigatorKey = GlobalKey<NavigatorState>();
   late final CcbThemePreferenceStore _themePreferenceStore =
       widget.themePreferenceStore ?? FlutterCcbThemePreferenceStore();
   late final CcbBackgroundConnectionPreferenceStore
@@ -47,6 +58,94 @@ class _CcbMobileAppState extends State<CcbMobileApp> {
     super.initState();
     _loadThemePreference();
     _loadBackgroundConnectionPreference();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      unawaited(_checkForUpdateOnLaunch());
+    });
+  }
+
+  Future<void> _checkForUpdateOnLaunch() async {
+    final isAndroid = widget.androidPlatformOverride ?? Platform.isAndroid;
+    if (!widget.automaticUpdateCheck || !isAndroid) return;
+    try {
+      final service = widget.updateService ?? CcbMobileUpdateService();
+      final result = await service.checkForUpdate();
+      final release = result.release;
+      final dialogContext = _navigatorKey.currentContext;
+      if (!mounted || release == null || dialogContext == null) return;
+      await _showUpdateDialog(dialogContext, service, release);
+    } catch (_) {
+      // Startup checks are best-effort and must never block the app.
+    }
+  }
+
+  Future<void> _showUpdateDialog(
+    BuildContext dialogContext,
+    CcbMobileUpdateService service,
+    CcbMobileRelease release,
+  ) async {
+    var downloading = false;
+    String? errorMessage;
+    await showDialog<void>(
+      context: dialogContext,
+      builder: (context) => StatefulBuilder(
+        builder: (context, setDialogState) {
+          final strings = CcbMobileLocalizations.of(context);
+          return AlertDialog(
+            title: Text(strings.updateAvailableTitle),
+            content: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(strings.newVersionAvailable(release.version)),
+                if (downloading) ...[
+                  const SizedBox(height: 16),
+                  const LinearProgressIndicator(),
+                  const SizedBox(height: 8),
+                  Text(strings.downloadingVersion(release.version)),
+                ],
+                if (errorMessage != null) ...[
+                  const SizedBox(height: 12),
+                  Text(
+                    errorMessage!,
+                    style: TextStyle(color: Theme.of(context).colorScheme.error),
+                  ),
+                ],
+              ],
+            ),
+            actions: [
+              TextButton(
+                onPressed: downloading ? null : () => Navigator.of(context).pop(),
+                child: Text(strings.later),
+              ),
+              FilledButton(
+                key: const ValueKey('startup-update-install-button'),
+                onPressed: downloading
+                    ? null
+                    : () async {
+                        setDialogState(() {
+                          downloading = true;
+                          errorMessage = null;
+                        });
+                        try {
+                          final apk = await service.downloadApk(release);
+                          await widget.installApk(apk);
+                          if (context.mounted) Navigator.of(context).pop();
+                        } catch (_) {
+                          if (context.mounted) {
+                            setDialogState(() {
+                              downloading = false;
+                              errorMessage = strings.updateDownloadFailed;
+                            });
+                          }
+                        }
+                      },
+                child: Text(strings.updateNow),
+              ),
+            ],
+          );
+        },
+      ),
+    );
   }
 
   Future<void> _loadThemePreference() async {
@@ -89,6 +188,7 @@ class _CcbMobileAppState extends State<CcbMobileApp> {
   Widget build(BuildContext context) {
     final repository = FakeMobileCcbRepository.demo();
     return MaterialApp(
+      navigatorKey: _navigatorKey,
       onGenerateTitle: (context) => CcbMobileLocalizations.of(context).appTitle,
       localizationsDelegates: GlobalMaterialLocalizations.delegates,
       supportedLocales: CcbMobileLocalizations.supportedLocales,

--- a/mobile/app/lib/features/project_home/project_home_update_panel.dart
+++ b/mobile/app/lib/features/project_home/project_home_update_panel.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 
 import '../../app/app_update.dart';
@@ -5,16 +8,34 @@ import '../../l10n/ccb_mobile_localizations.dart';
 import '../../platform/external_url_opener.dart';
 
 typedef ProjectHomeUpdateUrlLauncher = Future<bool> Function(String url);
+typedef CcbMobileApkInstaller = Future<void> Function(File apk);
 
-class ProjectHomeUpdatePanel extends StatelessWidget {
+class ProjectHomeUpdatePanel extends StatefulWidget {
   const ProjectHomeUpdatePanel({
     this.updateInfo = const CcbMobileUpdateInfo(),
+    this.updateService,
+    this.installApk = installCcbMobileApk,
     this.openUpdateUrl = openExternalUrl,
     super.key,
   });
 
   final CcbMobileUpdateInfo updateInfo;
+  final CcbMobileUpdateService? updateService;
+  final CcbMobileApkInstaller installApk;
   final ProjectHomeUpdateUrlLauncher openUpdateUrl;
+
+  @override
+  State<ProjectHomeUpdatePanel> createState() => _ProjectHomeUpdatePanelState();
+}
+
+class _ProjectHomeUpdatePanelState extends State<ProjectHomeUpdatePanel> {
+  late final CcbMobileUpdateService _updateService =
+      widget.updateService ??
+      CcbMobileUpdateService(currentVersion: widget.updateInfo.version);
+  CcbMobileRelease? _release;
+  String? _status;
+  bool _checking = false;
+  bool _installing = false;
 
   @override
   Widget build(BuildContext context) {
@@ -47,15 +68,18 @@ class ProjectHomeUpdatePanel extends StatelessWidget {
             ),
             const SizedBox(height: 6),
             Text(
-              strings.currentVersion(updateInfo.version),
+              strings.currentVersion(widget.updateInfo.version),
               key: const ValueKey('project-home-update-version'),
               style: theme.textTheme.bodyMedium,
             ),
             const SizedBox(height: 6),
             Text(
-              strings.mobileUpdatesDescription,
+              _status ?? strings.mobileUpdatesDescription,
+              key: const ValueKey('project-home-update-status'),
               style: theme.textTheme.bodyMedium?.copyWith(
-                color: colorScheme.onSurfaceVariant,
+                color: _release == null
+                    ? colorScheme.onSurfaceVariant
+                    : colorScheme.primary,
               ),
             ),
             const SizedBox(height: 8),
@@ -66,16 +90,49 @@ class ProjectHomeUpdatePanel extends StatelessWidget {
               ),
             ),
             const SizedBox(height: 12),
-            Align(
-              alignment: Alignment.centerLeft,
-              child: OutlinedButton.icon(
-                key: const ValueKey('project-home-update-open-apk-button'),
-                onPressed: () {
-                  _openDownload(context);
-                },
-                icon: const Icon(Icons.open_in_browser),
-                label: Text(strings.openApkDownload),
-              ),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                if (_release == null)
+                  FilledButton.icon(
+                    key: const ValueKey('project-home-update-check-button'),
+                    onPressed: _checking ? null : () => unawaited(_check()),
+                    icon: _checking
+                        ? const SizedBox.square(
+                            dimension: 18,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.refresh),
+                    label: Text(
+                      _checking
+                          ? strings.checkingForUpdates
+                          : strings.checkForUpdates,
+                    ),
+                  )
+                else
+                  FilledButton.icon(
+                    key: const ValueKey('project-home-update-install-button'),
+                    onPressed: _installing ? null : () => unawaited(_install()),
+                    icon: _installing
+                        ? const SizedBox.square(
+                            dimension: 18,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.download),
+                    label: Text(
+                      _installing
+                          ? strings.downloadingUpdate
+                          : strings.downloadAndInstall,
+                    ),
+                  ),
+                OutlinedButton.icon(
+                  key: const ValueKey('project-home-update-open-apk-button'),
+                  onPressed: () => unawaited(_openDownload()),
+                  icon: const Icon(Icons.open_in_browser),
+                  label: Text(strings.openReleasePage),
+                ),
+              ],
             ),
           ],
         ),
@@ -83,12 +140,83 @@ class ProjectHomeUpdatePanel extends StatelessWidget {
     );
   }
 
-  Future<void> _openDownload(BuildContext context) async {
+  Future<void> _check() async {
     final strings = CcbMobileLocalizations.of(context);
-    final opened = await openUpdateUrl(updateInfo.apkDownloadUrl);
-    if (!context.mounted || opened) {
-      return;
+    setState(() {
+      _checking = true;
+      _status = null;
+    });
+    try {
+      final result = await _updateService.checkForUpdate();
+      if (!mounted) return;
+      setState(() {
+        _release = result.release;
+        _status = result.release == null
+            ? strings.alreadyLatestVersion
+            : strings.newVersionAvailable(result.release!.version);
+      });
+      final release = result.release;
+      if (release != null) {
+        await _showUpdateDialog(release);
+      }
+    } catch (_) {
+      if (!mounted) return;
+      setState(() => _status = strings.updateCheckFailed);
+    } finally {
+      if (mounted) setState(() => _checking = false);
     }
+  }
+
+  Future<void> _showUpdateDialog(CcbMobileRelease release) async {
+    final strings = CcbMobileLocalizations.of(context);
+    final install = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(strings.updateAvailableTitle),
+        content: Text(strings.newVersionAvailable(release.version)),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: Text(strings.later),
+          ),
+          FilledButton(
+            key: const ValueKey('manual-update-dialog-install-button'),
+            onPressed: () => Navigator.of(context).pop(true),
+            child: Text(strings.updateNow),
+          ),
+        ],
+      ),
+    );
+    if (install == true && mounted) {
+      await _install();
+    }
+  }
+
+  Future<void> _install() async {
+    final release = _release;
+    if (release == null) return;
+    final strings = CcbMobileLocalizations.of(context);
+    setState(() {
+      _installing = true;
+      _status = strings.downloadingVersion(release.version);
+    });
+    try {
+      final apk = await _updateService.downloadApk(release);
+      await widget.installApk(apk);
+      if (mounted) setState(() => _status = strings.androidInstallerOpened);
+    } catch (_) {
+      if (mounted) setState(() => _status = strings.updateDownloadFailed);
+    } finally {
+      if (mounted) setState(() => _installing = false);
+    }
+  }
+
+  Future<void> _openDownload() async {
+    final strings = CcbMobileLocalizations.of(context);
+    final opened = await widget.openUpdateUrl(
+      _release?.releasePageUrl ?? widget.updateInfo.apkDownloadUrl,
+    );
+    if (!mounted || opened) return;
     ScaffoldMessenger.of(context)
       ..clearSnackBars()
       ..showSnackBar(SnackBar(content: Text(strings.couldNotOpenUpdateUrl)));

--- a/mobile/app/lib/l10n/ccb_mobile_localizations.dart
+++ b/mobile/app/lib/l10n/ccb_mobile_localizations.dart
@@ -163,15 +163,48 @@ class CcbMobileLocalizations {
 
   String get mobileUpdatesDescription =>
       isChinese
-          ? '打开官方发布页下载新的 APK，并通过相同签名渠道覆盖安装。'
-          : 'Open the official release page to download a newer APK and install it over the same signed channel.';
+          ? '启动时会自动检查新版本，也可以在这里手动检查。'
+          : 'Updates are checked automatically at startup, or you can check manually here.';
 
   String get mobileUpdateInstallNote =>
       isChinese
           ? '覆盖安装会保留已配对资料。若 Android 提示签名冲突，说明曾安装不同签名的测试包，需要一次性卸载后再安装正式包。'
           : 'Cover-installing preserves paired data. If Android reports a signature conflict, an older test APK used a different signature and must be uninstalled once before installing the official build.';
 
-  String get openApkDownload => isChinese ? '打开 APK 下载' : 'Open APK download';
+  String get checkForUpdates => isChinese ? '检查更新' : 'Check for updates';
+
+  String get checkingForUpdates => isChinese ? '正在检查' : 'Checking';
+
+  String get alreadyLatestVersion => isChinese ? '当前已是最新版本。' : 'You are up to date.';
+
+  String newVersionAvailable(String version) =>
+      isChinese ? '发现新版本 $version。' : 'Version $version is available.';
+
+  String get downloadAndInstall => isChinese ? '下载并安装' : 'Download and install';
+
+  String get downloadingUpdate => isChinese ? '正在下载' : 'Downloading';
+
+  String downloadingVersion(String version) =>
+      isChinese ? '正在下载 $version 并校验安装包…' : 'Downloading and verifying $version…';
+
+  String get androidInstallerOpened =>
+      isChinese ? '安装包已校验，已打开 Android 安装器。' : 'APK verified. Android installer opened.';
+
+  String get updateCheckFailed =>
+      isChinese ? '检查更新失败，请检查网络或打开发布页。' : 'Update check failed. Check your network or open the release page.';
+
+  String get updateDownloadFailed =>
+      isChinese ? '更新下载或校验失败，请重试或打开发布页。' : 'Update download or verification failed. Retry or open the release page.';
+
+  String get openReleasePage => isChinese ? '打开发布页' : 'Open release page';
+
+  String get updateAvailableTitle => isChinese ? '发现 CCB Mobile 更新' : 'CCB Mobile update available';
+
+  String get later => isChinese ? '稍后' : 'Later';
+
+  String get updateNow => isChinese ? '立即更新' : 'Update now';
+
+  String get openApkDownload => openReleasePage;
 
   String get couldNotOpenUpdateUrl =>
       isChinese ? '无法打开更新下载链接' : 'Could not open update download';

--- a/mobile/app/pubspec.lock
+++ b/mobile/app/pubspec.lock
@@ -114,7 +114,7 @@ packages:
     source: hosted
     version: "0.3.5+2"
   crypto:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
       name: crypto
       sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf

--- a/mobile/app/pubspec.yaml
+++ b/mobile/app/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   path_provider: ^2.1.6
   open_filex:
     path: third_party/open_filex
+  crypto: ^3.0.7
   mime: ^2.0.0
   path: ^1.9.1
   firebase_core: 4.11.0
@@ -31,7 +32,6 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  crypto: ^3.0.7
   lints: ">=4.0.0 <7.0.0"
   test: ^1.25.15
 

--- a/mobile/app/test/android_auto_update_config_test.dart
+++ b/mobile/app/test/android_auto_update_config_test.dart
@@ -1,0 +1,14 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('release manifest permits network access and signed APK installation', () {
+    final manifest = File(
+      'android/app/src/main/AndroidManifest.xml',
+    ).readAsStringSync();
+
+    expect(manifest, contains('android.permission.INTERNET'));
+    expect(manifest, contains('android.permission.REQUEST_INSTALL_PACKAGES'));
+  });
+}

--- a/mobile/app/test/app_update_startup_widget_test.dart
+++ b/mobile/app/test/app_update_startup_widget_test.dart
@@ -1,0 +1,80 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:ccb_mobile/ccb_mobile.dart';
+
+import 'support/project_home_test_fakes.dart';
+
+void main() {
+  testWidgets('Android startup check prompts when a new release is available', (
+    tester,
+  ) async {
+    final service = _StartupUpdateService();
+    File? installed;
+    await tester.pumpWidget(
+      CcbMobileApp(
+        androidPlatformOverride: true,
+        updateService: service,
+        installApk: (apk) async {
+          installed = apk;
+        },
+        themePreferenceStore: _ThemeStore(),
+        backgroundConnectionPreferenceStore: _BackgroundStore(),
+        profileStore: GatewayHostProfileStore(secureStore: MemorySecureStore()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('CCB Mobile update available'), findsOneWidget);
+    expect(find.text('Version 9.0.0 is available.'), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('startup-update-install-button')));
+    await tester.pumpAndSettle();
+
+    expect(installed?.path, '/tmp/ccb-mobile-v9.0.0.apk');
+    expect(find.text('CCB Mobile update available'), findsNothing);
+  });
+}
+
+class _StartupUpdateService extends CcbMobileUpdateService {
+  static const release = CcbMobileRelease(
+    version: '9.0.0',
+    versionCode: 9000000,
+    apkDownloadUrl:
+        'https://github.com/SeemSeam/claude_codex_bridge/releases/download/v9.0.0/ccb-mobile-v9.0.0.apk',
+    sha256:
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    sizeBytes: 10,
+    releasePageUrl:
+        'https://github.com/SeemSeam/claude_codex_bridge/releases/tag/v9.0.0',
+  );
+
+  @override
+  Future<CcbMobileUpdateCheckResult> checkForUpdate() async =>
+      const CcbMobileUpdateCheckResult(
+        currentVersion: ccbMobileCurrentVersion,
+        release: release,
+      );
+
+  @override
+  Future<File> downloadApk(CcbMobileRelease release) async =>
+      File('/tmp/ccb-mobile-v${release.version}.apk');
+}
+
+class _ThemeStore implements CcbThemePreferenceStore {
+  @override
+  Future<CcbThemePreference> read() async => CcbThemePreference.system;
+
+  @override
+  Future<void> write(CcbThemePreference preference) async {}
+}
+
+class _BackgroundStore implements CcbBackgroundConnectionPreferenceStore {
+  @override
+  Future<bool> read() async => false;
+
+  @override
+  Future<void> write(bool enabled) async {}
+}

--- a/mobile/app/test/app_update_test.dart
+++ b/mobile/app/test/app_update_test.dart
@@ -1,0 +1,180 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:ccb_mobile/app/app_update.dart';
+
+void main() {
+  test('compiled update version stays aligned with pubspec', () {
+    final pubspec = File('pubspec.yaml').readAsLinesSync();
+    final versionLine = pubspec.singleWhere(
+      (line) => line.startsWith('version:'),
+    );
+    expect(versionLine.split(':').last.trim(), ccbMobileDefaultVersion);
+  });
+
+  test('compares numeric mobile versions without lexical ordering bugs', () {
+    expect(compareCcbMobileVersions('8.10.0', '8.9.9'), greaterThan(0));
+    expect(compareCcbMobileVersions('8.3.1+99', '8.3.1+1'), 0);
+    expect(compareCcbMobileVersions('8.3', '8.3.0'), 0);
+  });
+
+  test('checks a proxy after the official GitHub API fails', () async {
+    final calls = <Uri>[];
+    final service = CcbMobileUpdateService(
+      currentVersion: '8.3.1+8030001',
+      proxyPrefixes: const ['https://proxy.example/'],
+      fetchBytes: (uri, _) async {
+        calls.add(uri);
+        if (uri.toString() == ccbMobileReleaseApiUrl) {
+          throw const SocketException('blocked');
+        }
+        if (uri.toString() == ccbMobileLatestManifestUrl) {
+          throw const SocketException('github blocked');
+        }
+        if (uri.path.endsWith('.json')) {
+          return utf8.encode(jsonEncode(_manifest));
+        }
+        return utf8.encode(jsonEncode(_githubRelease));
+      },
+    );
+
+    final result = await service.checkForUpdate();
+
+    expect(result.release?.version, '9.0.0');
+    expect(calls.first.toString(), ccbMobileReleaseApiUrl);
+    expect(calls[1].toString(), ccbMobileLatestManifestUrl);
+    expect(
+      calls[2].toString(),
+      'https://proxy.example/$ccbMobileLatestManifestUrl',
+    );
+  });
+
+  test('does not offer a release with an older Android version code', () async {
+    final service = CcbMobileUpdateService(
+      currentVersion: '9.0.0+9000001',
+      proxyPrefixes: const [],
+      fetchBytes: (uri, _) async => utf8.encode(
+        jsonEncode(uri.path.endsWith('.json') ? _manifest : _githubRelease),
+      ),
+    );
+
+    final result = await service.checkForUpdate();
+
+    expect(result.updateAvailable, isFalse);
+  });
+
+  test('discovers a tagged manifest through jsDelivr and a proxy', () async {
+    final calls = <Uri>[];
+    final service = CcbMobileUpdateService(
+      currentVersion: '8.3.1+8030001',
+      proxyPrefixes: const ['https://proxy.example/'],
+      fetchBytes: (uri, _) async {
+        calls.add(uri);
+        if (uri.toString() == ccbMobileJsdelivrVersionsUrl) {
+          return utf8.encode(
+            jsonEncode(<String, Object?>{
+              'versions': <String>['next', '9.0.0', '8.3.0'],
+            }),
+          );
+        }
+        if (uri.toString() == 'https://proxy.example/$_manifestUrl') {
+          return utf8.encode(jsonEncode(_manifest));
+        }
+        throw const SocketException('blocked');
+      },
+    );
+
+    final result = await service.checkForUpdate();
+
+    expect(result.release?.version, '9.0.0');
+    expect(calls, contains(Uri.parse(ccbMobileJsdelivrVersionsUrl)));
+    expect(calls, contains(Uri.parse(_manifestUrl)));
+    expect(calls, contains(Uri.parse('https://proxy.example/$_manifestUrl')));
+  });
+
+  test('rejects an unsafe version from a fallback manifest', () async {
+    final unsafeManifest = <String, Object?>{
+      ..._manifest,
+      'version': '../../update',
+    };
+    final service = CcbMobileUpdateService(
+      proxyPrefixes: const [],
+      fetchBytes: (uri, _) async {
+        if (uri.toString() == ccbMobileReleaseApiUrl) {
+          throw const SocketException('blocked');
+        }
+        return utf8.encode(jsonEncode(unsafeManifest));
+      },
+    );
+
+    await expectLater(
+      service.checkForUpdate(),
+      throwsA(isA<CcbMobileUpdateException>()),
+    );
+  });
+
+  test('rejects a bad APK checksum then downloads from a proxy', () async {
+    final temp = await Directory.systemTemp.createTemp('ccb-update-test-');
+    addTearDown(() => temp.delete(recursive: true));
+    final apkBytes = utf8.encode('signed-apk-fixture');
+    final release = CcbMobileRelease(
+      version: '9.0.0',
+      versionCode: 9000000,
+      apkDownloadUrl: _apkUrl,
+      sha256: sha256.convert(apkBytes).toString(),
+      sizeBytes: apkBytes.length,
+      releasePageUrl: _releasePageUrl,
+    );
+    final calls = <Uri>[];
+    final service = CcbMobileUpdateService(
+      proxyPrefixes: const ['https://proxy.example/'],
+      downloadDirectory: () async => temp,
+      downloadFile: (uri, target, _) async {
+        calls.add(uri);
+        final bytes = uri.host == 'github.com'
+            ? utf8.encode('tampered-apk-data')
+            : apkBytes;
+        await target.writeAsBytes(bytes);
+      },
+    );
+
+    final file = await service.downloadApk(release);
+
+    expect(await file.readAsBytes(), apkBytes);
+    expect(calls.map((uri) => uri.host), ['github.com', 'proxy.example']);
+  });
+}
+
+const _apkUrl =
+    'https://github.com/SeemSeam/claude_codex_bridge/releases/download/v9.0.0/ccb-mobile-v9.0.0.apk';
+const _manifestUrl =
+    'https://github.com/SeemSeam/claude_codex_bridge/releases/download/v9.0.0/ccb-mobile-v9.0.0.json';
+const _releasePageUrl =
+    'https://github.com/SeemSeam/claude_codex_bridge/releases/tag/v9.0.0';
+
+const _githubRelease = <String, Object?>{
+  'tag_name': 'v9.0.0',
+  'html_url': _releasePageUrl,
+  'assets': <Object?>[
+    <String, Object?>{
+      'name': 'ccb-mobile-v9.0.0.json',
+      'browser_download_url': _manifestUrl,
+    },
+  ],
+};
+
+const _manifest = <String, Object?>{
+  'schema_version': 1,
+  'version': '9.0.0',
+  'android': <String, Object?>{
+    'application_id': 'io.ccb.mobile.ccb_mobile',
+    'version_code': 9000000,
+    'version_name': '9.0.0',
+    'download_url': _apkUrl,
+    'sha256': 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    'size_bytes': 10,
+  },
+};

--- a/mobile/app/test/project_home_connection_details_panel_host_test.dart
+++ b/mobile/app/test/project_home_connection_details_panel_host_test.dart
@@ -56,7 +56,10 @@ void main() {
         find.byKey(const ValueKey('project-home-update-panel')),
         findsOneWidget,
       );
-      expect(find.text('Current version: 8.3.1+8030001'), findsOneWidget);
+      expect(
+        find.text('Current version: $ccbMobileDefaultVersion'),
+        findsOneWidget,
+      );
       expect(find.byKey(const ValueKey('gateway-pairing-panel')), findsNothing);
       expect(find.byKey(const ValueKey('gateway-url-field')), findsNothing);
       expect(find.byKey(const ValueKey('runtime-mode-panel')), findsOneWidget);

--- a/mobile/app/test/project_home_onboarding_widget_test.dart
+++ b/mobile/app/test/project_home_onboarding_widget_test.dart
@@ -35,7 +35,10 @@ void main() {
       find.byKey(const ValueKey('project-home-update-panel')),
       findsOneWidget,
     );
-    expect(find.text('Current version: 8.3.1+8030001'), findsOneWidget);
+    expect(
+      find.text('Current version: $ccbMobileDefaultVersion'),
+      findsOneWidget,
+    );
     expect(
       find.byKey(const ValueKey('project-home-onboarding-scan-button')),
       findsOneWidget,

--- a/mobile/app/test/project_home_update_panel_test.dart
+++ b/mobile/app/test/project_home_update_panel_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -40,7 +42,8 @@ void main() {
       findsOneWidget,
     );
     expect(find.text('Current version: 9.1.0+9010000'), findsOneWidget);
-    expect(find.text('Open APK download'), findsOneWidget);
+    expect(find.text('Open release page'), findsOneWidget);
+    expect(find.text('Check for updates'), findsOneWidget);
 
     await tester.tap(
       find.byKey(const ValueKey('project-home-update-open-apk-button')),
@@ -48,6 +51,62 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(openedUrls, ['https://example.com/ccb-mobile.apk']);
+  });
+
+  testWidgets('manual check opens the update dialog and installs from it', (
+    tester,
+  ) async {
+    final service = _FakeUpdateService(updateAvailable: true);
+    File? installed;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ProjectHomeUpdatePanel(
+            updateService: service,
+            installApk: (apk) async {
+              installed = apk;
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(
+      find.byKey(const ValueKey('project-home-update-check-button')),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('CCB Mobile update available'), findsOneWidget);
+    expect(find.text('Version 9.0.0 is available.'), findsNWidgets(2));
+
+    await tester.tap(
+      find.byKey(const ValueKey('manual-update-dialog-install-button')),
+    );
+    await tester.pumpAndSettle();
+    expect(installed?.path, '/tmp/ccb-mobile-v9.0.0.apk');
+    expect(
+      find.text('APK verified. Android installer opened.'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('manual check reports that the installed version is current', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ProjectHomeUpdatePanel(
+            updateService: _FakeUpdateService(updateAvailable: false),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(
+      find.byKey(const ValueKey('project-home-update-check-button')),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('You are up to date.'), findsOneWidget);
   });
 
   testWidgets('update panel reports failed browser handoff', (tester) async {
@@ -71,4 +130,32 @@ void main() {
 
     expect(find.text('Could not open update download'), findsOneWidget);
   });
+}
+
+const _release = CcbMobileRelease(
+  version: '9.0.0',
+  versionCode: 9000000,
+  apkDownloadUrl:
+      'https://github.com/SeemSeam/claude_codex_bridge/releases/download/v9.0.0/ccb-mobile-v9.0.0.apk',
+  sha256: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  sizeBytes: 10,
+  releasePageUrl:
+      'https://github.com/SeemSeam/claude_codex_bridge/releases/tag/v9.0.0',
+);
+
+class _FakeUpdateService extends CcbMobileUpdateService {
+  _FakeUpdateService({required this.updateAvailable});
+
+  final bool updateAvailable;
+
+  @override
+  Future<CcbMobileUpdateCheckResult> checkForUpdate() async =>
+      CcbMobileUpdateCheckResult(
+        currentVersion: ccbMobileCurrentVersion,
+        release: updateAvailable ? _release : null,
+      );
+
+  @override
+  Future<File> downloadApk(CcbMobileRelease release) async =>
+      File('/tmp/ccb-mobile-v${release.version}.apk');
 }


### PR DESCRIPTION
## Summary

- check for Android app updates at startup and expose a manual check action that opens the update prompt when a release is available
- discover GitHub releases with jsDelivr metadata fallback and domestic GitHub asset proxies
- stream APK downloads, verify size and SHA-256, then hand off to the Android package installer
- publish a stable `ccb-mobile-latest.json` release manifest alias and document the update flow

## Verification

- added unit and widget coverage for version comparison, release discovery fallback, startup prompts, manual prompts, APK verification, and Android configuration
- verified the low-version Android build on an Android 15 emulator: startup and manual checks found v8.3.0, the proxy APK download completed, checksum verification passed, and the system installer opened
- fork CI is running for the final squashed commit