### PR TITLE
fix(claude): stop dropping non-API keys from agents.<name>.env

### DIFF
--- a/lib/provider_backends/claude/launcher_runtime/env_runtime/exports.py
+++ b/lib/provider_backends/claude/launcher_runtime/env_runtime/exports.py
@@ -41,10 +41,28 @@ def build_claude_env_prefix(
         claude_user_base_url_fn=claude_user_base_url_fn,
     )
 
+    passthrough_statement = render_export_statement(passthrough_env(extra_env, api_keys=api_keys))
+    if passthrough_statement:
+        parts.append(passthrough_statement)
+
     export_statement = render_export_statement(explicit_env)
     if export_statement:
         parts.append(export_statement)
     return "; ".join(parts)
+
+
+def passthrough_env(extra_env: dict[str, str] | None, *, api_keys: set[str]) -> dict[str, str]:
+    """Keys from `agents.<name>.env` that the API reconciler above does not govern.
+
+    That reconciler exists to decide credential and endpoint precedence, so it
+    keeps only the provider's API keys. `agents.<name>.env` is a general
+    environment map though, and every other launcher passes it through whole, so
+    the remaining keys still have to reach the launched process.
+
+    Emitted before the API exports and before CCB's own managed overrides, so
+    neither can be shadowed by a value declared in config.
+    """
+    return {key: value for key, value in (extra_env or {}).items() if key not in api_keys}
 
 
 def runtime_home_env_parts(*, profile=None) -> list[str]:
@@ -185,4 +203,4 @@ def render_export_statement(explicit_env: dict[str, str]) -> str:
     return f"export {exports}"
 
 
-__all__ = ["build_claude_env_prefix"]
+__all__ = ["build_claude_env_prefix", "passthrough_env"]

--- a/test/test_claude_launcher_env.py
+++ b/test/test_claude_launcher_env.py
@@ -92,3 +92,36 @@ def test_write_claude_settings_overlay_strips_env_section_from_agent_settings(tm
     payload = json.loads(overlay.read_text(encoding="utf-8"))
     assert payload == {"theme": "light"}
     assert claude_user_base_url(user_settings_path=settings_path) == "http://127.0.0.1:12345"
+
+
+def test_build_claude_env_prefix_passes_through_non_api_agent_env() -> None:
+    result = build_claude_env_prefix(
+        extra_env={"GH_CONFIG_DIR": "/home/user/.config/gh", "ANTHROPIC_API_KEY": "sk-test"},
+        env={},
+        should_drop_base_url_fn=lambda value: False,
+        claude_user_base_url_fn=lambda: "",
+    )
+
+    assert "export GH_CONFIG_DIR=/home/user/.config/gh" in result
+    assert "export ANTHROPIC_API_KEY=sk-test" in result
+
+
+def test_build_claude_env_prefix_emits_passthrough_before_api_env() -> None:
+    result = build_claude_env_prefix(
+        extra_env={"HTTPS_PROXY": "http://proxy.example.test:3128", "ANTHROPIC_API_KEY": "sk-test"},
+        env={},
+        should_drop_base_url_fn=lambda value: False,
+        claude_user_base_url_fn=lambda: "",
+    )
+
+    assert result.index("HTTPS_PROXY") < result.index("ANTHROPIC_API_KEY")
+
+
+def test_build_claude_env_prefix_without_agent_env_is_unchanged() -> None:
+    result = build_claude_env_prefix(
+        env={},
+        should_drop_base_url_fn=lambda value: False,
+        claude_user_base_url_fn=lambda: "",
+    )
+
+    assert result == ""


### PR DESCRIPTION
## Problem

`agents.<name>.env` is an accepted config key and `AgentSpec.env` is typed as a general `dict[str, str]`. For a claude seat, only `ANTHROPIC_*` survives — everything else is discarded with no error and no warning.

```toml
[agents.main_contral]
env = { GH_CONFIG_DIR = "/home/user/.config/gh" }
```

```
$ printenv GH_CONFIG_DIR      # inside the claude seat
(unset)
```

The config parses, `ccb reload --dry-run` reports `reload_status: ok`, the seat starts normally, and the variable is simply gone. The only way to notice is `printenv` inside the seat or reading `start_cmd` in the session file.

## Cause

`build_claude_env_prefix` is the only consumer of `spec.env` in the claude launcher, and it runs it through `filtered_api_env`, which keeps only `provider_api_env_keys("claude")`:

```python
def filtered_api_env(env_map, *, api_keys):
    return {key: value for key, value in env_map.items() if key in api_keys}
```

Every later clause in `join_env_prefix` is a fixed dict (`DISABLE_AUTOUPDATER`, `provider_user_session_env()`, `home_overrides`, `caller_context_env`), so nothing re-adds the filtered-out keys.

That filter is correct for its own job — it decides credential and endpoint precedence between profile env, ambient shell and user settings. The gap is that nothing then exports the keys it is not responsible for.

## Inconsistency this creates

Other launchers pass `spec.env` through whole:

| launcher | handling of `spec.env` |
| --- | --- |
| kimi, agy, mimo, native-CLI (pi, qwen, cursor, copilot, …) | `export_env_clause(spec.env)` |
| codex | `explicit_env.update(spec.env)` |
| deepseek | `**spec.env` |
| **claude** | filtered to `ANTHROPIC_*` |

So the same `agents.<name>.env` block works on a kimi seat and silently does nothing on a claude seat.

## Fix

Export the non-API keys separately, before the API exports and before CCB's own managed overrides, so neither can be shadowed by a value declared in config. API-key precedence is untouched.

## Deliberately not changing gemini

`build_gemini_env_prefix` has the identical shape, but `test_build_gemini_env_prefix_clears_non_inherited_api_and_exports_filtered_keys` asserts that a non-API key passed via `extra_env` must **not** reach the prefix:

```python
prefix = build_gemini_env_prefix(profile=profile, extra_env={"GOOGLE_API_KEY": "extra-key", "UNRELATED": "ignored"})
assert "UNRELATED" not in prefix
```

That reads as an intended contract rather than an oversight, so this PR leaves gemini alone rather than rewriting an assertion the maintainers wrote. If the general-env reading is the intended one there too, I am happy to extend the same change to gemini in this PR — just say so. The claude path has no equivalent test.

## Tests

Three cases added to `test/test_claude_launcher_env.py`: a non-API key reaches the prefix alongside an API key, passthrough is emitted before the API exports, and an empty `agents.<name>.env` still produces an unchanged (empty) prefix. The existing claude and gemini launcher env tests are unaffected.

Scope of verification, to be precise about it: the symptom above was observed on a live CCB project — the same `env = { GH_CONFIG_DIR = ... }` block reached a pi seat's `start_cmd` and was absent from a claude seat's. The fix itself is covered at unit level only; I have not yet run a patched build through a full seat launch.
