### PR TITLE
feat(pi): drive the visible pane, read replies from pi's own session log

### DIFF
--- a/lib/provider_backends/pi/execution.py
+++ b/lib/provider_backends/pi/execution.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any
 
@@ -14,7 +15,19 @@ from provider_backends.native_cli_support import (
 )
 
 
-def build_execution_adapter() -> NativeCliSubprocessAdapter:
+PI_EXECUTION_MODE_ENV = "CCB_PI_EXECUTION_MODE"
+
+
+def build_execution_adapter():
+    """Pane-driven by default; set CCB_PI_EXECUTION_MODE=headless to roll back."""
+    if (os.environ.get(PI_EXECUTION_MODE_ENV) or "").strip().lower() == "headless":
+        return build_headless_execution_adapter()
+    from .pane_execution import PiProviderAdapter
+
+    return PiProviderAdapter()
+
+
+def build_headless_execution_adapter() -> NativeCliSubprocessAdapter:
     return NativeCliSubprocessAdapter(
         NativeCliExecutionConfig(
             provider="pi",
@@ -306,4 +319,8 @@ def _pi_time(value: Any) -> object | None:
     return None
 
 
-__all__ = ["build_execution_adapter", "observe_pi_json_output"]
+__all__ = [
+    "build_execution_adapter",
+    "build_headless_execution_adapter",
+    "observe_pi_json_output",
+]

--- a/lib/provider_backends/pi/pane_execution.py
+++ b/lib/provider_backends/pi/pane_execution.py
@@ -1,0 +1,388 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+from ccbd.api_models import JobRecord
+from completion.models import CompletionConfidence, CompletionSourceKind, CompletionStatus
+from provider_core.protocol import request_anchor_for_job
+from provider_execution.base import ProviderPollResult, ProviderRuntimeContext, ProviderSubmission
+from provider_execution.common import error_submission, send_prompt_to_runtime_target
+
+from provider_backends.native_cli_support import wrap_native_prompt
+
+from .pane_native_log import observe_pi_pane_turn
+from .pane_support import (
+    _native_turn_timeout_secs,
+    _pane_ready_for_input,
+    _pane_session_dir,
+    _pane_snapshot,
+    _pane_terminal,
+    _resolve_work_dir,
+    _seconds_between,
+    _send_prompt,
+    _state_str,
+)
+from .session import load_project_session
+
+
+ANCHOR_WAIT_SECS = 120.0
+READY_WAIT_SECS = 60.0
+
+
+class PiProviderAdapter:
+    """Drive the visible pi pane, read the reply from pi's own session log.
+
+    The prompt is typed into the pane so the seat's work is visible the way
+    claude and kimi seats are. Completion and reply text come from the JSONL
+    session log pi writes under its ``--session-dir``, which carries typed
+    content blocks and an explicit ``stopReason`` -- so pane text never has to
+    be parsed.
+    """
+
+    provider = "pi"
+
+    def restore_diagnostics(self) -> dict[str, object]:
+        return {
+            "resume_supported": False,
+            "restore_mode": "resubmit_required",
+            "restore_reason": "provider_resume_unsupported",
+            "restore_detail": (
+                "pi pane turns are observed through pi's own session JSONL; completed turns stay "
+                "readable after restart, but an interrupted in-flight job must be resubmitted"
+            ),
+        }
+
+    def start(
+        self,
+        job: JobRecord,
+        *,
+        context: ProviderRuntimeContext | None,
+        now: str,
+    ) -> ProviderSubmission:
+        return _pane_start_submission(job, context=context, now=now, provider=self.provider)
+
+    def poll(self, submission: ProviderSubmission, *, now: str) -> ProviderPollResult | None:
+        return _pane_poll_submission(submission, now=now)
+
+    def resume(
+        self,
+        job: JobRecord,
+        submission: ProviderSubmission,
+        *,
+        context: ProviderRuntimeContext | None,
+        persisted_state,
+        now: str,
+    ) -> ProviderSubmission | None:
+        del job, submission, context, persisted_state, now
+        return None
+
+
+def _pane_start_submission(
+    job: JobRecord,
+    *,
+    context: ProviderRuntimeContext | None,
+    now: str,
+    provider: str,
+) -> ProviderSubmission:
+    work_dir = _resolve_work_dir(job, context)
+    if work_dir is None:
+        return error_submission(
+            job,
+            provider=provider,
+            now=now,
+            source_kind=CompletionSourceKind.SESSION_EVENT_LOG,
+            reason="runtime_unavailable",
+            error="work_dir_missing",
+        )
+
+    session = None
+    load_error: str | None = None
+    instance = (job.agent_name or "").strip().lower() or None
+    try:
+        if instance is not None:
+            session = load_project_session(work_dir, instance=instance)
+        if session is None:
+            session = load_project_session(work_dir)
+    except Exception as exc:
+        load_error = f"load_session_failed:{exc!r}"
+
+    if session is None:
+        return error_submission(
+            job,
+            provider=provider,
+            now=now,
+            source_kind=CompletionSourceKind.SESSION_EVENT_LOG,
+            reason="runtime_unavailable",
+            error=load_error or "pi_session_file_missing",
+        )
+
+    pane_id = str(getattr(session, "pane_id", "") or "").strip()
+    if not pane_id:
+        return error_submission(
+            job,
+            provider=provider,
+            now=now,
+            source_kind=CompletionSourceKind.SESSION_EVENT_LOG,
+            reason="pane_unavailable",
+            error="pane_id_missing_in_session",
+        )
+
+    try:
+        backend = session.backend()
+    except Exception as exc:
+        backend = None
+        backend_error = f"backend_resolve_failed:{exc!r}"
+    else:
+        backend_error = None
+
+    if backend is None:
+        return error_submission(
+            job,
+            provider=provider,
+            now=now,
+            source_kind=CompletionSourceKind.SESSION_EVENT_LOG,
+            reason="backend_unavailable",
+            error=backend_error or "terminal_backend_unavailable",
+        )
+
+    session_dir = _pane_session_dir(session)
+    if session_dir is None:
+        return error_submission(
+            job,
+            provider=provider,
+            now=now,
+            source_kind=CompletionSourceKind.SESSION_EVENT_LOG,
+            reason="runtime_unavailable",
+            error="pi_session_dir_missing",
+        )
+
+    req_id = request_anchor_for_job(job.job_id)
+    prompt = wrap_native_prompt(job.request.body or "", req_id)
+
+    initial_content = _pane_snapshot(backend, pane_id)
+    prompt_deferred_until_ready = not _pane_ready_for_input(initial_content)
+    send_error: str | None = None
+    prompt_sent = False
+    if not prompt_deferred_until_ready:
+        send_error = _send_prompt(backend, pane_id, prompt)
+        prompt_sent = send_error is None
+
+    diagnostics: dict[str, object] = {
+        "provider": provider,
+        "mode": "pane_native_log",
+        "pane_id": pane_id,
+        "req_id": req_id,
+        "task_id": job.request.task_id,
+        "workspace_path": str(work_dir),
+        "session_dir": str(session_dir),
+    }
+    if send_error:
+        diagnostics["send_error"] = send_error
+    if prompt_deferred_until_ready:
+        diagnostics["prompt_deferred_until_ready"] = True
+
+    return ProviderSubmission(
+        job_id=job.job_id,
+        agent_name=job.agent_name,
+        provider=provider,
+        accepted_at=now,
+        ready_at=now,
+        source_kind=CompletionSourceKind.SESSION_EVENT_LOG,
+        reply="",
+        diagnostics=diagnostics,
+        runtime_state={
+            "mode": "pane_native_log",
+            "provider": provider,
+            "backend": backend,
+            "pane_id": pane_id,
+            "req_id": req_id,
+            "session_dir": str(session_dir),
+            "work_dir": str(work_dir),
+            "started_at": now,
+            "last_poll_at": now,
+            "prompt_sent": prompt_sent,
+            "pending_prompt": prompt,
+            "prompt_deferred_until_ready": prompt_deferred_until_ready,
+            "send_error": send_error,
+            "next_seq": 1,
+            "reply_buffer": "",
+        },
+    )
+
+
+def _pane_poll_submission(submission: ProviderSubmission, *, now: str) -> ProviderPollResult | None:
+    state = dict(submission.runtime_state)
+
+    send_error = state.get("send_error")
+    if send_error:
+        return _pane_terminal(
+            submission,
+            state,
+            now,
+            status=CompletionStatus.FAILED,
+            reason=f"send_failed:{send_error}",
+            reply="",
+            confidence=CompletionConfidence.DEGRADED,
+        )
+
+    pane_id = _state_str(state, "pane_id")
+    req_id = _state_str(state, "req_id")
+    session_dir = _state_str(state, "session_dir")
+    backend = state.get("backend")
+    if not pane_id or not req_id or not session_dir:
+        return _pane_terminal(
+            submission,
+            state,
+            now,
+            status=CompletionStatus.FAILED,
+            reason="runtime_state_invalid",
+            reply="",
+            confidence=CompletionConfidence.DEGRADED,
+        )
+    if backend is None:
+        return _pane_terminal(
+            submission,
+            state,
+            now,
+            status=CompletionStatus.FAILED,
+            reason="runtime_handle_lost",
+            reply="",
+            confidence=CompletionConfidence.DEGRADED,
+        )
+
+    if not bool(state.get("prompt_sent")):
+        return _pane_poll_deferred_prompt(submission, state, now=now, backend=backend, pane_id=pane_id)
+
+    state["last_poll_at"] = now
+    started_at = _state_str(state, "started_at") or submission.accepted_at or now
+    total_secs = _seconds_between(started_at, now)
+    max_wait_secs = _native_turn_timeout_secs()
+    state["total_secs"] = total_secs
+    state["max_wait_secs"] = max_wait_secs
+
+    observation = observe_pi_pane_turn(Path(session_dir), req_id)
+    if observation is None:
+        if total_secs >= ANCHOR_WAIT_SECS:
+            return _pane_terminal(
+                submission,
+                state,
+                now,
+                status=CompletionStatus.INCOMPLETE,
+                reason="pi_native_anchor_missing",
+                reply="",
+                confidence=CompletionConfidence.DEGRADED,
+                diagnostics_extra={
+                    "anchor_seen": False,
+                    "total_secs": total_secs,
+                    "diagnosis": "pi session log did not record the submitted CCB_REQ_ID.",
+                },
+            )
+        return None
+
+    state["anchor_seen"] = True
+    state["session_path"] = observation.session_path
+    state["stop_reason"] = observation.stop_reason
+    if observation.reply:
+        state["reply_buffer"] = observation.reply
+
+    if observation.completed:
+        return _pane_terminal(
+            submission,
+            state,
+            now,
+            status=CompletionStatus.COMPLETED,
+            reason="pi_pane_turn_end",
+            reply=observation.reply,
+            confidence=CompletionConfidence.OBSERVED,
+            diagnostics_extra={
+                "session_path": observation.session_path,
+                "provider_session_id": observation.session_id,
+                "provider_turn_ref": observation.provider_turn_ref,
+                "native_completed_at": observation.native_completed_at,
+            },
+        )
+
+    if total_secs >= max_wait_secs:
+        return _pane_terminal(
+            submission,
+            state,
+            now,
+            status=CompletionStatus.FAILED,
+            reason="pi_native_turn_timeout",
+            reply=_state_str(state, "reply_buffer"),
+            confidence=CompletionConfidence.DEGRADED,
+            diagnostics_extra={"max_wait_secs": max_wait_secs, "stop_reason": observation.stop_reason},
+        )
+
+    updated = replace(submission, reply=_state_str(state, "reply_buffer"), runtime_state=state)
+    if updated != submission:
+        return ProviderPollResult(submission=updated, items=())
+    return None
+
+
+def _pane_poll_deferred_prompt(
+    submission: ProviderSubmission,
+    state: dict[str, object],
+    *,
+    now: str,
+    backend: object,
+    pane_id: str,
+) -> ProviderPollResult:
+    started_at = _state_str(state, "started_at") or submission.accepted_at or now
+    ready_wait_secs = _seconds_between(started_at, now)
+    state["ready_wait_secs"] = ready_wait_secs
+
+    if _pane_ready_for_input(_pane_snapshot(backend, pane_id)):
+        pending_prompt = _state_str(state, "pending_prompt")
+        if not pending_prompt:
+            return _pane_terminal(
+                submission,
+                state,
+                now,
+                status=CompletionStatus.FAILED,
+                reason="runtime_state_invalid",
+                reply="",
+                confidence=CompletionConfidence.DEGRADED,
+                diagnostics_extra={"missing_pending_prompt": True},
+            )
+        send_error = _send_prompt(backend, pane_id, pending_prompt)
+        if send_error:
+            state["send_error"] = send_error
+            return _pane_terminal(
+                submission,
+                state,
+                now,
+                status=CompletionStatus.FAILED,
+                reason=f"send_failed:{send_error}",
+                reply="",
+                confidence=CompletionConfidence.DEGRADED,
+            )
+        state["prompt_sent"] = True
+        state["prompt_sent_at"] = now
+        state["prompt_deferred_until_ready"] = False
+        state["started_at"] = now
+        state["last_poll_at"] = now
+        return ProviderPollResult(submission=replace(submission, runtime_state=state), items=())
+
+    if ready_wait_secs >= READY_WAIT_SECS:
+        return _pane_terminal(
+            submission,
+            state,
+            now,
+            status=CompletionStatus.INCOMPLETE,
+            reason="pi_input_not_ready",
+            reply="",
+            confidence=CompletionConfidence.DEGRADED,
+            diagnostics_extra={
+                "input_not_ready": True,
+                "ready_wait_secs": ready_wait_secs,
+                "diagnosis": "pi pane did not reach an input-ready state before prompt delivery.",
+            },
+        )
+
+    state["last_poll_at"] = now
+    return ProviderPollResult(submission=replace(submission, runtime_state=state), items=())
+
+
+__all__ = ["PiProviderAdapter"]

--- a/lib/provider_backends/pi/pane_native_log.py
+++ b/lib/provider_backends/pi/pane_native_log.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from provider_backends.native_cli_support.prompt import clean_native_reply
+from provider_core.protocol import REQ_ID_PREFIX
+
+
+# The pane pi keeps one JSONL per interactive session and headless `pi run`
+# jobs drop their own files in the same directory. Scanning the newest few by
+# mtime finds the live pane session without having to track which file it owns.
+MAX_SESSION_FILES = 12
+MAX_CHAIN_STEPS = 2000
+
+# Assistant messages that stop to call a tool are not a finished turn.
+_PENDING_STOP_REASONS = frozenset({"tool_use", "tool_calls", "toolcall", "max_tokens"})
+
+
+@dataclass(frozen=True)
+class PiTurnObservation:
+    request_seen: bool = False
+    completed: bool = False
+    reply: str = ""
+    session_id: str = ""
+    session_path: str = ""
+    provider_turn_ref: str = ""
+    stop_reason: str = ""
+    native_started_at: str | None = None
+    native_completed_at: str | None = None
+
+
+def observe_pi_pane_turn(session_dir: Path, req_id: str) -> PiTurnObservation | None:
+    """Locate the pane turn carrying ``req_id`` in pi's own session log.
+
+    The pane pi appends a structured JSONL log under its ``--session-dir``:
+    ``thinking`` and ``text`` arrive as separately typed content blocks and
+    every message carries ``parentId``, so the reply and the turn boundary are
+    both exact. Pane text is never parsed, which is what keeps this free of the
+    reasoning-vs-answer heuristics screen scraping would need.
+
+    Returns ``None`` until the request anchor shows up in some session file.
+    """
+    if not req_id:
+        return None
+    for path in _candidate_session_files(session_dir):
+        observation = _observe_session_file(path, req_id)
+        if observation is not None:
+            return observation
+    return None
+
+
+def _candidate_session_files(session_dir: Path) -> list[Path]:
+    try:
+        files = [entry for entry in session_dir.glob("*.jsonl") if entry.is_file()]
+    except OSError:
+        return []
+    files.sort(key=_safe_mtime, reverse=True)
+    return files[:MAX_SESSION_FILES]
+
+
+def _safe_mtime(path: Path) -> float:
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return 0.0
+
+
+def _observe_session_file(path: Path, req_id: str) -> PiTurnObservation | None:
+    records = _load_records(path)
+    if not records:
+        return None
+
+    anchor = f"{REQ_ID_PREFIX} {req_id}"
+    request_record = None
+    for record in records:
+        if _record_role(record) != "user":
+            continue
+        if anchor in _record_text(record):
+            request_record = record
+    if request_record is None:
+        return None
+
+    session_id = _session_id(records) or path.stem
+    request_id = str(request_record.get("id") or "")
+    last_assistant = _walk_to_last_assistant(records, request_id)
+
+    if last_assistant is None:
+        return PiTurnObservation(
+            request_seen=True,
+            session_id=session_id,
+            session_path=str(path),
+            provider_turn_ref=f"{session_id}:{req_id}",
+            native_started_at=_timestamp(request_record),
+        )
+
+    message = last_assistant.get("message") or {}
+    stop_reason = str(message.get("stopReason") or message.get("stop_reason") or "").strip()
+    reply = clean_native_reply(_assistant_text(last_assistant), req_id)
+    completed = bool(stop_reason) and stop_reason.lower() not in _PENDING_STOP_REASONS
+
+    return PiTurnObservation(
+        request_seen=True,
+        completed=completed and bool(reply),
+        reply=reply,
+        session_id=session_id,
+        session_path=str(path),
+        provider_turn_ref=f"{session_id}:{req_id}",
+        stop_reason=stop_reason,
+        native_started_at=_timestamp(request_record),
+        native_completed_at=_timestamp(last_assistant) if completed else None,
+    )
+
+
+def _load_records(path: Path) -> list[dict[str, Any]]:
+    try:
+        raw = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+    records: list[dict[str, Any]] = []
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            record = json.loads(stripped)
+        except json.JSONDecodeError:
+            # A partially flushed trailing record is normal while pi is writing.
+            continue
+        if isinstance(record, dict):
+            records.append(record)
+    return records
+
+
+def _walk_to_last_assistant(records: list[dict[str, Any]], start_id: str) -> dict[str, Any] | None:
+    """Follow the parentId chain forward and return the turn's final assistant message.
+
+    Tool rounds extend the chain (assistant -> tool result -> assistant), so the
+    last assistant node reached before the next anchored user turn is the answer.
+    """
+    if not start_id:
+        return None
+    children: dict[str, list[dict[str, Any]]] = {}
+    for record in records:
+        parent = str(record.get("parentId") or "")
+        if parent:
+            children.setdefault(parent, []).append(record)
+
+    current = start_id
+    last_assistant: dict[str, Any] | None = None
+    for _ in range(MAX_CHAIN_STEPS):
+        kids = children.get(current) or []
+        if not kids:
+            break
+        node = kids[-1]
+        role = _record_role(node)
+        if role == "user" and REQ_ID_PREFIX in _record_text(node):
+            break
+        if role == "assistant":
+            last_assistant = node
+        node_id = str(node.get("id") or "")
+        if not node_id or node_id == current:
+            break
+        current = node_id
+    return last_assistant
+
+
+def _record_role(record: dict[str, Any]) -> str:
+    if record.get("type") != "message":
+        return ""
+    message = record.get("message")
+    if not isinstance(message, dict):
+        return ""
+    return str(message.get("role") or "").strip().lower()
+
+
+def _record_text(record: dict[str, Any]) -> str:
+    message = record.get("message")
+    if not isinstance(message, dict):
+        return ""
+    return _content_text(message.get("content"), include_thinking=True)
+
+
+def _assistant_text(record: dict[str, Any]) -> str:
+    message = record.get("message")
+    if not isinstance(message, dict):
+        return ""
+    return _content_text(message.get("content"), include_thinking=False).strip()
+
+
+def _content_text(content: Any, *, include_thinking: bool) -> str:
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        kind = str(block.get("type") or "").strip().lower()
+        if kind == "text":
+            parts.append(str(block.get("text") or ""))
+        elif kind == "thinking" and include_thinking:
+            parts.append(str(block.get("thinking") or ""))
+    return "".join(parts)
+
+
+def _session_id(records: list[dict[str, Any]]) -> str:
+    for record in records:
+        if record.get("type") == "session":
+            return str(record.get("id") or "")
+    return ""
+
+
+def _timestamp(record: dict[str, Any]) -> str | None:
+    raw = record.get("timestamp")
+    return str(raw) if raw else None
+
+
+__all__ = ["PiTurnObservation", "observe_pi_pane_turn"]

--- a/lib/provider_backends/pi/pane_support.py
+++ b/lib/provider_backends/pi/pane_support.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import os
+from dataclasses import replace
+from datetime import datetime
+from pathlib import Path
+
+from ccbd.api_models import JobRecord
+from completion.models import (
+    CompletionConfidence,
+    CompletionCursor,
+    CompletionDecision,
+    CompletionStatus,
+)
+from provider_execution.base import ProviderPollResult, ProviderRuntimeContext, ProviderSubmission
+from provider_execution.common import send_prompt_to_runtime_target
+
+
+PI_NATIVE_TURN_TIMEOUT_ENV = "CCB_PI_NATIVE_TURN_TIMEOUT_S"
+PANE_LINES_DEFAULT = 2000
+MAX_WAIT_SECS = 300.0
+
+
+def _pane_terminal(
+    submission: ProviderSubmission,
+    state: dict[str, object],
+    now: str,
+    *,
+    status: CompletionStatus,
+    reason: str,
+    reply: str,
+    confidence: CompletionConfidence,
+    diagnostics_extra: dict[str, object] | None = None,
+) -> ProviderPollResult:
+    cleaned_reply = reply or ""
+    progress = replace(
+        submission,
+        runtime_state=state,
+        status=status,
+        reason=reason,
+        reply=cleaned_reply,
+        confidence=confidence,
+    )
+    cursor = CompletionCursor(
+        source_kind=submission.source_kind,
+        event_seq=_state_int(state, "next_seq", 1),
+        updated_at=now,
+    )
+    diagnostics: dict[str, object] = {
+        "mode": "pane_native_log",
+        "total_secs": float(state.get("total_secs") or state.get("ready_wait_secs") or 0.0),
+        "anchor_seen": bool(state.get("anchor_seen")),
+        "reply_chars": len(cleaned_reply),
+    }
+    diagnostics.update(diagnostics_extra or {})
+    if reason == "pi_native_turn_timeout" and not cleaned_reply:
+        diagnostics.update(
+            {
+                "no_captured_reply": True,
+                "provider_no_reply": True,
+                "receipt_valid": False,
+                "receipt_class": "no_captured_reply",
+                "error_type": "empty_provider_reply",
+                "diagnosis": (
+                    "pi pane turn polling timed out after observing the submitted CCB_REQ_ID, "
+                    "but no assistant reply text was captured."
+                ),
+            }
+        )
+    decision = CompletionDecision(
+        terminal=True,
+        status=status,
+        reason=reason,
+        confidence=confidence,
+        reply=cleaned_reply,
+        anchor_seen=bool(state.get("anchor_seen")),
+        reply_started=bool(cleaned_reply),
+        reply_stable=bool(cleaned_reply) and status is CompletionStatus.COMPLETED,
+        provider_turn_ref=_state_str(state, "req_id") or submission.job_id,
+        source_cursor=cursor,
+        finished_at=now,
+        diagnostics=diagnostics,
+    )
+    return ProviderPollResult(submission=progress, items=(), decision=decision)
+
+
+def _pane_session_dir(session: object) -> Path | None:
+    data = getattr(session, "data", None)
+    if not isinstance(data, dict):
+        return None
+    raw = str(data.get("pi_session_dir") or "").strip()
+    if raw:
+        return Path(raw).expanduser()
+    state_dir = str(data.get("pi_state_dir") or "").strip()
+    if state_dir:
+        return Path(state_dir).expanduser() / "sessions"
+    return None
+
+
+def _pane_snapshot(backend: object, pane_id: str) -> str:
+    getter = getattr(backend, "get_pane_content", None)
+    if not callable(getter):
+        getter = getattr(backend, "get_text", None)
+    if not callable(getter):
+        return ""
+    try:
+        return str(getter(pane_id, lines=PANE_LINES_DEFAULT) or "")
+    except Exception:
+        return ""
+
+
+def _pane_ready_for_input(content: str) -> bool:
+    """True once pi's TUI chrome is rendered, meaning the input box accepts a paste."""
+    text = content or ""
+    if "─" * 24 not in text:
+        return False
+    return "LSP" in text or "(auto)" in text
+
+
+def _send_prompt(backend: object, pane_id: str, prompt: str) -> str | None:
+    try:
+        send_prompt_to_runtime_target(backend, pane_id, prompt)
+    except Exception as exc:
+        return f"send_text_failed:{exc!r}"
+    return None
+
+
+def _resolve_work_dir(job: JobRecord, context: ProviderRuntimeContext | None) -> Path | None:
+    candidate = (context.workspace_path if context else None) or job.workspace_path
+    if not candidate:
+        return None
+    try:
+        return Path(candidate).expanduser()
+    except Exception:
+        return None
+
+
+def _native_turn_timeout_secs() -> float:
+    raw = os.environ.get(PI_NATIVE_TURN_TIMEOUT_ENV)
+    if raw is None or not raw.strip():
+        return MAX_WAIT_SECS
+    try:
+        value = float(raw)
+    except ValueError:
+        return MAX_WAIT_SECS
+    return value if value > 0 else MAX_WAIT_SECS
+
+
+def _parse_now(now: str) -> datetime | None:
+    if not now:
+        return None
+    try:
+        return datetime.fromisoformat(now.replace("Z", "+00:00"))
+    except Exception:
+        return None
+
+
+def _seconds_between(start: str, end: str) -> float:
+    start_dt = _parse_now(start)
+    end_dt = _parse_now(end)
+    if start_dt is None or end_dt is None:
+        return 0.0
+    return max(0.0, (end_dt - start_dt).total_seconds())
+
+
+def _state_int(state: dict[str, object], key: str, default: int) -> int:
+    value = state.get(key)
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _state_str(state: dict[str, object], key: str, default: str = "") -> str:
+    value = state.get(key)
+    if value is None:
+        return default
+    return str(value)
+
+
+__all__ = [
+    "MAX_WAIT_SECS",
+    "PANE_LINES_DEFAULT",
+    "PI_NATIVE_TURN_TIMEOUT_ENV",
+]

--- a/test/test_pi_pane_native_log.py
+++ b/test/test_pi_pane_native_log.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from provider_backends.pi.pane_native_log import observe_pi_pane_turn
+
+
+REQ = "job_pi_pane_001"
+ANCHOR = f"CCB_REQ_ID: {REQ}"
+
+
+def _write_session(path: Path, records: list[dict]) -> None:
+    path.write_text("".join(json.dumps(record) + "\n" for record in records), encoding="utf-8")
+
+
+def _session_header(session_id: str = "sess-1") -> dict:
+    return {"type": "session", "version": 3, "id": session_id, "cwd": "/work"}
+
+
+def _user(msg_id: str, parent: str, text: str) -> dict:
+    return {
+        "type": "message",
+        "id": msg_id,
+        "parentId": parent,
+        "timestamp": "2026-07-29T03:00:00.000Z",
+        "message": {"role": "user", "content": [{"type": "text", "text": text}]},
+    }
+
+
+def _assistant(msg_id: str, parent: str, *, thinking: str = "", text: str = "", stop: str = "stop") -> dict:
+    content: list[dict] = []
+    if thinking:
+        content.append({"type": "thinking", "thinking": thinking, "thinkingSignature": "sig"})
+    if text:
+        content.append({"type": "text", "text": text})
+    return {
+        "type": "message",
+        "id": msg_id,
+        "parentId": parent,
+        "timestamp": "2026-07-29T03:00:05.000Z",
+        "message": {"role": "assistant", "content": content, "stopReason": stop, "model": "k3"},
+    }
+
+
+def test_reply_excludes_thinking_block(tmp_path: Path) -> None:
+    _write_session(
+        tmp_path / "s.jsonl",
+        [
+            _session_header(),
+            _user("m1", "root", f"{ANCHOR}\n\nwhere are you running?"),
+            _assistant("m2", "m1", thinking="The user asks about cwd. Let me answer.", text="I run in /work."),
+        ],
+    )
+
+    observation = observe_pi_pane_turn(tmp_path, REQ)
+
+    assert observation is not None
+    assert observation.request_seen is True
+    assert observation.completed is True
+    assert observation.stop_reason == "stop"
+    assert observation.reply == "I run in /work."
+
+
+def test_pending_tool_stop_reason_is_not_complete(tmp_path: Path) -> None:
+    _write_session(
+        tmp_path / "s.jsonl",
+        [
+            _session_header(),
+            _user("m1", "root", f"{ANCHOR}\n\ncount the lines"),
+            _assistant("m2", "m1", text="reading the file", stop="tool_use"),
+        ],
+    )
+
+    observation = observe_pi_pane_turn(tmp_path, REQ)
+
+    assert observation is not None
+    assert observation.request_seen is True
+    assert observation.completed is False
+
+
+def test_tool_round_returns_final_assistant_message(tmp_path: Path) -> None:
+    _write_session(
+        tmp_path / "s.jsonl",
+        [
+            _session_header(),
+            _user("m1", "root", f"{ANCHOR}\n\ncount the lines"),
+            _assistant("m2", "m1", text="calling wc", stop="tool_use"),
+            _user("m3", "m2", "tool result: 54"),
+            _assistant("m4", "m3", thinking="wc said 54.", text="LINES=54"),
+        ],
+    )
+
+    observation = observe_pi_pane_turn(tmp_path, REQ)
+
+    assert observation is not None
+    assert observation.completed is True
+    assert observation.reply == "LINES=54"
+
+
+def test_walk_stops_before_the_next_anchored_turn(tmp_path: Path) -> None:
+    _write_session(
+        tmp_path / "s.jsonl",
+        [
+            _session_header(),
+            _user("m1", "root", f"{ANCHOR}\n\nfirst question"),
+            _assistant("m2", "m1", text="first answer"),
+            _user("m3", "m2", "CCB_REQ_ID: job_pi_pane_002\n\nsecond question"),
+            _assistant("m4", "m3", text="second answer"),
+        ],
+    )
+
+    observation = observe_pi_pane_turn(tmp_path, REQ)
+
+    assert observation is not None
+    assert observation.reply == "first answer"
+
+
+def test_anchor_seen_before_assistant_replies(tmp_path: Path) -> None:
+    _write_session(
+        tmp_path / "s.jsonl",
+        [
+            _session_header(),
+            _user("m1", "root", f"{ANCHOR}\n\nstill thinking"),
+        ],
+    )
+
+    observation = observe_pi_pane_turn(tmp_path, REQ)
+
+    assert observation is not None
+    assert observation.request_seen is True
+    assert observation.completed is False
+    assert observation.reply == ""
+
+
+def test_unknown_request_returns_none(tmp_path: Path) -> None:
+    _write_session(
+        tmp_path / "s.jsonl",
+        [
+            _session_header(),
+            _user("m1", "root", "CCB_REQ_ID: some_other_job\n\nhello"),
+            _assistant("m2", "m1", text="hi"),
+        ],
+    )
+
+    assert observe_pi_pane_turn(tmp_path, REQ) is None
+    assert observe_pi_pane_turn(tmp_path, "") is None
+
+
+def test_turn_is_found_across_sibling_session_files(tmp_path: Path) -> None:
+    _write_session(
+        tmp_path / "other.jsonl",
+        [_session_header("sess-other"), _user("a1", "root", "CCB_REQ_ID: unrelated\n\nhi")],
+    )
+    _write_session(
+        tmp_path / "target.jsonl",
+        [
+            _session_header("sess-target"),
+            _user("m1", "root", f"{ANCHOR}\n\nquestion"),
+            _assistant("m2", "m1", text="answer"),
+        ],
+    )
+
+    observation = observe_pi_pane_turn(tmp_path, REQ)
+
+    assert observation is not None
+    assert observation.session_id == "sess-target"
+    assert observation.reply == "answer"
+
+
+def test_partial_trailing_record_is_tolerated(tmp_path: Path) -> None:
+    path = tmp_path / "s.jsonl"
+    _write_session(
+        path,
+        [
+            _session_header(),
+            _user("m1", "root", f"{ANCHOR}\n\nquestion"),
+            _assistant("m2", "m1", text="answer"),
+        ],
+    )
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write('{"type":"message","id":"m3","parentI')
+
+    observation = observe_pi_pane_turn(tmp_path, REQ)
+
+    assert observation is not None
+    assert observation.completed is True
+    assert observation.reply == "answer"
+
+
+def test_missing_session_dir_returns_none(tmp_path: Path) -> None:
+    assert observe_pi_pane_turn(tmp_path / "absent", REQ) is None


### PR DESCRIPTION
## What

pi seats run headless: every job spawns its own `pi run` subprocess, so the agent pane sits at its startup banner and the seat's work is invisible — unlike claude and kimi seats, which drive their pane.

This sends the prompt to the pane instead, and takes the reply from the JSONL session log pi writes under its `--session-dir`.

## Why read the session log instead of scraping the pane

I tried `pane_quiet_support` first. It does not hold up for pi, because pi renders its reasoning into the pane and the parser folds that reasoning into the reply whenever the thinking text does not happen to contain the done marker:

```
reply: 'The user asks which directory. I should answer directly in one sentence.\n
        Let me check the cwd shown in the footer.\n\n我现在运行在目录 /home/umax/work/n14。'
```

Filtering that would mean another prefix blacklist like `_looks_like_kimi_non_answer`. pi's own session log makes it unnecessary — `thinking` and `text` are separately typed content blocks, messages chain by `parentId`, and `stopReason` is explicit:

```json
{"type":"message","id":"f0996678","parentId":"40bf081e","message":{
  "role":"assistant",
  "content":[{"type":"thinking","thinking":"..."},{"type":"text","text":"..."}],
  "stopReason":"stop","model":"k3"}}
```

So the reply and the turn boundary are both exact, with no heuristics. This mirrors what `KimiProviderAdapter` does with `native_turn_log`, where pane text is only rescue evidence.

## Behaviour

- `stopReason: tool_use` keeps the turn open, so tool rounds are not cut short
- the `parentId` walk stops at the next anchored user turn
- a partially flushed trailing JSONL record is tolerated (normal while pi is writing)
- `CCB_PI_EXECUTION_MODE=headless` restores the previous adapter
- `CCB_PI_NATIVE_TURN_TIMEOUT_S` overrides the 300s turn budget

One semantic change worth calling out for review: pane mode shares a single pi session, so a pi seat now accumulates context across jobs instead of starting fresh per job. That matches claude/kimi seat behaviour, but it is a change for anyone relying on pi jobs being isolated.

## Layout

`execution.py` keeps the headless adapter and becomes a thin mode selector. The pane path is split so no file exceeds 400 lines:

| file | lines | role |
| --- | --- | --- |
| `pane_native_log.py` | 222 | session-log observer |
| `pane_execution.py` | 388 | adapter + submission lifecycle |
| `pane_support.py` | 187 | terminal decision + runtime helpers |

## Verification

Ran against a live CCB project (`coder2:pi`, model k3) on this branch's code:

- plain turn — `reason=pi_pane_turn_end`, reply exact, 10.5s
- tool turn — `read` + `wc -l` rounds, 30s; reply is the final assistant message, not the intermediate `tool_use` one. Its `LINES=54` claim independently confirmed with `wc -l`
- pane visibility — prompt, reasoning, tool calls and answer all render live in the pane
- reasoning isolation — both replies clean (28 / 43 chars) with reasoning visible in the pane and absent from the reply

`test/test_pi_pane_native_log.py` adds 9 unit tests covering thinking exclusion, `tool_use` not completing, the tool-round chain walk, the next-turn boundary, anchor-before-reply, unknown request, sibling session files, partial trailing record, and a missing session dir.

Note: the end-to-end runs above were made before the file split; the split is a pure code move verified by import checks and the unit tests, not by a second live round trip.
