### PR TITLE
fix(pi): restore native session on CCB restart

### DIFF
--- a/docs/features/pi-session-history.md
+++ b/docs/features/pi-session-history.md
@@ -1,0 +1,47 @@
+# Pi Session History Recovery
+
+## Feature Overview
+
+CCB keeps its launch identity (`ccb_session_id`) separate from Pi's native
+conversation identity. A managed Pi launch records the native JSONL session
+id and path from the `extension_ready` event emitted at `session_start`.
+
+## Supported Flow
+
+- A restore launch selects the exact validated `--session <jsonl-path>`.
+- A fresh launch, `--new-context`, and explicit Pi session controls preserve
+  their existing semantics and do not receive automatic CCB resume arguments.
+- Older `.pi-session` records with a legacy `ccb-*` id or a missing native path
+  scan only the managed Pi session directory and resume the latest valid JSONL
+  transcript for the matching agent, project, and working directory.
+- Invalid bindings fall back to a fresh native session.
+
+## Backend Design
+
+`lib/provider_backends/pi/launcher.py` owns managed session-directory setup,
+marker-based command rendering, and CCB session payload projection.
+`lib/provider_backends/pi/pane_events.py` exposes the native identity captured
+in `extension_ready`; `lib/provider_backends/pi/pane_execution.py` persists it
+before prompt dispatch can advance the event offset.
+
+## Persistence Contract
+
+The `.pi-session` record stores `ccb_session_id` plus `pi_session_id`,
+`pi_session_path`, normalized working directory, binding timestamp, and binding
+source. Native paths must be direct files in the managed session directory,
+have a matching JSONL `session` header and id, and match the recorded cwd.
+
+## Verification Status
+
+Focused session-history, pane-execution, and runtime-launch checks pass:
+`155 passed` with Python 3.13 using:
+`python3 -m pytest -q test/test_pi_session_history.py
+test/test_pi_pane_execution.py test/test_v2_runtime_launch.py`.
+`python3 -m compileall -q lib test` and `git diff --check` also pass. The
+regression suite specifically covers initial ready-event persistence, explicit
+session controls, and legacy records without a native path.
+
+## Known Limitations
+
+If Pi does not emit a valid `session_start` identity or the managed JSONL file
+fails validation, CCB intentionally starts a fresh native session.

--- a/lib/provider_backends/pi/launcher.py
+++ b/lib/provider_backends/pi/launcher.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import hashlib
 import os
+import shlex
 from pathlib import Path
 
 from provider_core.contracts import ProviderRuntimeLauncher
+from provider_core.pathing import session_filename_for_agent
+from provider_core.runtime_shared import provider_start_parts
 
 from provider_backends.native_cli_support import NativeCliLaunchConfig
 from provider_backends.native_cli_support.launcher import (
@@ -16,6 +19,11 @@ from provider_backends.native_cli_support.launcher import (
 from provider_backends.native_cli_support.launcher import (
     prepare_launch_context as prepare_native_launch_context,
 )
+from provider_backends.pi.session import (
+    PI_RESTART_SESSION_MARKER,
+    render_restart_command,
+    resume_binding_for_launch,
+)
 
 _PI_COMPLETION_SCHEMA_VERSION = 1
 _PI_EXTENSION_FILENAME = "ccb-pi-completion.ts"
@@ -26,16 +34,7 @@ def build_runtime_launcher() -> ProviderRuntimeLauncher:
     return ProviderRuntimeLauncher(
         provider="pi",
         launch_mode="simple_tmux",
-        prepare_launch_context=lambda context, spec, plan, runtime_dir, prepared_state: (
-            prepare_native_launch_context(
-                config,
-                context,
-                spec,
-                plan,
-                runtime_dir,
-                prepared_state,
-            )
-        ),
+        prepare_launch_context=prepare_launch_context,
         build_start_cmd=lambda command, spec, runtime_dir, launch_session_id, prepared_state=None: (
             _build_start_cmd(
                 config,
@@ -62,6 +61,57 @@ def build_runtime_launcher() -> ProviderRuntimeLauncher:
             )
         ),
     )
+
+
+def prepare_launch_context(
+    context,
+    spec,
+    plan,
+    runtime_dir: Path,
+    prepared_state: dict[str, object],
+) -> dict[str, object]:
+    payload = prepare_native_launch_context(
+        _launch_config(),
+        context,
+        spec,
+        plan,
+        runtime_dir,
+        prepared_state,
+    )
+    run_cwd = Path(str(payload.get("workspace_path") or plan.workspace_path))
+    session_dir = _pi_session_dir(payload)
+    session_file = context.paths.ccb_dir / session_filename_for_agent("pi", spec.name)
+    payload.update(
+        resume_binding_for_launch(
+            session_file,
+            agent_name=spec.name,
+            project_id=context.project.project_id,
+            work_dir=run_cwd,
+            session_dir=session_dir,
+        )
+    )
+    payload["pi_session_dir"] = str(session_dir)
+    return payload
+
+
+def _has_session_control(parts: tuple[str, ...] | list[str]) -> bool:
+    normalized = [str(part).strip() for part in parts]
+    if any(part in _SESSION_CONTROL_FLAGS for part in normalized):
+        return True
+    return any(
+        part.startswith(("--session=", "--session-id=", "--resume=", "--continue="))
+        for part in normalized
+    )
+
+
+_SESSION_CONTROL_FLAGS = {
+    "--continue",
+    "--session",
+    "--session-id",
+    "--resume",
+    "-c",
+    "-r",
+}
 
 
 def _launch_config() -> NativeCliLaunchConfig:
@@ -93,12 +143,24 @@ def _build_start_cmd(
 ) -> str:
     if prepared_state is None:
         raise RuntimeError("pi launch requires prepared_state")
+    launch_context = prepared_state
+    command_parts = (*provider_start_parts("pi"), *spec.startup_args)
+    template_parts = _template_parts(getattr(spec, "provider_command_template", None))
+    if _has_session_control((*command_parts, *template_parts)):
+        launch_context["pi_resume_status"] = "explicit_session_control"
+        launch_context["pi_explicit_session_control"] = True
+    else:
+        launch_context["pi_explicit_session_control"] = False
+        if not command.restore:
+            launch_context["pi_resume_status"] = "fresh_restore_disabled"
+        elif launch_context.get("pi_resume_status") == "exact_session_ready":
+            launch_context["pi_resume_status"] = "exact_session_selected"
     _materialize_completion_extension(
         prepared_state,
         runtime_dir=runtime_dir,
         launch_session_id=launch_session_id,
     )
-    return build_native_start_cmd(
+    command_template = build_native_start_cmd(
         config,
         command,
         spec,
@@ -106,6 +168,28 @@ def _build_start_cmd(
         launch_session_id,
         prepared_state=prepared_state,
     )
+    if command_template.count(PI_RESTART_SESSION_MARKER) == 1:
+        launch_context["pi_restart_start_cmd_template"] = command_template
+    else:
+        launch_context.pop("pi_restart_start_cmd_template", None)
+    exact_args = ""
+    if launch_context.get("pi_resume_status") == "exact_session_selected":
+        resume_path = str(launch_context.get("pi_resume_session_path") or "").strip()
+        if resume_path:
+            exact_args = f"--session {shlex.quote(resume_path)}"
+        else:
+            launch_context["pi_resume_status"] = "fresh_native_session_path_missing"
+    return render_restart_command(command_template, exact_args=exact_args) or command_template
+
+
+def _template_parts(template: object) -> tuple[str, ...]:
+    raw = str(template or "").strip()
+    if not raw:
+        return ()
+    try:
+        return tuple(shlex.split(raw))
+    except ValueError:
+        return ()
 
 
 def _build_session_payload(
@@ -134,20 +218,32 @@ def _build_session_payload(
         launch_session_id,
         prepared_state,
     )
+    payload.pop("pi_session_id", None)
+    payload.pop("pi_session_path", None)
     payload.update(
         {
             "pi_completion_schema_version": _PI_COMPLETION_SCHEMA_VERSION,
-            "pi_completion_extension": str(
-                prepared_state.get("pi_completion_extension") or ""
-            ),
-            "pi_completion_event_log": str(
-                prepared_state.get("pi_completion_event_log") or ""
-            ),
-            "pi_dispatch_event_log": str(
-                prepared_state.get("pi_dispatch_event_log") or ""
-            ),
+            "pi_completion_extension": str(prepared_state.get("pi_completion_extension") or ""),
+            "pi_completion_event_log": str(prepared_state.get("pi_completion_event_log") or ""),
+            "pi_dispatch_event_log": str(prepared_state.get("pi_dispatch_event_log") or ""),
+            "pi_session_dir": str(prepared_state.get("pi_session_dir") or _pi_session_dir(prepared_state)),
+            "pi_resume_status": str(prepared_state.get("pi_resume_status") or "fresh_no_binding"),
+            "pi_explicit_session_control": bool(prepared_state.get("pi_explicit_session_control")),
+            "pi_restart_start_cmd_template": str(prepared_state.get("pi_restart_start_cmd_template") or ""),
         }
     )
+    if payload["pi_resume_status"] == "exact_session_selected":
+        payload.update(
+            {
+                "pi_session_id": str(prepared_state.get("pi_resume_session_id") or ""),
+                "pi_session_path": str(prepared_state.get("pi_resume_session_path") or ""),
+                "pi_session_work_dir_norm": str(prepared_state.get("pi_resume_session_work_dir_norm") or ""),
+                "pi_session_bound_at": str(prepared_state.get("pi_resume_session_bound_at") or ""),
+                "pi_session_binding_source": str(
+                    prepared_state.get("pi_resume_binding_source") or "native_session_observation"
+                ),
+            }
+        )
     return payload
 
 
@@ -155,13 +251,16 @@ def _pi_visible_args(prepared_state: dict[str, object]) -> tuple[str, ...]:
     session_dir = _pi_session_dir(prepared_state)
     extension_path = _path_from_prepared(prepared_state, "pi_completion_extension")
     session_dir.mkdir(parents=True, exist_ok=True)
-    return (
+    args = (
         "--session-dir",
         str(session_dir),
         "--extension",
         str(extension_path),
         "--no-approve",
     )
+    if not bool(prepared_state.get("pi_explicit_session_control")):
+        return (*args, PI_RESTART_SESSION_MARKER)
+    return args
 
 
 def _pi_visible_env(prepared_state: dict[str, object]) -> dict[str, str]:
@@ -397,7 +496,13 @@ function bindDispatchedInput(prompt: string, source: string): boolean {
 }
 
 export default function ccbPiCompletion(pi: any): void {
-  appendEvent("extension_ready");
+  pi.on("session_start", async (_event: any, ctx: any) => {
+    const manager = ctx?.sessionManager;
+    appendEvent("extension_ready", {
+      pi_session_id: String(manager?.getSessionId?.() || ""),
+      pi_session_path: String(manager?.getSessionFile?.() || ""),
+    });
+  });
 
   pi.on("input", async (event: any) => {
     const prompt = String(event?.text || "");

--- a/lib/provider_backends/pi/pane_events.py
+++ b/lib/provider_backends/pi/pane_events.py
@@ -21,6 +21,9 @@ class PiRuntimeObservation:
     ready: bool = False
     busy: bool = False
     runtime_instance_id: str = ""
+    native_session_id: str = ""
+    native_session_path: str = ""
+    native_session_observed_at: str = ""
     next_offset: int = 0
     trailing_partial: bool = False
     protocol_error: str = ""
@@ -141,6 +144,9 @@ def inspect_pi_runtime(
     ready = False
     busy = False
     runtime_instance_id = ""
+    native_session_id = ""
+    native_session_path = ""
+    native_session_observed_at = ""
     expected_actor = _text(actor)
     expected_session = _text(launch_session_id)
     for event in batch.events:
@@ -156,6 +162,9 @@ def inspect_pi_runtime(
             ready = True
             busy = False
             runtime_instance_id = event_instance
+            native_session_id = _text(event.get("pi_session_id"))
+            native_session_path = _text(event.get("pi_session_path"))
+            native_session_observed_at = _text(event.get("timestamp"))
             continue
         if not ready or event_instance != runtime_instance_id:
             continue
@@ -168,6 +177,9 @@ def inspect_pi_runtime(
         ready=ready,
         busy=busy,
         runtime_instance_id=runtime_instance_id,
+        native_session_id=native_session_id,
+        native_session_path=native_session_path,
+        native_session_observed_at=native_session_observed_at,
         next_offset=batch.next_offset,
         trailing_partial=batch.trailing_partial,
     )

--- a/lib/provider_backends/pi/pane_execution.py
+++ b/lib/provider_backends/pi/pane_execution.py
@@ -45,7 +45,7 @@ from .pane_events import (
     normalized_event_type,
     read_pi_events,
 )
-from .session import load_project_session
+from .session import load_project_session, persist_native_session_binding
 
 PI_PANE_MODE = "pi_pane"
 PI_EXTENSION_READY_TIMEOUT_ENV = "CCB_PI_EXTENSION_READY_TIMEOUT_S"
@@ -59,12 +59,12 @@ class PiPaneExecutionAdapter:
     def restore_diagnostics(self) -> dict[str, object]:
         return {
             "resume_supported": True,
-            "restore_mode": "exact_runtime_rebind",
-            "restore_reason": "pi_pane_runtime_rebind",
+            "restore_mode": "exact_native_session",
+            "restore_reason": "pi_native_session_resume",
             "restore_detail": (
-                "Pi pane jobs persist their exact launch and extension-instance "
-                "identity; restore rebinds only while that managed Pi process is "
-                "still current"
+                "Pi pane jobs persist the native session id and path after startup; "
+                "restore selects that session only when its managed path and working "
+                "directory still match"
             ),
         }
 
@@ -135,8 +135,11 @@ class PiPaneExecutionAdapter:
             "pane_id": prepared.pane_id,
             "work_dir": str(prepared.work_dir),
             "actor": actor,
+            "project_id": _text(session_data.get("ccb_project_id")),
             "launch_session_id": launch_session_id,
             "runtime_instance_id": "",
+            "session_file": str(getattr(prepared.session, "session_file", "") or ""),
+            "session_dir": _text(session_data.get("pi_session_dir")),
             "event_path": str(event_path),
             "dispatch_path": str(dispatch_path),
             "event_offset": 0,
@@ -292,6 +295,12 @@ class PiPaneExecutionAdapter:
                             "observed_runtime_instance_id": event_instance,
                         },
                     )
+                _persist_native_session_fields(
+                    state,
+                    native_session_id=_text(event.get("pi_session_id")),
+                    native_session_path=_text(event.get("pi_session_path")),
+                    observed_at=_text(event.get("timestamp")),
+                )
                 continue
             if event_instance != runtime_instance_id:
                 continue
@@ -464,7 +473,7 @@ class PiPaneExecutionAdapter:
         persisted_state,
         now: str,
     ) -> ProviderSubmission | None:
-        del persisted_state, now
+        del persisted_state
         state = dict(submission.runtime_state)
         if _text(state.get("mode")) != PI_PANE_MODE:
             return None
@@ -508,6 +517,7 @@ class PiPaneExecutionAdapter:
             or observation.trailing_partial
         ):
             return None
+        _persist_observed_native_session(state, observation, observed_at=now)
         prompt_sent = bool(state.get("prompt_sent"))
         if (
             prompt_sent
@@ -570,6 +580,7 @@ def _dispatch_if_ready(
     if observation.busy:
         state["runtime_instance_id"] = observation.runtime_instance_id
         state["event_offset"] = observation.next_offset
+        _persist_observed_native_session(state, observation, observed_at=now)
         return replace(submission, runtime_state=state)
 
     prompt = _text(state.get("pending_prompt"))
@@ -586,6 +597,7 @@ def _dispatch_if_ready(
         )
     state["runtime_instance_id"] = observation.runtime_instance_id
     state["event_offset"] = observation.next_offset
+    _persist_observed_native_session(state, observation, observed_at=now)
     try:
         _append_dispatch(state, prompt=prompt, now=now)
         send_prompt_to_runtime_target(
@@ -608,6 +620,55 @@ def _dispatch_if_ready(
     state["prompt_sent_at"] = now
     state.pop("pending_prompt", None)
     return replace(submission, runtime_state=state)
+
+
+def _persist_observed_native_session(
+    state: dict[str, object],
+    observation,
+    *,
+    observed_at: str,
+) -> None:
+    _persist_native_session_fields(
+        state,
+        native_session_id=_text(getattr(observation, "native_session_id", "")),
+        native_session_path=_text(getattr(observation, "native_session_path", "")),
+        observed_at=_text(getattr(observation, "native_session_observed_at", "")) or observed_at,
+    )
+
+
+def _persist_native_session_fields(
+    state: dict[str, object],
+    *,
+    native_session_id: str,
+    native_session_path: str,
+    observed_at: str,
+) -> None:
+    session_file = _text(state.get("session_file"))
+    session_dir = _text(state.get("session_dir"))
+    if not native_session_id or not native_session_path or not session_file or not session_dir:
+        return
+    if (
+        native_session_id == _text(state.get("native_session_id"))
+        and native_session_path == _text(state.get("native_session_path"))
+    ):
+        return
+    ok, error = persist_native_session_binding(
+        Path(session_file),
+        expected_ccb_session_id=_text(state.get("launch_session_id")),
+        agent_name=_text(state.get("actor")),
+        project_id=_text(state.get("project_id")),
+        work_dir=Path(_text(state.get("work_dir"))),
+        session_dir=Path(session_dir),
+        native_session_id=native_session_id,
+        native_session_path=Path(native_session_path),
+        observed_at=observed_at,
+    )
+    if ok:
+        state["native_session_id"] = native_session_id
+        state["native_session_path"] = native_session_path
+        state.pop("native_session_binding_error", None)
+    else:
+        state["native_session_binding_error"] = error or "binding_persist_failed"
 
 
 def _ready_timeout_or_pending(

--- a/lib/provider_backends/pi/session.py
+++ b/lib/provider_backends/pi/session.py
@@ -1,27 +1,391 @@
 from __future__ import annotations
 
+import json
+import re
+import shlex
 from pathlib import Path
-from typing import Optional
+from typing import ClassVar, Optional
 
 from provider_backends.native_cli_support.session import (
-    build_native_session_binding,
+    NativeCliProjectSession,
     compute_session_key,
     find_project_session_file as _find_project_session_file,
-    load_native_project_session,
+)
+from provider_backends.pane_log_support.session import (
+    build_session_binding_for_provider,
+    load_project_session_for_provider,
+    read_session_json,
 )
 from provider_core.contracts import ProviderSessionBinding
+from provider_sessions.files import safe_write_session
+from project.identity import normalize_work_dir
+
+
+_SESSION_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+PI_RESTART_SESSION_MARKER = "__CCB_PI_EXACT_SESSION_6E9A2F41__"
+_NATIVE_BINDING_KEYS = (
+    "pi_session_id",
+    "pi_session_path",
+    "pi_session_work_dir_norm",
+    "pi_session_bound_at",
+    "pi_session_binding_source",
+    "pi_resume_status",
+)
+
+
+class PiProjectSession(NativeCliProjectSession):
+    provider_name: ClassVar[str] = "pi"
+
+    @property
+    def pi_session_id(self) -> str:
+        return str(self.data.get("pi_session_id") or "").strip()
+
+    @property
+    def pi_session_path(self) -> str:
+        # The CCB record is not a Pi transcript. Keep the native path empty
+        # until Pi has reported one so provider binding consumers cannot
+        # mistake `.pi-session` for a JSONL conversation file.
+        return str(self.data.get("pi_session_path") or "").strip()
+
+    @property
+    def start_cmd(self) -> str:
+        return prepare_restart_start_cmd(self)
+
+    def backend(self):
+        from terminal_runtime import get_backend_for_session
+
+        return get_backend_for_session(self.data)
 
 
 def find_project_session_file(work_dir: Path, instance: Optional[str] = None) -> Optional[Path]:
     return _find_project_session_file(work_dir, provider="pi", session_filename=".pi-session", instance=instance)
 
 
-def load_project_session(work_dir: Path, instance: Optional[str] = None):
-    return load_native_project_session(work_dir, provider="pi", session_filename=".pi-session", instance=instance)
+def load_project_session(work_dir: Path, instance: Optional[str] = None) -> Optional[PiProjectSession]:
+    return load_project_session_for_provider(
+        work_dir,
+        session_filename=".pi-session",
+        session_cls=PiProjectSession,
+        instance=instance,
+    )
 
 
 def build_session_binding() -> ProviderSessionBinding:
-    return build_native_session_binding(provider="pi", session_filename=".pi-session")
+    return build_session_binding_for_provider(
+        provider="pi",
+        load_session=load_project_session,
+    )
 
 
-__all__ = ["build_session_binding", "compute_session_key", "find_project_session_file", "load_project_session"]
+def resume_binding_for_launch(
+    session_file: Path,
+    *,
+    agent_name: str,
+    project_id: str,
+    work_dir: Path,
+    session_dir: Path,
+) -> dict[str, object]:
+    if not session_file.is_file():
+        return {"pi_resume_status": "fresh_no_binding"}
+    data = read_session_json(session_file)
+    if not data:
+        return {"pi_resume_status": "fresh_invalid_session_record"}
+    mismatch = _ccb_binding_mismatch(data, agent_name=agent_name, project_id=project_id, work_dir=work_dir)
+    if mismatch:
+        return {"pi_resume_status": f"fresh_{mismatch}"}
+    session_id = str(data.get("pi_session_id") or "").strip()
+    session_path_raw = str(data.get("pi_session_path") or "").strip()
+    if session_id and session_path_raw and not _is_legacy_ccb_session_id(session_id):
+        session_path = _native_path_from_record(session_path_raw, session_dir=session_dir)
+        valid, reason = validate_native_session_binding(
+            session_id=session_id,
+            session_path=session_path,
+            work_dir=work_dir,
+            session_dir=session_dir,
+        )
+        if not valid:
+            return {"pi_resume_status": f"fresh_{reason}"}
+        return {
+            "pi_resume_status": "exact_session_ready",
+            "pi_resume_session_id": session_id,
+            "pi_resume_session_path": str(session_path),
+            "pi_resume_session_work_dir_norm": str(data.get("pi_session_work_dir_norm") or normalize_work_dir(work_dir)),
+            "pi_resume_session_bound_at": str(data.get("pi_session_bound_at") or "").strip(),
+            "pi_resume_binding_source": str(data.get("pi_session_binding_source") or "").strip(),
+        }
+
+    # Before CCB persisted a native Pi binding, it stored the CCB launch id
+    # as pi_session_id, or left the native path absent. Recover the latest
+    # valid Pi transcript for either legacy record shape.
+    if session_path_raw and not _is_legacy_ccb_session_id(session_id):
+        return {"pi_resume_status": "fresh_no_observed_native_session"}
+    preferred_id = session_id if session_id and not _is_legacy_ccb_session_id(session_id) else None
+    discovered = _discover_latest_native_session(
+        session_dir,
+        work_dir,
+        preferred_id=preferred_id,
+    )
+    if discovered is None:
+        return {"pi_resume_status": "fresh_no_observed_native_session"}
+    discovered_id, discovered_path = discovered
+    return {
+        "pi_resume_status": "exact_session_ready",
+        "pi_resume_session_id": discovered_id,
+        "pi_resume_session_path": str(discovered_path),
+        "pi_resume_session_work_dir_norm": normalize_work_dir(work_dir),
+        "pi_resume_session_bound_at": "",
+        "pi_resume_binding_source": "legacy_native_session_discovery",
+    }
+
+
+def _discover_latest_native_session(
+    session_dir: Path,
+    work_dir: Path,
+    *,
+    preferred_id: str | None = None,
+) -> tuple[str, Path] | None:
+    try:
+        candidates = sorted(
+            (path for path in session_dir.glob("*.jsonl") if path.is_file()),
+            key=lambda path: path.stat().st_mtime,
+            reverse=True,
+        )
+    except OSError:
+        return None
+    for candidate in candidates:
+        try:
+            with candidate.open("r", encoding="utf-8-sig") as stream:
+                header = json.loads(stream.readline())
+        except (OSError, ValueError):
+            continue
+        if not isinstance(header, dict) or header.get("type") != "session":
+            continue
+        native_id = str(header.get("id") or "").strip()
+        if preferred_id and native_id != preferred_id:
+            continue
+        valid, _reason = validate_native_session_binding(
+            session_id=native_id,
+            session_path=candidate,
+            work_dir=work_dir,
+            session_dir=session_dir,
+        )
+        if valid:
+            return native_id, candidate
+    return None
+
+
+def _is_legacy_ccb_session_id(session_id: str) -> bool:
+    return str(session_id or "").strip().lower().startswith("ccb-")
+
+
+def _native_path_from_record(raw_path: str, *, session_dir: Path) -> Path:
+    candidate = Path(raw_path).expanduser()
+    return candidate if candidate.is_absolute() else Path(session_dir).expanduser() / candidate
+
+
+def persist_native_session_binding(
+    session_file: Path,
+    *,
+    expected_ccb_session_id: str,
+    agent_name: str,
+    project_id: str = "",
+    work_dir: Path,
+    session_dir: Path,
+    native_session_id: str,
+    native_session_path: Path,
+    observed_at: str,
+) -> tuple[bool, str | None]:
+    data = read_session_json(session_file)
+    if not data:
+        return False, "session_record_missing_or_invalid"
+    if str(data.get("ccb_session_id") or "").strip() != str(expected_ccb_session_id or "").strip():
+        return False, "ccb_launch_session_changed"
+    mismatch = _ccb_binding_mismatch(
+        data,
+        agent_name=agent_name,
+        project_id=project_id,
+        work_dir=work_dir,
+    )
+    if mismatch:
+        return False, mismatch
+    valid, reason = validate_native_session_binding(
+        session_id=native_session_id,
+        session_path=native_session_path,
+        work_dir=work_dir,
+        session_dir=session_dir,
+    )
+    if not valid:
+        return False, reason
+    latest = read_session_json(session_file)
+    if not latest:
+        return False, "session_record_missing_or_invalid"
+    if str(latest.get("ccb_session_id") or "").strip() != str(expected_ccb_session_id or "").strip():
+        return False, "ccb_launch_session_changed"
+    mismatch = _ccb_binding_mismatch(
+        latest,
+        agent_name=agent_name,
+        project_id=project_id,
+        work_dir=work_dir,
+    )
+    if mismatch:
+        return False, mismatch
+    data = latest
+    data.update(
+        {
+            "pi_session_id": str(native_session_id).strip(),
+            "pi_session_path": str(native_session_path),
+            "pi_session_work_dir_norm": normalize_work_dir(work_dir),
+            "pi_session_bound_at": str(observed_at or ""),
+            "pi_session_binding_source": "pi_session_start_observation",
+            "pi_resume_status": "exact_session_bound",
+        }
+    )
+    ok, error = safe_write_session(session_file, json.dumps(data, ensure_ascii=False, indent=2) + "\n")
+    return ok, error
+
+
+def validate_native_session_binding(
+    *,
+    session_id: str,
+    session_path: Path,
+    work_dir: Path,
+    session_dir: Path,
+) -> tuple[bool, str]:
+    normalized_id = str(session_id or "").strip()
+    if not _SESSION_ID_RE.fullmatch(normalized_id):
+        return False, "native_session_id_invalid"
+    candidate = Path(session_path).expanduser()
+    managed_root = Path(session_dir).expanduser()
+    if candidate.is_symlink() or managed_root.is_symlink():
+        return False, "native_session_path_symlinked"
+    try:
+        relative = candidate.absolute().relative_to(managed_root.absolute())
+    except ValueError:
+        return False, "native_session_path_mismatch"
+    session_name = candidate.name
+    if (
+        len(relative.parts) != 1
+        or candidate.suffix != ".jsonl"
+        or not (
+            session_name == f"{normalized_id}.jsonl"
+            or session_name.endswith(f"_{normalized_id}.jsonl")
+        )
+    ):
+        return False, "native_session_path_mismatch"
+    components = [managed_root]
+    for part in relative.parts:
+        components.append(components[-1] / part)
+    if any(component.is_symlink() for component in components):
+        return False, "native_session_path_symlinked"
+    if _resolved_path(candidate) != _resolved_path(components[-1]):
+        return False, "native_session_path_mismatch"
+    if not candidate.is_file():
+        return False, "native_session_missing"
+    try:
+        with candidate.open("r", encoding="utf-8-sig") as stream:
+            header = json.loads(stream.readline())
+    except (OSError, ValueError):
+        return False, "native_session_header_invalid"
+    if not isinstance(header, dict) or header.get("type") != "session" or str(header.get("id") or "") != normalized_id:
+        return False, "native_session_header_mismatch"
+    recorded_cwd = str(header.get("cwd") or "").strip()
+    if not recorded_cwd or normalize_work_dir(Path(recorded_cwd)) != normalize_work_dir(work_dir):
+        return False, "native_work_dir_mismatch"
+    return True, ""
+
+
+def prepare_restart_start_cmd(session: PiProjectSession) -> str:
+    data = session.data
+    current_cmd = str(data.get("start_cmd") or "").strip()
+    if not current_cmd or bool(data.get("pi_explicit_session_control")):
+        return current_cmd
+    command_template = str(data.get("pi_restart_start_cmd_template") or "")
+    fresh_cmd = render_restart_command(command_template, exact_args="") or current_cmd
+    session_dir_text = str(data.get("pi_session_dir") or "").strip()
+    if not session_dir_text:
+        _persist_fresh_restart(session, fresh_cmd, status="fresh_session_dir_missing")
+        return fresh_cmd
+    binding = resume_binding_for_launch(
+        session.session_file,
+        agent_name=str(data.get("agent_name") or ""),
+        project_id=str(data.get("ccb_project_id") or ""),
+        work_dir=Path(session.work_dir),
+        session_dir=Path(session_dir_text),
+    )
+    if binding.get("pi_resume_status") != "exact_session_ready":
+        _persist_fresh_restart(session, fresh_cmd, status=str(binding.get("pi_resume_status") or "fresh_binding_invalid"))
+        return fresh_cmd
+    if command_template.count(PI_RESTART_SESSION_MARKER) != 1:
+        _persist_fresh_restart(session, fresh_cmd, status="fresh_restart_template_missing")
+        return fresh_cmd
+    exact_cmd = render_restart_command(
+        command_template,
+        exact_args=" ".join(
+            ("--session", shlex.quote(str(binding.get("pi_resume_session_path") or "")))
+        ),
+    )
+    if not exact_cmd:
+        _persist_fresh_restart(session, fresh_cmd, status="fresh_restart_template_invalid")
+        return fresh_cmd
+    data["start_cmd"] = exact_cmd
+    data["pi_resume_status"] = "exact_session_selected"
+    session._write_back()
+    return exact_cmd
+
+
+def render_restart_command(command_template: str, *, exact_args: str) -> str:
+    if command_template.count(PI_RESTART_SESSION_MARKER) != 1:
+        return ""
+    if exact_args:
+        return command_template.replace(PI_RESTART_SESSION_MARKER, exact_args).strip()
+    without_marker = command_template.replace(f"{PI_RESTART_SESSION_MARKER} ", "", 1)
+    if without_marker == command_template:
+        without_marker = command_template.replace(f" {PI_RESTART_SESSION_MARKER}", "", 1)
+    return without_marker.strip()
+
+
+def _persist_fresh_restart(session: PiProjectSession, start_cmd: str, *, status: str) -> None:
+    for key in _NATIVE_BINDING_KEYS:
+        session.data.pop(key, None)
+    session.data["start_cmd"] = start_cmd
+    session.data["pi_resume_status"] = status
+    session._write_back()
+
+
+def _ccb_binding_mismatch(data: dict[str, object], *, agent_name: str, project_id: str, work_dir: Path) -> str | None:
+    if data.get("active") is False:
+        return "inactive_session_record"
+    if str(data.get("agent_name") or "").strip() != str(agent_name or "").strip():
+        return "agent_mismatch"
+    recorded_project = str(data.get("ccb_project_id") or "").strip()
+    if project_id and recorded_project != project_id:
+        return "project_mismatch"
+    recorded_work_dir = str(data.get("work_dir_norm") or data.get("work_dir") or "").strip()
+    if not recorded_work_dir or recorded_work_dir != normalize_work_dir(work_dir):
+        return "work_dir_mismatch"
+    native_work_dir = str(data.get("pi_session_work_dir_norm") or "").strip()
+    if native_work_dir and native_work_dir != normalize_work_dir(work_dir):
+        return "native_work_dir_mismatch"
+    return None
+
+
+def _resolved_path(path: Path) -> Path:
+    try:
+        return Path(path).expanduser().resolve(strict=False)
+    except Exception:
+        return Path(path).expanduser().absolute()
+
+
+__all__ = [
+    "PI_RESTART_SESSION_MARKER",
+    "PiProjectSession",
+    "build_session_binding",
+    "compute_session_key",
+    "find_project_session_file",
+    "load_project_session",
+    "persist_native_session_binding",
+    "prepare_restart_start_cmd",
+    "render_restart_command",
+    "resume_binding_for_launch",
+    "validate_native_session_binding",
+]

--- a/test/test_pi_pane_execution.py
+++ b/test/test_pi_pane_execution.py
@@ -35,6 +35,8 @@ NOW = "2026-07-29T00:00:00Z"
 class _FakeSession:
     def __init__(self, data: dict[str, object]) -> None:
         self.data = data
+        session_file = str(data.get("session_file") or "").strip()
+        self.session_file = Path(session_file) if session_file else ""
 
     def ensure_pane(self) -> tuple[bool, str]:
         return True, "%9"
@@ -812,6 +814,60 @@ def test_pi_runtime_observation_tracks_foreign_busy_state(
     _append(path, _event("agent_settled"))
     idle = inspect_pi_runtime(path, actor=ACTOR, launch_session_id=LAUNCH_ID)
     assert idle.busy is False
+
+
+def test_pi_initial_ready_observation_persists_native_session_binding(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    data, events, _ = _runtime(tmp_path)
+    session_dir = tmp_path / "state" / "sessions"
+    native_id = "019fdd2b-8362-7958-9e85-d0a5eed17084"
+    native_path = session_dir / f"2026-07-29T00-00-00-000Z_{native_id}.jsonl"
+    session_dir.mkdir(parents=True)
+    native_path.write_text(
+        json.dumps({"type": "session", "id": native_id, "cwd": str(tmp_path)}) + "\n",
+        encoding="utf-8",
+    )
+    session_file = tmp_path / ".ccb" / ".pi-pi1-session"
+    session_file.parent.mkdir(parents=True, exist_ok=True)
+    session_file.write_text(
+        json.dumps(
+            {
+                "ccb_session_id": LAUNCH_ID,
+                "agent_name": ACTOR,
+                "ccb_project_id": "project-1",
+                "work_dir": str(tmp_path),
+            }
+        ),
+        encoding="utf-8",
+    )
+    data.update(
+        {
+            "session_file": str(session_file),
+            "work_dir": str(tmp_path),
+            "pi_session_dir": str(session_dir),
+        }
+    )
+    _append(
+        events,
+        _event(
+            "extension_ready",
+            pi_session_id=native_id,
+            pi_session_path=str(native_path),
+        ),
+    )
+    backend = _FakeBackend()
+    _bind(monkeypatch, session=_FakeSession(data), backend=backend)
+
+    submission = PiPaneExecutionAdapter().start(
+        _job(),
+        context=_context(tmp_path),
+        now=NOW,
+    )
+
+    assert submission.runtime_state["native_session_id"] == native_id
+    assert json.loads(session_file.read_text(encoding="utf-8"))["pi_session_id"] == native_id
 
 
 class _RoutingAdapter:

--- a/test/test_pi_session_history.py
+++ b/test/test_pi_session_history.py
@@ -1,0 +1,376 @@
+from __future__ import annotations
+
+import json
+import shlex
+from pathlib import Path
+from types import SimpleNamespace
+
+from provider_backends.pi import launcher
+from provider_backends.pi.session import (
+    PiProjectSession,
+    persist_native_session_binding,
+    resume_binding_for_launch,
+    validate_native_session_binding,
+)
+
+
+def _pi_file(root: Path, *, session_id: str, cwd: Path) -> Path:
+    path = root / f"2026-08-08T00-00-00-000Z_{session_id}.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "type": "session",
+                "version": 3,
+                "id": session_id,
+                "timestamp": "2026-08-08T00:00:00.000Z",
+                "cwd": str(cwd),
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _ccb_record(path: Path, *, ccb_session_id: str, work_dir: Path, **extra: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "ccb_session_id": ccb_session_id,
+                "agent_name": "pi1",
+                "ccb_project_id": "project-1",
+                "work_dir": str(work_dir),
+                **extra,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_pi_resume_binding_requires_matching_managed_session_header(tmp_path: Path) -> None:
+    work_dir = tmp_path / "workspace"
+    session_dir = tmp_path / "state" / "sessions"
+    native_id = "019fdd2b-8362-7958-9e85-d0a5eed17084"
+    native_path = _pi_file(session_dir, session_id=native_id, cwd=work_dir)
+    ccb_file = tmp_path / ".ccb" / ".pi-pi1-session"
+    _ccb_record(
+        ccb_file,
+        ccb_session_id="ccb-launch-1",
+        work_dir=work_dir,
+        pi_session_id=native_id,
+        pi_session_path=str(native_path),
+    )
+
+    binding = resume_binding_for_launch(
+        ccb_file,
+        agent_name="pi1",
+        project_id="project-1",
+        work_dir=work_dir,
+        session_dir=session_dir,
+    )
+
+    assert binding["pi_resume_status"] == "exact_session_ready"
+    assert binding["pi_resume_session_id"] == native_id
+    assert binding["pi_resume_session_path"] == str(native_path)
+
+    native_path.write_text(native_path.read_text(encoding="utf-8").replace(str(work_dir), str(tmp_path / "other")), encoding="utf-8")
+    invalid = resume_binding_for_launch(
+        ccb_file,
+        agent_name="pi1",
+        project_id="project-1",
+        work_dir=work_dir,
+        session_dir=session_dir,
+    )
+    assert invalid["pi_resume_status"] == "fresh_native_work_dir_mismatch"
+
+
+def test_legacy_ccb_record_discovers_latest_valid_pi_session(tmp_path: Path) -> None:
+    import os
+
+    work_dir = tmp_path / "workspace"
+    session_dir = tmp_path / "state" / "sessions"
+    older_id = "019fdd2b-8362-7958-9e85-d0a5eed17084"
+    newer_id = "019fdd1e-a08d-75b6-a64f-6ce980692624"
+    older_path = _pi_file(session_dir, session_id=older_id, cwd=work_dir)
+    newer_path = _pi_file(session_dir, session_id=newer_id, cwd=work_dir)
+    os.utime(older_path, (10, 10))
+    os.utime(newer_path, (20, 20))
+    ccb_file = tmp_path / ".ccb" / ".pi-pi1-session"
+    _ccb_record(
+        ccb_file,
+        ccb_session_id="ccb-new-launch",
+        work_dir=work_dir,
+        pi_session_id="ccb-old-launch",
+    )
+
+    binding = resume_binding_for_launch(
+        ccb_file,
+        agent_name="pi1",
+        project_id="project-1",
+        work_dir=work_dir,
+        session_dir=session_dir,
+    )
+
+    assert binding["pi_resume_status"] == "exact_session_ready"
+    assert binding["pi_resume_session_id"] == newer_id
+    assert binding["pi_resume_session_path"] == str(newer_path)
+    assert binding["pi_resume_binding_source"] == "legacy_native_session_discovery"
+
+
+def test_legacy_record_with_native_id_but_missing_path_discovers_pi_session(tmp_path: Path) -> None:
+    import os
+
+    work_dir = tmp_path / "workspace"
+    session_dir = tmp_path / "state" / "sessions"
+    native_id = "019fdd2b-8362-7958-9e85-d0a5eed17084"
+    native_path = _pi_file(session_dir, session_id=native_id, cwd=work_dir)
+    newer_path = _pi_file(
+        session_dir,
+        session_id="019fdd1e-a08d-75b6-a64f-6ce980692624",
+        cwd=work_dir,
+    )
+    os.utime(native_path, (10, 10))
+    os.utime(newer_path, (20, 20))
+    ccb_file = tmp_path / ".ccb" / ".pi-pi1-session"
+    _ccb_record(
+        ccb_file,
+        ccb_session_id="ccb-launch-1",
+        work_dir=work_dir,
+        pi_session_id=native_id,
+    )
+
+    binding = resume_binding_for_launch(
+        ccb_file,
+        agent_name="pi1",
+        project_id="project-1",
+        work_dir=work_dir,
+        session_dir=session_dir,
+    )
+
+    assert binding["pi_resume_status"] == "exact_session_ready"
+    assert binding["pi_resume_session_id"] == native_id
+    assert binding["pi_resume_session_path"] == str(native_path)
+
+
+def test_legacy_ccb_id_ignores_stale_path_and_discovers_native_session(tmp_path: Path) -> None:
+    work_dir = tmp_path / "workspace"
+    session_dir = tmp_path / "state" / "sessions"
+    native_id = "019fdd2b-8362-7958-9e85-d0a5eed17084"
+    native_path = _pi_file(session_dir, session_id=native_id, cwd=work_dir)
+    ccb_file = tmp_path / ".ccb" / ".pi-pi1-session"
+    _ccb_record(
+        ccb_file,
+        ccb_session_id="ccb-launch-1",
+        work_dir=work_dir,
+        pi_session_id="ccb-old-launch",
+        pi_session_path=str(native_path),
+    )
+
+    binding = resume_binding_for_launch(
+        ccb_file,
+        agent_name="pi1",
+        project_id="project-1",
+        work_dir=work_dir,
+        session_dir=session_dir,
+    )
+
+    assert binding["pi_resume_status"] == "exact_session_ready"
+    assert binding["pi_resume_session_id"] == native_id
+    assert binding["pi_resume_session_path"] == str(native_path)
+    assert binding["pi_resume_binding_source"] == "legacy_native_session_discovery"
+
+
+def test_pi_persists_observed_native_session_only_for_current_ccb_launch(tmp_path: Path) -> None:
+    work_dir = tmp_path / "workspace"
+    session_dir = tmp_path / "state" / "sessions"
+    native_id = "019fdd2b-8362-7958-9e85-d0a5eed17084"
+    native_path = _pi_file(session_dir, session_id=native_id, cwd=work_dir)
+    ccb_file = tmp_path / ".ccb" / ".pi-pi1-session"
+    _ccb_record(ccb_file, ccb_session_id="ccb-launch-1", work_dir=work_dir)
+
+    ok, error = persist_native_session_binding(
+        ccb_file,
+        expected_ccb_session_id="ccb-launch-1",
+        agent_name="pi1",
+        project_id="project-1",
+        work_dir=work_dir,
+        session_dir=session_dir,
+        native_session_id=native_id,
+        native_session_path=native_path,
+        observed_at="2026-08-08T00:00:01Z",
+    )
+
+    assert (ok, error) == (True, None)
+    data = json.loads(ccb_file.read_text(encoding="utf-8"))
+    assert data["pi_session_id"] == native_id
+    assert data["pi_session_path"] == str(native_path)
+    assert data["pi_resume_status"] == "exact_session_bound"
+
+    stale, reason = persist_native_session_binding(
+        ccb_file,
+        expected_ccb_session_id="ccb-launch-2",
+        agent_name="pi1",
+        project_id="project-1",
+        work_dir=work_dir,
+        session_dir=session_dir,
+        native_session_id=native_id,
+        native_session_path=native_path,
+        observed_at="2026-08-08T00:00:02Z",
+    )
+    assert stale is False
+    assert reason == "ccb_launch_session_changed"
+
+
+def test_pi_native_binding_rejects_wrong_project(tmp_path: Path) -> None:
+    work_dir = tmp_path / "workspace"
+    session_dir = tmp_path / "state" / "sessions"
+    native_id = "019fdd2b-8362-7958-9e85-d0a5eed17084"
+    native_path = _pi_file(session_dir, session_id=native_id, cwd=work_dir)
+    ccb_file = tmp_path / ".ccb" / ".pi-pi1-session"
+    _ccb_record(ccb_file, ccb_session_id="ccb-launch-1", work_dir=work_dir)
+
+    ok, reason = persist_native_session_binding(
+        ccb_file,
+        expected_ccb_session_id="ccb-launch-1",
+        agent_name="pi1",
+        project_id="different-project",
+        work_dir=work_dir,
+        session_dir=session_dir,
+        native_session_id=native_id,
+        native_session_path=native_path,
+        observed_at="2026-08-08T00:00:01Z",
+    )
+
+    assert ok is False
+    assert reason == "project_mismatch"
+
+
+def test_pi_restart_command_selects_exact_session_and_falls_back_safely(tmp_path: Path) -> None:
+    work_dir = tmp_path / "workspace"
+    session_dir = tmp_path / "state with space" / "sessions"
+    native_id = "019fdd2b-8362-7958-9e85-d0a5eed17084"
+    native_path = _pi_file(session_dir, session_id=native_id, cwd=work_dir)
+    ccb_file = tmp_path / ".ccb" / ".pi-pi1-session"
+    _ccb_record(
+        ccb_file,
+        ccb_session_id="ccb-launch-1",
+        work_dir=work_dir,
+        pi_session_id=native_id,
+        pi_session_path=str(native_path),
+    )
+    session = PiProjectSession(
+        session_file=ccb_file,
+        data={
+            "ccb_session_id": "ccb-launch-1",
+            "agent_name": "pi1",
+            "ccb_project_id": "project-1",
+            "work_dir": str(work_dir),
+            "pi_session_dir": str(session_dir),
+            "pi_restart_start_cmd_template": "pi --session-dir managed __CCB_PI_EXACT_SESSION_6E9A2F41__",
+            "start_cmd": "pi --session-dir managed",
+        },
+    )
+
+    assert session.provider_name == "pi"
+    assert session.provider_session_id == "ccb-launch-1"
+    assert session.pi_session_path == ""
+    restored = session.start_cmd
+
+    assert shlex.split(restored) == ["pi", "--session-dir", "managed", "--session", str(native_path)]
+    assert json.loads(ccb_file.read_text(encoding="utf-8"))["pi_resume_status"] == "exact_session_selected"
+
+
+def test_pi_launcher_injects_exact_session_path_only_for_restore(monkeypatch, tmp_path: Path) -> None:
+    marker = launcher.PI_RESTART_SESSION_MARKER
+    original_materialize = launcher._materialize_completion_extension
+    original_build = launcher.build_native_start_cmd
+    launcher._materialize_completion_extension = lambda *args, **kwargs: None
+    launcher.build_native_start_cmd = lambda *args, **kwargs: f"pi --session-dir managed {marker}"
+    try:
+        command = SimpleNamespace(restore=True)
+        spec = SimpleNamespace(startup_args=())
+        prepared = {
+            "pi_resume_status": "exact_session_ready",
+            "pi_resume_session_path": str(tmp_path / "session.jsonl"),
+        }
+        exact = launcher._build_start_cmd(
+            launcher._launch_config(),
+            command,
+            spec,
+            tmp_path,
+            "ccb-launch-2",
+            prepared_state=prepared,
+        )
+        assert exact == f"pi --session-dir managed --session {tmp_path / 'session.jsonl'}"
+
+        fresh = launcher._build_start_cmd(
+            launcher._launch_config(),
+            command,
+            spec,
+            tmp_path,
+            "ccb-launch-3",
+            prepared_state={"pi_resume_status": "fresh_no_binding"},
+        )
+        assert fresh == "pi --session-dir managed"
+    finally:
+        launcher._materialize_completion_extension = original_materialize
+        launcher.build_native_start_cmd = original_build
+
+
+def test_pi_launcher_does_not_inject_resume_for_explicit_session_control() -> None:
+    args = launcher._pi_visible_args(
+        {
+            "pi_state_dir": "/tmp/ccb-pi-state",
+            "pi_completion_extension": "/tmp/ccb-pi-extension.ts",
+            "pi_explicit_session_control": True,
+        }
+    )
+    assert "__CCB_PI_EXACT_SESSION_6E9A2F41__" not in args
+
+
+def test_pi_launcher_preserves_explicit_session_control(monkeypatch, tmp_path: Path) -> None:
+    marker = launcher.PI_RESTART_SESSION_MARKER
+    original_materialize = launcher._materialize_completion_extension
+    original_build = launcher.build_native_start_cmd
+    launcher._materialize_completion_extension = lambda *args, **kwargs: None
+    launcher.build_native_start_cmd = lambda *args, **kwargs: f"pi --resume user-session"
+    try:
+        prepared = {
+            "pi_resume_status": "exact_session_ready",
+            "pi_resume_session_path": str(tmp_path / "managed session.jsonl"),
+        }
+        command = SimpleNamespace(restore=True)
+        spec = SimpleNamespace(startup_args=("--resume", "user-session"))
+        command_line = launcher._build_start_cmd(
+            launcher._launch_config(),
+            command,
+            spec,
+            tmp_path,
+            "ccb-launch-3",
+            prepared_state=prepared,
+        )
+        assert command_line == "pi --resume user-session"
+        assert prepared["pi_resume_status"] == "explicit_session_control"
+        assert prepared["pi_explicit_session_control"] is True
+        assert marker not in command_line
+    finally:
+        launcher._materialize_completion_extension = original_materialize
+        launcher.build_native_start_cmd = original_build
+
+
+def test_validate_pi_session_rejects_path_outside_managed_session_dir(tmp_path: Path) -> None:
+    work_dir = tmp_path / "workspace"
+    managed = tmp_path / "managed" / "sessions"
+    outside = _pi_file(tmp_path / "outside", session_id="native-session", cwd=work_dir)
+
+    valid, reason = validate_native_session_binding(
+        session_id="native-session",
+        session_path=outside,
+        work_dir=work_dir,
+        session_dir=managed,
+    )
+
+    assert valid is False
+    assert reason == "native_session_path_mismatch"

--- a/test/test_v2_runtime_launch.py
+++ b/test/test_v2_runtime_launch.py
@@ -2207,7 +2207,10 @@ def test_native_cli_launcher_builds_provider_state_payload(
     assert payload[f'{provider}_state_dir'] == str(state_dir)
     assert payload[f'{provider}_home'] == str(state_dir / 'home')
     assert payload[f'{provider}_data_dir'] == str(state_dir / 'data')
-    assert payload[f'{provider}_session_id'] == 'sess-native'
+    if provider == 'pi':
+        assert 'pi_session_id' not in payload
+    else:
+        assert payload[f'{provider}_session_id'] == 'sess-native'
     assert f'HOME={shlex.quote(str(state_dir / "home"))}' in start_cmd
     assert f'XDG_CONFIG_HOME={shlex.quote(str(state_dir / "home" / ".config"))}' in start_cmd
     assert f'XDG_DATA_HOME={shlex.quote(str(state_dir / "data"))}' in start_cmd


### PR DESCRIPTION
## Problem

CCB previously conflated its launch-scoped `ccb-*` id with Pi's native conversation id and did not retain the native JSONL path. After a CCB restart, Pi could open a fresh conversation instead of restoring the previous managed dialogue.

## Fix

- Keep the CCB launch id separate from Pi's native session id and JSONL path.
- Capture the native id/path from Pi's `session_start` event and persist the binding before pane dispatch advances the event offset.
- On CCB restart, inject the exact validated `--session <jsonl-path>` for the matching managed conversation.
- Preserve explicit `--session`, `--resume`, and `--continue` controls without injecting CCB recovery arguments.
- Support legacy `.pi-session` records containing `ccb-*` ids or missing native paths by discovering only validated sessions in the managed directory.
- Validate agent, project, cwd, managed directory, filename, JSONL header, and symlink boundaries; fall back to a fresh session when the binding is invalid.

## Compatibility and scope

The change is limited to the Pi provider and its pane execution path. Existing fresh-launch and explicit-session semantics remain unchanged. The CCB session record now stores the native binding metadata needed for deterministic restore.

## Verification

- `python3.13 -m pytest -q test/test_pi_session_history.py test/test_pi_pane_execution.py test/test_v2_runtime_launch.py`: **155 passed**
- Related native CLI/provider registry tests: **60 passed**
- Pane log/session authority tests: **25 passed**
- `python3 -m compileall -q lib test`: passed
- `git diff --check`: passed
- Built and installed a macOS universal release preview locally; the installed CCB and helper binaries passed smoke checks, and manual Pi session restore verification passed.

The full repository suite is not claimed as passing: an earlier run was stopped near 91% after unrelated failures outside this Pi change.

## Related

Related to #274. This PR implements the Pi-specific native session binding; it does not implement the proposed general plugin mechanism.