### PR TITLE
fix(claude): stop treating session slug as subagent marker; recover orphaned chains

### DIFF
--- a/lib/ccbd/services/dispatcher_runtime/callbacks.py
+++ b/lib/ccbd/services/dispatcher_runtime/callbacks.py
@@ -152,6 +152,85 @@ def callback_child_edge(dispatcher, job) -> CallbackEdgeRecord | None:
     return dispatcher._message_bureau.callback_edge_for_child_message(message.message_id)
 
 
+def deliver_orphaned_chain_result(
+    dispatcher,
+    edge: CallbackEdgeRecord,
+    *,
+    child_job,
+    decision: CompletionDecision,
+    finished_at: str,
+) -> str | None:
+    """Deliver a chain child result whose edge closed before the child finished.
+
+    When the callback edge is already FAILED/TIMED_OUT (e.g. the parent job was
+    cancelled or the continuation lineage broke), the normal continuation path
+    drops the child result silently. Re-deliver it to the dispatching agent
+    (edge.parent_agent) as a fresh notice so the result is never lost.
+    """
+    if dispatcher._message_bureau is None:
+        return None
+    parent_job = get_job(dispatcher, edge.parent_job_id)
+    if parent_job is None:
+        return None
+    reply_id = dispatcher._message_bureau.record_notice(
+        parent_job,
+        reply=_orphaned_result_body(edge=edge, child_job=child_job, decision=decision),
+        diagnostics={
+            'notice': True,
+            'chain_edge_id': edge.edge_id,
+            'chain_orphan_delivery': True,
+            'edge_state': edge.state.value,
+            'child_job_id': child_job.job_id,
+            'child_status': child_job.status.value,
+        },
+        finished_at=finished_at,
+        terminal_status=(
+            ReplyTerminalStatus.COMPLETED
+            if child_job.status is JobStatus.COMPLETED
+            else ReplyTerminalStatus.INCOMPLETE
+        ),
+        deliver_to_actor=edge.parent_agent,
+    )
+    append_event(
+        dispatcher,
+        child_job,
+        'chain_orphan_result_delivered',
+        {
+            'edge_id': edge.edge_id,
+            'edge_state': edge.state.value,
+            'deliver_to_actor': edge.parent_agent,
+            'notice_reply_id': reply_id,
+        },
+        timestamp=finished_at,
+    )
+    return reply_id
+
+
+def _orphaned_result_body(*, edge: CallbackEdgeRecord, child_job, decision: CompletionDecision) -> str:
+    failure = str((edge.diagnostics or {}).get('failure_reason') or '').strip()
+    parts = [
+        'CCB orphaned chain result delivery.',
+        '',
+        f'Chain edge: {edge.edge_id} (state: {edge.state.value})',
+        f'Parent job: {edge.parent_job_id}',
+        f'Child job: {child_job.job_id}',
+        f'Child agent: {child_job.agent_name}',
+        f'Child status: {child_job.status.value}',
+    ]
+    if failure:
+        parts.append(f'Edge failure: {failure}')
+    parts.extend(
+        [
+            '',
+            'The chain closed before the child result could be continued, so it is delivered here as a new event.',
+            '',
+            'Child result:',
+            _reply_summary(decision) or '(no reply body)',
+        ]
+    )
+    return '\n'.join(parts)
+
+
 def submit_callback_continuation(
     dispatcher,
     edge: CallbackEdgeRecord,
@@ -851,6 +930,7 @@ __all__ = [
     'callback_child_edge',
     'delegated_parent_edge',
     'delegated_terminal_job',
+    'deliver_orphaned_chain_result',
     'mark_parent_message_waiting',
     'mark_callback_done',
     'persist_delegated_terminal_job',

--- a/lib/ccbd/services/dispatcher_runtime/finalization_runtime/message_bureau.py
+++ b/lib/ccbd/services/dispatcher_runtime/finalization_runtime/message_bureau.py
@@ -9,6 +9,7 @@ from message_bureau import CallbackEdgeState
 from ..callbacks import (
     callback_child_edge,
     delegated_parent_edge,
+    deliver_orphaned_chain_result,
     mark_callback_done,
     mark_parent_message_waiting,
     persist_delegated_terminal_job,
@@ -138,14 +139,23 @@ def _record_terminal_result(
             finished_at=finished_at,
             deliver_to_caller=False,
         )
-        submit_callback_continuation(
-            dispatcher,
-            child_edge,
-            child_job=terminal,
-            child_reply_id=reply_id,
-            decision=decision,
-            finished_at=finished_at,
-        )
+        if child_edge.state in {CallbackEdgeState.FAILED, CallbackEdgeState.TIMED_OUT}:
+            deliver_orphaned_chain_result(
+                dispatcher,
+                child_edge,
+                child_job=terminal,
+                decision=decision,
+                finished_at=finished_at,
+            )
+        else:
+            submit_callback_continuation(
+                dispatcher,
+                child_edge,
+                child_job=terminal,
+                child_reply_id=reply_id,
+                decision=decision,
+                finished_at=finished_at,
+            )
         mark_callback_done(dispatcher, terminal, finished_at=finished_at)
         return
     dispatcher._message_bureau.record_reply(

--- a/lib/provider_backends/claude/comm_runtime/parsing_runtime/structured.py
+++ b/lib/provider_backends/claude/comm_runtime/parsing_runtime/structured.py
@@ -173,14 +173,20 @@ def _event_record(
         entry.get("subagent_id") or entry.get("agentId") or entry.get("agent_id"),
         lowercase=False,
     )
+    # NOTE: entry.slug is the Claude session-name slug (written on every entry
+    # of a named session since Claude ~2.1.x), not a subagent marker; treating
+    # it as one mislabels every main-chain event as subagent activity, which
+    # hides the request anchor and strands completion tracking.
     subagent_name = _optional_text(
-        entry.get("subagent_name") or entry.get("slug") or entry.get("agentName"),
+        entry.get("subagent_name") or entry.get("agentName"),
         lowercase=False,
     )
     if subagent_id:
         event["subagent_id"] = subagent_id
     if subagent_name:
         event["subagent_name"] = subagent_name
+    if bool(entry.get("isSidechain")):
+        event["is_sidechain"] = True
     return event
 
 

--- a/lib/provider_backends/claude/execution_runtime/polling.py
+++ b/lib/provider_backends/claude/execution_runtime/polling.py
@@ -10,6 +10,8 @@ from provider_execution.base import ProviderPollResult, ProviderSubmission
 
 from .event_reading import is_turn_boundary_event, read_events, terminal_api_error_payload
 from .hook_results import poll_exact_hook
+from .hook_results_runtime import hook_poll_context
+from provider_hooks.artifacts import load_event
 from .state_machine import (
     apply_session_rotation,
     build_poll_state,
@@ -47,6 +49,8 @@ def poll_submission(
     if reply_delivery_terminal is not None:
         return _merge_poll_result_items(reply_delivery_terminal, prefix_items=dispatch_items)
     hook_result = poll_exact_hook(submission, now=now) if _prompt_completion_is_eligible(submission) else None
+    if hook_result is None:
+        hook_result = _orphaned_exact_hook(submission, prepared=prepared, now=now)
     if hook_result is not None:
         return _merge_poll_result_items(hook_result, prefix_items=dispatch_items)
     pane_dead_result = _ensure_prepared_pane_alive(submission, prepared=prepared, now=now)
@@ -232,6 +236,87 @@ def _prompt_completion_is_eligible(submission: ProviderSubmission) -> bool:
     if state.get("prompt_anchor_emitted_at"):
         return False
     return bool(state.get("anchor_seen", False))
+
+
+_ORPHANED_HOOK_GRACE_S = 180.0
+
+
+def _orphaned_exact_hook(submission: ProviderSubmission, *, prepared, now: str) -> ProviderPollResult | None:
+    """Recover a terminal Stop-hook artifact when session-log anchor tracking failed.
+
+    The primary hook path is gated on the session event log observing prompt
+    activation and the request anchor. If log parsing misses that window
+    (parser regression, rotated offsets, already-consumed bytes), the job
+    would zombie-run forever with its terminal reply stranded on disk and its
+    active-task flag never cleared. Accept the artifact only with independent
+    proof: it names this job's own request anchor (load_event enforces the
+    req_id match), it was written after submission, a grace period has elapsed
+    since it was written, the hook session matches the tracked session, and
+    the target pane is observably idle.
+    """
+    state = submission.runtime_state
+    if bool(state.get("no_wrap", False)):
+        return None
+    if not bool(state.get("prompt_sent", False)):
+        return None
+    context = hook_poll_context(submission)
+    if context is None:
+        return None
+    event = load_event(context.completion_dir, context.request_anchor)
+    if not event:
+        return None
+    finished_at = _parse_utc(str(event.get("timestamp") or ""))
+    now_dt = _parse_utc(now)
+    if finished_at is None or now_dt is None:
+        return None
+    accepted_at = _parse_utc(str(getattr(submission, "accepted_at", "") or ""))
+    if accepted_at is not None and finished_at < accepted_at:
+        return None
+    if (now_dt - finished_at).total_seconds() < _ORPHANED_HOOK_GRACE_S:
+        return None
+    if not _orphaned_hook_session_matches(submission, event):
+        return None
+    if not _pane_observably_idle(prepared):
+        return None
+    return poll_exact_hook(submission, now=now)
+
+
+def _parse_utc(value: str):
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        parsed = parse_utc_timestamp(text)
+    except Exception:
+        return None
+    if parsed.tzinfo is None:
+        from datetime import timezone
+
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _orphaned_hook_session_matches(submission: ProviderSubmission, event: dict[str, object]) -> bool:
+    hook_session = str(event.get("session_id") or "").strip()
+    tracked = str(submission.runtime_state.get("session_path") or "").strip()
+    if not hook_session or not tracked:
+        return True
+    tracked_stem = tracked.rsplit("/", 1)[-1].removesuffix(".jsonl")
+    return hook_session == tracked_stem
+
+
+def _pane_observably_idle(prepared) -> bool:
+    backend = getattr(prepared, "backend", None)
+    get_pane_content = getattr(backend, "get_pane_content", None)
+    if not callable(get_pane_content):
+        return False
+    try:
+        text = str(get_pane_content(getattr(prepared, "pane_id", None), lines=80) or "")
+    except Exception:
+        return False
+    if "esc to interrupt" in text.lower():
+        return False
+    return _has_idle_input_box(text)
 
 
 def _merge_poll_result_items(result: ProviderPollResult, *, prefix_items: tuple) -> ProviderPollResult:

--- a/lib/provider_backends/claude/execution_runtime/state_machine_runtime/assistant_events_runtime.py
+++ b/lib/provider_backends/claude/execution_runtime/state_machine_runtime/assistant_events_runtime.py
@@ -54,7 +54,8 @@ def assistant_text(event: dict[str, object]) -> str:
 def assistant_identity(event: dict[str, object]) -> tuple[str, str, bool]:
     subagent_id = str(event.get("subagent_id") or "").strip()
     subagent_name = str(event.get("subagent_name") or "").strip()
-    return subagent_id, subagent_name, bool(subagent_id or subagent_name)
+    is_subagent = bool(subagent_id or subagent_name or event.get("is_sidechain"))
+    return subagent_id, subagent_name, is_subagent
 
 
 def assistant_uuid(event: dict[str, object]) -> str:

--- a/lib/provider_backends/claude/execution_runtime/state_machine_runtime/system_events.py
+++ b/lib/provider_backends/claude/execution_runtime/state_machine_runtime/system_events.py
@@ -80,10 +80,14 @@ def is_top_level_user_prompt(event: dict[str, object] | None) -> bool:
         return True
     if event.get("subagent_id") or event.get("subagent_name"):
         return False
+    if bool(event.get("is_sidechain")):
+        return False
     entry = event.get("entry")
     if not isinstance(entry, dict):
         return True
     if entry.get("toolUseResult") is not None or bool(entry.get("isMeta", False)):
+        return False
+    if bool(entry.get("isSidechain")):
         return False
     message = entry.get("message")
     if not isinstance(message, dict):


### PR DESCRIPTION
## Problem

Claude ≥ 2.1.x writes a session-name `slug` on **every** transcript entry once a session gets named (auto or manual). `comm_runtime/parsing_runtime/structured.py` maps `entry.slug` → event `subagent_name`, so from that point on every main-chain event is mislabeled as subagent activity.

Observed failure cascade (live incident, Claude 2.1.220):

1. `is_top_level_user_prompt` rejects the job's own anchor user prompt → `anchor_seen` / `prompt_activated` never flip in the poll state machine.
2. `_prompt_completion_is_eligible` then gates off `poll_exact_hook` forever — the exact Stop-hook artifact (written by the provider hook with the job's own `req_id`) is never consumed.
3. The job zombie-runs after its terminal reply: active-task flag never cleared, `plain ask` refused (forced `--chain`/`--silence`), and a `--chain` result continuation queued behind the zombie parent is never delivered — the child result strands on disk.

Reproduced deterministically by replaying the affected session transcript through `ClaudeLogReader.try_get_entries` + `_process_events`: anchor missed before the patch, `anchor_seen=True` after.

## Fix

- **Parsing (root cause):** drop `slug` from subagent markers in `_event_record` (it is the session name, not a subagent marker); propagate `entry.isSidechain` as event `is_sidechain` and honor it in `is_top_level_user_prompt` / `assistant_identity` so real sidechain filtering still works via the reliable field.
- **Polling (recovery):** add `_orphaned_exact_hook` fallback — when session-log anchor tracking failed, accept the exact hook artifact only with independent proof: `req_id` match (already enforced by `load_event`), event timestamp ≥ `accepted_at`, 180 s grace elapsed, hook session == tracked session, and an observably idle pane. This un-zombies stuck jobs and lets terminal replies clear the active-task flag.
- **Chain delivery (no result loss):** when a callback edge is already `FAILED`/`TIMED_OUT` at child completion, `submit_callback_continuation` used to return early and silently drop the child result. New `deliver_orphaned_chain_result` delivers it to the dispatching agent (`edge.parent_agent`) as a notice instead.

## Verification

- Transcript replay regression: anchor detected, prompt activated, reply captured after patch.
- `_orphaned_exact_hook` boundary cases (7/7): busy pane, fresh event (< grace), pre-submission event, session mismatch, no pane proof, prompt-not-sent all rejected.
- `deliver_orphaned_chain_result` cases (8/8): notice recorded to dispatching agent with orphan diagnostics and full body; safe on missing bureau/parent.
- Existing suites on patched tree: `test_claude_comm_parsing`, `test_claude_hook_results`, `test_claude_queued_prompt_activation`, `test_claude_execution_polling`, `test_v2_ccbd_dispatcher`, `test_v2_message_bureau_dispatcher_integration` — **171 passed**.
- Live deployment: daemon restart finalized the zombie job via the normal hook path, delivered the stranded chain continuation to the dispatching agent, edge reached `done`, and all agents returned to zero open jobs.
