### PR TITLE
fix(qoder): route asks through visible panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@
 - **Asset Projection Is One-Way And Owned**: managed Provider assets are
   refreshed inside private homes without writable aliases back to user-global
   state, and packaged Qoder `ask` / `ccb-clear` controls are now guaranteed.
+- **Qoder Asks Stay In The Visible Pane**: Qoder and Qoder CLI CN asks now bind
+  to the exact managed agent session, validate its owned tmux pane, and submit
+  through that visible TUI. Missing or foreign panes fail closed instead of
+  starting a hidden per-job print process.
 
 ## v8.4.3 (2026-07-27)
 

--- a/docs/ccb-provider-state-storage-boundary-plan.md
+++ b/docs/ccb-provider-state-storage-boundary-plan.md
@@ -813,15 +813,16 @@ only the explicit CCB update flow owns discovery and mutation.
 
 ### 6.4 Qoder
 
-Qoder must use its documented `--config-dir` option to bind the visible TUI and
-per-job print subprocess to the same agent-local provider-state root. The
-unsupported `QODER_HOME` assumption is not an isolation boundary.
+Qoder must use its documented `--config-dir` option to bind the managed visible
+TUI to the exact agent-local provider-state root. CCB ask execution must reuse
+that owned visible pane; it must not create a hidden per-job print subprocess.
+The unsupported `QODER_HOME` assumption is not an isolation boundary.
 
 Must remain agent-isolated:
 
 - the exact `--config-dir` root
 - `.auth/`, logs, sessions, settings, installation identity, and security state
-- deterministic per-job native session UUIDs
+- the visible provider conversation and its pane/session binding
 
 Must remain secret and agent-local:
 

--- a/docs/ccbd-startup-supervision-contract.md
+++ b/docs/ccbd-startup-supervision-contract.md
@@ -450,10 +450,12 @@ Managed provider startup mutation rules:
 - managed Qoder and Qoder CLI CN startup must resolve the final explicit or
   managed `--config-dir` before projecting skills; optional system skills, Role
   skills, and packaged `ask`/`ccb-clear` controls target that same effective
-  root for both visible and headless execution. The released provider key
-  `qoderclicn` remains stable. An explicit config root equal to the source
-  account's `.qoder` or `.qoder-cn` root remains external user authority and
-  must not be mutated by CCB projection.
+  root used by the managed visible pane. Ask execution must load the exact
+  agent session, validate the owned pane, and submit through that pane without
+  a hidden-process fallback. The released provider key `qoderclicn` remains
+  stable. An explicit config root equal to the source account's `.qoder` or
+  `.qoder-cn` root remains external user authority and must not be mutated by
+  CCB projection.
 - managed AGY must use private agent-local `.gemini` and `.antigravity`
   directories. It may copy allowlisted authentication/config files from the
   user's Windows provider home, but it must not symlink or junction either

--- a/docs/plantree/plans/native-cli-providers/implementation-status.md
+++ b/docs/plantree/plans/native-cli-providers/implementation-status.md
@@ -347,7 +347,19 @@ Evidence:
 - Classified Qoder CN `.auth/` state as secret and added focused command,
   observer, launcher, registry, runtime, and storage regression coverage.
 
-Historical first-slice verification:
+## 2026-07-29 Qoder Visible-Pane Ask Routing
+
+- Qoder and Qoder CLI CN default execution adapters now load the exact
+  agent-named session, require `session.ensure_pane()` ownership/liveness
+  validation, and submit asks to that managed visible pane.
+- Ask completion uses anchored pane transcript evidence with `CCB_REQ_ID` and
+  `CCB_DONE`; cancellation targets the same pane.
+- Missing, dead, or foreign panes fail closed as `pane_unavailable`. Normal ask
+  routing no longer falls back to a per-job `qodercli -p` or `qoderclicn -p`
+  subprocess. Print-mode builders remain isolated compatibility helpers rather
+  than registered ask adapters.
+
+## Historical First-Slice Verification
 
 - `node --version` returned `v22.20.0`.
 - `npm view @moonshot-ai/kimi-code@0.14.2 version bin engines --json` returned

--- a/docs/plantree/plans/native-cli-providers/roadmap.md
+++ b/docs/plantree/plans/native-cli-providers/roadmap.md
@@ -14,11 +14,11 @@ Date: 2026-06-13
   in source with ready-gated prompt delivery, pane fallback, and coalesced
   request diagnostics. Kimi restart now uses observation-bound per-agent native
   session ownership and capability-confirmed exact selection rather than
-  workdir-global `--continue`. Qoder's merged provider registration is now
-  corrected to use documented print/config arguments, UUID session identity,
-  agent-local config state, and provider-specific stream terminalization. Qoder
-  CLI CN is registered separately as `qoderclicn` and reuses that corrected
-  contract for `@qodercn-ai/qoderclicn` rather than the retired generic adapter.
+  workdir-global `--continue`. Qoder and Qoder CLI CN now route asks through
+  their exact managed visible panes, using agent-local config state, owned-pane
+  validation, anchored pane transcript completion, and no hidden-process
+  fallback. Qoder CLI CN remains registered separately as `qoderclicn` for
+  `@qodercn-ai/qoderclicn`.
 - Last verified: focused native completion tests, provider catalog tests,
   Kimi/OpenCode skill projection tests, and a real MiMo CCB ask passed after
   switching CCB MiMo execution to `mimo run --pure --format json`; full

--- a/lib/provider_backends/qoder/execution.py
+++ b/lib/provider_backends/qoder/execution.py
@@ -1,9 +1,26 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 import uuid
+from collections.abc import Callable
+from pathlib import Path
 from typing import Any
+
+from ccbd.api_models import JobRecord
+from completion.models import CompletionSourceKind
+from provider_core.protocol import request_anchor_for_job
+from provider_core.runtime_shared import provider_start_parts
+from provider_execution.active import PreparedActiveStart, prepare_active_start
+from provider_execution.base import (
+    ProviderPollResult,
+    ProviderRuntimeContext,
+    ProviderSubmission,
+)
+from provider_execution.common import (
+    interrupt_and_clear_runtime_target,
+    send_prompt_to_runtime_target,
+)
+from terminal_runtime import get_backend_for_session
 
 from provider_backends.native_cli_support import (
     NativeCliExecutionConfig,
@@ -11,14 +28,151 @@ from provider_backends.native_cli_support import (
     NativeCliObservation,
     NativeCliSubprocessAdapter,
 )
-from provider_core.runtime_shared import provider_start_parts
+from provider_backends.pane_quiet_support import (
+    PaneSnapshotReader,
+    wrap_pane_quiet_prompt,
+)
+from provider_backends.pane_quiet_support import (
+    poll_submission as poll_pane_submission,
+)
 
+from .session import load_project_session
 
 _NORMAL_STOP_REASONS = {"completed", "end_turn", "stop", "stop_sequence", "success"}
 _PERMISSION_OPTIONS = {"--dangerously-skip-permissions", "--permission-mode", "--yolo"}
 
 
-def build_execution_adapter() -> NativeCliSubprocessAdapter:
+class QoderPaneExecutionAdapter:
+    restart_resume_supported = False
+
+    def __init__(
+        self,
+        *,
+        provider: str,
+        load_project_session_fn: Callable,
+        backend_for_session_fn: Callable[[dict], object | None] = get_backend_for_session,
+    ) -> None:
+        self.provider = str(provider or "").strip().lower()
+        self._load_project_session = load_project_session_fn
+        self._backend_for_session = backend_for_session_fn
+
+    def restore_diagnostics(self) -> dict[str, object]:
+        return {
+            "resume_supported": False,
+            "restore_mode": "resubmit_required",
+            "restore_reason": "provider_resume_unsupported",
+            "restore_detail": (
+                f"{self.provider} asks run in the managed visible pane; interrupted "
+                "in-flight jobs should be resubmitted after daemon restart"
+            ),
+        }
+
+    def start(
+        self,
+        job: JobRecord,
+        *,
+        context: ProviderRuntimeContext | None,
+        now: str,
+    ) -> ProviderSubmission:
+        prepared = prepare_active_start(
+            job,
+            context=context,
+            provider=self.provider,
+            source_kind=CompletionSourceKind.TERMINAL_TEXT,
+            now=now,
+            missing_session_reason=f"missing_{self.provider}_session",
+            load_session_fn=self._load_session,
+            backend_for_session_fn=self._backend_for_session,
+        )
+        if not isinstance(prepared, PreparedActiveStart):
+            return prepared
+
+        request_anchor = request_anchor_for_job(job.job_id)
+        prompt = wrap_pane_quiet_prompt(job.request.body or "", request_anchor)
+        reader = PaneSnapshotReader(
+            backend=prepared.backend,
+            pane_id=prepared.pane_id,
+            lines=2000,
+        )
+        try:
+            send_prompt_to_runtime_target(prepared.backend, prepared.pane_id, prompt)
+        except Exception as exc:  # noqa: BLE001 - terminal backends expose provider-specific failures
+            send_error = f"send_text_failed:{exc!r}"
+        else:
+            send_error = None
+
+        return ProviderSubmission(
+            job_id=job.job_id,
+            agent_name=job.agent_name,
+            provider=self.provider,
+            accepted_at=now,
+            ready_at=now,
+            source_kind=CompletionSourceKind.TERMINAL_TEXT,
+            reply="",
+            diagnostics={
+                "provider": self.provider,
+                "mode": "visible_pane",
+                "workspace_path": str(prepared.work_dir),
+                "pane_id": prepared.pane_id,
+                **({"send_error": send_error} if send_error else {}),
+            },
+            runtime_state={
+                "mode": "pane_quiet",
+                "provider": self.provider,
+                "reader": reader,
+                "backend": prepared.backend,
+                "pane_id": prepared.pane_id,
+                "req_id": request_anchor,
+                "request_anchor": request_anchor,
+                "started_at": now,
+                "last_change_at": now,
+                "last_poll_at": now,
+                "last_hash": None,
+                "prompt_sent": send_error is None,
+                "pending_prompt": prompt,
+                "send_error": send_error,
+                "snapshot_errors": 0,
+                "next_seq": 1,
+            },
+        )
+
+    def poll(self, submission: ProviderSubmission, *, now: str) -> ProviderPollResult | None:
+        return poll_pane_submission(submission, now=now)
+
+    def cancel(self, submission: ProviderSubmission) -> None:
+        backend = submission.runtime_state.get("backend")
+        pane_id = str(submission.runtime_state.get("pane_id") or "").strip()
+        if backend is not None and pane_id:
+            interrupt_and_clear_runtime_target(backend, pane_id)
+
+    def _load_session(self, work_dir: Path, *, agent_name: str):
+        instance = str(agent_name or "").strip().lower()
+        if not instance:
+            return None
+        return self._load_project_session(work_dir, instance=instance)
+
+
+def build_qoder_pane_execution_adapter(
+    *,
+    provider: str,
+    load_project_session_fn: Callable,
+    backend_for_session_fn: Callable[[dict], object | None] = get_backend_for_session,
+) -> QoderPaneExecutionAdapter:
+    return QoderPaneExecutionAdapter(
+        provider=provider,
+        load_project_session_fn=load_project_session_fn,
+        backend_for_session_fn=backend_for_session_fn,
+    )
+
+
+def build_execution_adapter() -> QoderPaneExecutionAdapter:
+    return build_qoder_pane_execution_adapter(
+        provider="qoder",
+        load_project_session_fn=load_project_session,
+    )
+
+
+def build_headless_execution_adapter() -> NativeCliSubprocessAdapter:
     return NativeCliSubprocessAdapter(
         NativeCliExecutionConfig(
             provider="qoder",
@@ -240,6 +394,9 @@ def _has_option(parts: list[str], option: str) -> bool:
 
 
 __all__ = [
+    "QoderPaneExecutionAdapter",
     "build_execution_adapter",
+    "build_headless_execution_adapter",
+    "build_qoder_pane_execution_adapter",
     "observe_qoder_output",
 ]

--- a/lib/provider_backends/qoder/manifest.py
+++ b/lib/provider_backends/qoder/manifest.py
@@ -1,11 +1,39 @@
 from __future__ import annotations
 
-from provider_backends.native_cli_support import build_native_cli_manifest
+from agents.models import RuntimeMode
+from completion.models import CompletionFamily, CompletionSourceKind, SelectorFamily
+from completion.profiles import CompletionManifest
 from provider_core.manifests import ProviderManifest
 
 
 def build_manifest() -> ProviderManifest:
-    return build_native_cli_manifest(provider="qoder")
+    return build_qoder_pane_manifest(provider="qoder")
 
 
-__all__ = ["build_manifest"]
+def build_qoder_pane_manifest(*, provider: str) -> ProviderManifest:
+    provider = str(provider or "").strip().lower()
+    return ProviderManifest(
+        provider=provider,
+        supports_resume=False,
+        supports_permission_auto=True,
+        supports_stream_watch=False,
+        supports_subagents=False,
+        supports_workspace_attach=True,
+        runtime_profiles={
+            RuntimeMode.PANE_BACKED: CompletionManifest(
+                provider=provider,
+                runtime_mode=RuntimeMode.PANE_BACKED.value,
+                completion_family=CompletionFamily.TERMINAL_TEXT_QUIET,
+                completion_source_kind=CompletionSourceKind.TERMINAL_TEXT,
+                supports_exact_completion=False,
+                supports_observed_completion=True,
+                supports_anchor_binding=True,
+                supports_reply_stability=False,
+                supports_terminal_reason=True,
+                selector_family=SelectorFamily.FINAL_MESSAGE,
+            ),
+        },
+    )
+
+
+__all__ = ["build_manifest", "build_qoder_pane_manifest"]

--- a/lib/provider_backends/qoderclicn/execution.py
+++ b/lib/provider_backends/qoderclicn/execution.py
@@ -9,13 +9,23 @@ from provider_backends.native_cli_support import (
     NativeCliSubprocessAdapter,
 )
 from provider_backends.qoder.execution import (
+    QoderPaneExecutionAdapter,
     _build_qoder_command,
     _observe_qoder_output,
     _qoder_session_id_for_job,
+    build_qoder_pane_execution_adapter,
 )
+from provider_backends.qoderclicn.session import load_project_session
 
 
-def build_execution_adapter() -> NativeCliSubprocessAdapter:
+def build_execution_adapter() -> QoderPaneExecutionAdapter:
+    return build_qoder_pane_execution_adapter(
+        provider="qoderclicn",
+        load_project_session_fn=load_project_session,
+    )
+
+
+def build_headless_execution_adapter() -> NativeCliSubprocessAdapter:
     return NativeCliSubprocessAdapter(
         NativeCliExecutionConfig(
             provider="qoderclicn",
@@ -54,4 +64,8 @@ def _qoderclicn_session_id_for_job(job_id: str) -> str:
     return _qoder_session_id_for_job(job_id, provider="qoderclicn")
 
 
-__all__ = ["build_execution_adapter", "observe_qoderclicn_output"]
+__all__ = [
+    "build_execution_adapter",
+    "build_headless_execution_adapter",
+    "observe_qoderclicn_output",
+]

--- a/lib/provider_backends/qoderclicn/manifest.py
+++ b/lib/provider_backends/qoderclicn/manifest.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from provider_backends.native_cli_support import build_native_cli_manifest
 from provider_core.manifests import ProviderManifest
+
+from provider_backends.qoder.manifest import build_qoder_pane_manifest
 
 
 def build_manifest() -> ProviderManifest:
-    return build_native_cli_manifest(provider="qoderclicn")
+    return build_qoder_pane_manifest(provider="qoderclicn")
 
 
 __all__ = ["build_manifest"]

--- a/test/test_native_cli_provider_execution.py
+++ b/test/test_native_cli_provider_execution.py
@@ -25,11 +25,13 @@ from provider_backends.native_cli_support.execution import _native_cli_env
 from provider_backends.qoder.execution import (
     _build_command as build_qoder_command,
     _qoder_session_id_for_job,
+    build_headless_execution_adapter as build_qoder_headless_execution_adapter,
     observe_qoder_output,
 )
 from provider_backends.qoderclicn.execution import (
     _build_command as build_qoderclicn_command,
     _qoderclicn_session_id_for_job,
+    build_headless_execution_adapter as build_qoderclicn_headless_execution_adapter,
     observe_qoderclicn_output,
 )
 from provider_backends.zai.execution import observe_zai_output
@@ -38,7 +40,7 @@ from provider_core.registry import build_default_backend_registry
 from provider_execution.base import ProviderRuntimeContext, ProviderSubmission
 
 
-PROVIDERS = ("qwen", "qoder", "qoderclicn", "cursor", "copilot", "crush", "kiro", "pi", "omp", "zai")
+PROVIDERS = ("qwen", "cursor", "copilot", "crush", "kiro", "pi", "omp", "zai")
 STRUCTURED_PROVIDERS = ("qwen", "cursor", "copilot", "pi", "omp")
 
 
@@ -481,7 +483,11 @@ def test_qoder_provider_requires_native_result_envelope(
     _write_session(provider, work_dir)
     _install_stub(monkeypatch, provider, mode="no_terminal")
 
-    adapter = _adapter(provider)
+    adapter = (
+        build_qoder_headless_execution_adapter()
+        if provider == "qoder"
+        else build_qoderclicn_headless_execution_adapter()
+    )
     submission = adapter.start(
         _job(provider, work_dir),
         context=_runtime_context(provider, work_dir),

--- a/test/test_qoder_visible_execution.py
+++ b/test/test_qoder_visible_execution.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from ccbd.api_models import DeliveryScope, JobRecord, JobStatus, MessageEnvelope
+from completion.models import CompletionSourceKind, CompletionStatus
+from provider_backends.qoder.execution import (
+    QoderPaneExecutionAdapter,
+    build_qoder_pane_execution_adapter,
+)
+from provider_core.protocol import request_anchor_for_job
+from provider_core.registry import build_default_backend_registry
+from provider_execution.base import ProviderRuntimeContext
+
+
+class _Backend:
+    def __init__(self) -> None:
+        self.text = "Qoder ready\n"
+        self.sent: list[tuple[str, str]] = []
+        self.keys: list[tuple[str, str]] = []
+
+    def send_text_to_pane(self, pane_id: str, text: str) -> None:
+        self.sent.append((pane_id, text))
+
+    def get_pane_content(self, pane_id: str, *, lines: int) -> str:
+        del pane_id, lines
+        return self.text
+
+    def send_key(self, pane_id: str, key: str) -> None:
+        self.keys.append((pane_id, key))
+
+
+class _Session:
+    def __init__(self, *, pane_result: tuple[bool, str] = (True, "%12")) -> None:
+        self.data = {"terminal": "tmux", "pane_id": "%12"}
+        self._pane_result = pane_result
+
+    def ensure_pane(self) -> tuple[bool, str]:
+        return self._pane_result
+
+
+def _job(provider: str, agent_name: str, work_dir: Path) -> JobRecord:
+    return JobRecord(
+        job_id=f"job_{provider}_visible123",
+        submission_id=f"sub_{provider}_visible123",
+        agent_name=agent_name,
+        provider=provider,
+        request=MessageEnvelope(
+            project_id="proj",
+            to_agent=agent_name,
+            from_actor="main",
+            body="Reply from the visible pane.",
+            task_id=None,
+            reply_to=None,
+            message_type="ask",
+            delivery_scope=DeliveryScope.SINGLE,
+        ),
+        status=JobStatus.RUNNING,
+        terminal_decision=None,
+        cancel_requested_at=None,
+        created_at="2026-07-29T00:00:00Z",
+        updated_at="2026-07-29T00:00:00Z",
+        workspace_path=str(work_dir),
+    )
+
+
+def _context(agent_name: str, work_dir: Path) -> ProviderRuntimeContext:
+    return ProviderRuntimeContext(
+        agent_name=agent_name,
+        workspace_path=str(work_dir),
+        backend_type="pane-backed",
+        runtime_ref="%12",
+        session_ref=str(work_dir / ".ccb" / f"session-{agent_name}"),
+    )
+
+
+@pytest.mark.parametrize(
+    ("provider", "agent_name"),
+    (("qoder", "qoder"), ("qoderclicn", "qodercn")),
+)
+def test_qoder_asks_execute_in_exact_managed_visible_pane(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    provider: str,
+    agent_name: str,
+) -> None:
+    backend = _Backend()
+    session = _Session()
+    loaded_instances: list[str | None] = []
+
+    def load_session(work_dir: Path, instance: str | None = None):
+        assert work_dir == tmp_path
+        loaded_instances.append(instance)
+        return session
+
+    def hidden_process_forbidden(*args, **kwargs):
+        del args, kwargs
+        raise AssertionError("visible Qoder ask must not create a hidden subprocess")
+
+    monkeypatch.setattr(
+        "provider_backends.native_cli_support.execution.subprocess.Popen",
+        hidden_process_forbidden,
+    )
+    adapter = build_qoder_pane_execution_adapter(
+        provider=provider,
+        load_project_session_fn=load_session,
+        backend_for_session_fn=lambda data: backend,
+    )
+    job = _job(provider, agent_name, tmp_path)
+
+    submission = adapter.start(
+        job,
+        context=_context(agent_name, tmp_path),
+        now="2026-07-29T00:00:00Z",
+    )
+
+    assert loaded_instances == [agent_name]
+    assert submission.source_kind is CompletionSourceKind.TERMINAL_TEXT
+    assert submission.diagnostics["mode"] == "visible_pane"
+    assert submission.runtime_state["pane_id"] == "%12"
+    assert len(backend.sent) == 1
+    sent_pane, sent_prompt = backend.sent[0]
+    assert sent_pane == "%12"
+    assert "Reply from the visible pane." in sent_prompt
+    req_id = request_anchor_for_job(job.job_id)
+    assert f"CCB_REQ_ID: {req_id}" in sent_prompt
+    assert f"CCB_DONE: {req_id}" in sent_prompt
+
+    backend.text = (
+        f"CCB_REQ_ID: {req_id}\n"
+        "IMPORTANT: when you finish answering\n"
+        f"CCB_DONE: {req_id}\n"
+        "visible Qoder reply\n"
+        f"CCB_DONE: {req_id}\n"
+    )
+    result = adapter.poll(submission, now="2026-07-29T00:00:03Z")
+
+    assert result is not None
+    assert result.decision is not None
+    assert result.decision.status is CompletionStatus.COMPLETED
+    assert result.decision.reply == "visible Qoder reply"
+
+
+def test_qoder_visible_adapter_fails_closed_when_owned_pane_is_unavailable(tmp_path: Path) -> None:
+    backend = _Backend()
+    adapter = build_qoder_pane_execution_adapter(
+        provider="qoder",
+        load_project_session_fn=lambda work_dir, instance=None: _Session(
+            pane_result=(False, "Pane not alive: %12")
+        ),
+        backend_for_session_fn=lambda data: backend,
+    )
+
+    submission = adapter.start(
+        _job("qoder", "qoder", tmp_path),
+        context=_context("qoder", tmp_path),
+        now="2026-07-29T00:00:00Z",
+    )
+
+    assert submission.runtime_state["reason"] == "pane_unavailable"
+    assert submission.runtime_state["mode"] == "error"
+    assert backend.sent == []
+
+
+def test_default_qoder_backends_register_visible_pane_adapters() -> None:
+    registry = build_default_backend_registry(
+        include_optional=True,
+        include_test_doubles=False,
+    )
+
+    for provider in ("qoder", "qoderclicn"):
+        backend = registry.get(provider)
+        assert backend is not None
+        assert isinstance(backend.execution_adapter, QoderPaneExecutionAdapter)

--- a/test/test_v2_provider_catalog.py
+++ b/test/test_v2_provider_catalog.py
@@ -76,12 +76,18 @@ def test_default_provider_catalog_contains_expected_profiles() -> None:
     assert mimo.completion_source_kind is CompletionSourceKind.STRUCTURED_RESULT_STREAM
     assert mimo.supports_observed_completion is True
     assert mimo.supports_anchor_binding is True
-    for provider in ('qwen', 'qoder', 'qoderclicn', 'cursor', 'copilot', 'crush', 'kiro', 'pi', 'omp', 'zai', 'grok'):
+    for provider in ('qwen', 'cursor', 'copilot', 'crush', 'kiro', 'pi', 'omp', 'zai', 'grok'):
         native = catalog.resolve_completion_manifest(provider, RuntimeMode.PANE_BACKED)
         assert native.completion_family is CompletionFamily.STRUCTURED_RESULT
         assert native.completion_source_kind is CompletionSourceKind.STRUCTURED_RESULT_STREAM
         assert native.supports_observed_completion is True
         assert native.supports_anchor_binding is True
+    for provider in ('qoder', 'qoderclicn'):
+        visible = catalog.resolve_completion_manifest(provider, RuntimeMode.PANE_BACKED)
+        assert visible.completion_family is CompletionFamily.TERMINAL_TEXT_QUIET
+        assert visible.completion_source_kind is CompletionSourceKind.TERMINAL_TEXT
+        assert visible.supports_observed_completion is True
+        assert visible.supports_anchor_binding is True
     fake_legacy = catalog.resolve_completion_manifest('fake-legacy', RuntimeMode.PANE_BACKED)
     assert fake_legacy.completion_family is CompletionFamily.TERMINAL_TEXT_QUIET
 


### PR DESCRIPTION
## Summary

- route qoder and qoderclicn asks through the exact managed visible pane
- validate the agent session and owned tmux pane before prompt delivery
- fail closed when the pane is unavailable instead of starting a hidden print process
- switch completion metadata to anchored terminal-text evidence and update contracts

## Tests

- 188 focused Qoder/runtime tests passed
- 78 final core regression tests passed
- Ruff and git diff checks passed

The attempted full suite required additional optional dependencies and entered unrelated long-running campaign/platform failures; no Qoder-focused failures were observed.