### PR TITLE
feat(cursor): execute CCB jobs in visible Cursor panes

### DIFF
--- a/docs/plans/2026-08-11-cursor-visible-pane-execution-design.md
+++ b/docs/plans/2026-08-11-cursor-visible-pane-execution-design.md
@@ -1,0 +1,98 @@
+# Cursor Visible Pane Execution Design
+
+## Goal
+
+Route CCB jobs for the Cursor provider through each managed interactive Cursor pane so the full execution is visible and directly controllable, while preserving the current behavior of every non-Cursor provider.
+
+## Problem
+
+CCB currently mounts an interactive Cursor pane but executes incoming jobs in a separate `agent --print --output-format stream-json` subprocess. The subprocess writes output to completion artifacts, so the managed pane remains idle. The subprocess command also does not carry the agent's configured `startup_args`, which means a per-agent `--model` selection is not guaranteed for the job.
+
+The desired topology contains multiple named Cursor agents with different models. A job sent to one of those agents must run in that agent's existing pane and session, not in an unrelated background process.
+
+## Approaches Considered
+
+### 1. Pane injection with transcript-backed completion
+
+Send the anchored CCB request to the managed tmux pane. Observe the isolated Cursor transcript directory, identify the transcript containing the exact request anchor, collect assistant text, and finish only when a matching `turn_ended` record appears.
+
+This is the selected approach. It gives complete pane visibility, preserves the configured interactive model, and supports direct takeover without changing non-Cursor providers.
+
+### 2. Pre-created chat IDs with `agent create-chat` and `--resume`
+
+Create a Cursor chat before launching the pane and bind the pane to that chat ID. This provides an explicit transcript identifier but adds provider-side session creation to every launch and relies on a less mature command path. It also changes existing session startup and recovery behavior unnecessarily.
+
+### 3. Headless execution with a pane log mirror
+
+Keep the current subprocess and mirror its structured output into a terminal pane. This does not provide a real interactive session, cannot support clean takeover, and still leaves model selection split between the visible pane and the headless job.
+
+## Architecture
+
+The change is confined to `lib/provider_backends/cursor/`:
+
+- `execution.py` selects pane-backed execution by default and retains the current headless adapter as an explicit rollback path.
+- `pane_execution.py` owns CCB submission, idle waiting, tmux delivery, polling, completion, and cancellation for Cursor panes.
+- `transcript.py` discovers and incrementally reads Cursor transcript JSONL files under the managed Cursor home.
+
+No Claude, Codex, Gemini, Grok, shared dispatcher, or generic native CLI execution behavior changes. The existing Cursor launcher remains responsible for starting the interactive pane with the configured `startup_args`, including `--model`.
+
+Set `CCB_CURSOR_EXECUTION_MODE=headless` to select the previous subprocess behavior if a future Cursor CLI release changes its transcript contract.
+
+## Data Flow
+
+1. CCB accepts a job for a named Cursor agent.
+2. The Cursor pane adapter loads the exact `.cursor-session` binding and validates the pane and workspace.
+3. The adapter inspects the most recently active top-level transcript in the agent's isolated Cursor home.
+4. If the transcript contains a user turn without a following `turn_ended`, the job remains accepted but unsent. Polling repeats the idle check until the pane becomes ready.
+5. Once idle, the adapter snapshots transcript offsets and sends a prompt containing the unique `CCB_REQ_ID` anchor to the exact tmux pane.
+6. Polling scans only new or changed top-level transcripts and binds the job to the file containing that exact anchor. Subagent transcript directories are excluded.
+7. Assistant text after the anchored user message is accumulated while the Cursor TUI shows the live reasoning state and tool activity.
+8. A following `turn_ended` with `status=success` completes the CCB job. `status=error` fails it. No terminal event means the job remains active.
+
+## Concurrency and Manual Use
+
+CCB continues to serialize jobs per named agent. A job arriving while the target pane is in a manual turn waits rather than becoming a steering message or corrupting the user's input.
+
+Waiting and execution have bounded timeouts. A dead pane, missing session, malformed transcript, or wait timeout fails closed with a specific diagnostic reason. The adapter never retries or duplicates a prompt after it has observed the request anchor in a transcript.
+
+Manual input during an active CCB-owned turn remains a user takeover action and may steer that turn, matching ordinary Cursor behavior.
+
+## Transcript Contract
+
+The observed Cursor transcript format uses:
+
+- `{role: "user", message: {content: [...]}}`
+- `{role: "assistant", message: {content: [...]}}`
+- `{type: "turn_ended", status: "success" | "error"}`
+
+The parser treats unknown records as ignorable and malformed JSON as incomplete while the file may still be growing. It does not infer completion from pane text, elapsed time, or the presence of an assistant message alone.
+
+Only assistant text is returned as the CCB reply. Tool calls remain visible in the Cursor pane and transcript but are not copied into the caller's reply.
+
+## Compatibility
+
+- Three-Cursor configurations gain visible, model-pinned pane execution.
+- Mixed or three-independent-provider configurations keep their current adapters and behavior.
+- Existing CCB configuration remains valid.
+- The headless rollback mode preserves the previous Cursor execution path.
+- Interrupted in-flight Cursor jobs remain resubmit-required because CCB cannot prove safe prompt ownership across daemon restart.
+
+## Testing
+
+Automated tests will cover:
+
+- Cursor selects pane execution by default and headless execution only through the rollback switch.
+- A ready pane receives exactly one anchored prompt.
+- A busy pane waits and sends only after a terminal event makes it idle.
+- The adapter binds only to the transcript containing the exact request anchor.
+- Subagent and stale transcript records do not complete the parent job.
+- Assistant text is accumulated and returned on `turn_ended: success`.
+- `turn_ended: error`, pane death, malformed evidence, and timeout fail closed.
+- Cancellation interrupts only the exact bound pane after the prompt has been sent.
+- Existing non-Cursor provider and native CLI tests remain unchanged and pass.
+
+A final authenticated smoke test will mount three Cursor agents with different models, submit concurrent jobs to Sol and Grok, confirm that both panes visibly execute, and verify that the returned replies match the corresponding anchored transcripts.
+
+## Rollout
+
+Development and tests run in an isolated source worktree. The existing release installation is not modified until automated tests pass and a local three-Cursor smoke test succeeds. Installation then uses the source checkout so future changes are version-controlled and reversible.

--- a/docs/plans/2026-08-11-cursor-visible-pane-execution-design.md
+++ b/docs/plans/2026-08-11-cursor-visible-pane-execution-design.md
@@ -42,16 +42,16 @@ Set `CCB_CURSOR_EXECUTION_MODE=headless` to select the previous subprocess behav
 
 1. CCB accepts a job for a named Cursor agent.
 2. The Cursor pane adapter loads the exact `.cursor-session` binding and validates the pane and workspace.
-3. The adapter inspects the most recently active top-level transcript in the agent's isolated Cursor home.
-4. If the transcript contains a user turn without a following `turn_ended`, the job remains accepted but unsent. Polling repeats the idle check until the pane becomes ready.
+3. The adapter inspects both the most recently active top-level transcript and the visible Cursor pane state in the agent's isolated runtime.
+4. If the transcript contains an unfinished turn, or the pane reports `Working`/`ctrl+c to stop`, the job remains accepted but unsent. A job that observed an active pane must see a new top-level `turn_ended` and then a stable idle interval before delivery. This covers Cursor versions that do not flush the user transcript until the active turn ends.
 5. Once idle, the adapter snapshots transcript offsets and sends a prompt containing the unique `CCB_REQ_ID` anchor to the exact tmux pane.
-6. Polling scans only new or changed top-level transcripts and binds the job to the file containing that exact anchor. Subagent transcript directories are excluded.
+6. Until the unique anchor appears, polling scans complete top-level transcripts and excludes files that already contained that anchor before dispatch. After binding, polling becomes incremental. This handles Cursor replacing the previous terminal record when appending a new turn. Subagent transcript directories are excluded.
 7. Assistant text after the anchored user message is accumulated while the Cursor TUI shows the live reasoning state and tool activity.
 8. A following `turn_ended` with `status=success` completes the CCB job. `status=error` fails it. No terminal event means the job remains active.
 
 ## Concurrency and Manual Use
 
-CCB continues to serialize jobs per named agent. A job arriving while the target pane is in a manual turn waits rather than becoming a steering message or corrupting the user's input.
+CCB continues to serialize jobs per named agent. A job arriving while the target pane is in a manual turn waits rather than becoming a Cursor follow-up/steering message or corrupting the user's input. Transcript evidence is authoritative for the transition out of an observed active turn; pane text is used as an early busy/not-ready signal.
 
 Waiting and execution have bounded timeouts. A dead pane, missing session, malformed transcript, or wait timeout fails closed with a specific diagnostic reason. The adapter never retries or duplicates a prompt after it has observed the request anchor in a transcript.
 
@@ -64,6 +64,8 @@ The observed Cursor transcript format uses:
 - `{role: "user", message: {content: [...]}}`
 - `{role: "assistant", message: {content: [...]}}`
 - `{type: "turn_ended", status: "success" | "error"}`
+
+For a continuing session, Cursor may remove the prior trailing `turn_ended` before writing the next user record, then write a new terminal record at the end of the combined transcript. The pre-anchor scanner therefore cannot rely on a monotonic old EOF offset.
 
 The parser treats unknown records as ignorable and malformed JSON as incomplete while the file may still be growing. It does not infer completion from pane text, elapsed time, or the presence of an assistant message alone.
 
@@ -84,6 +86,8 @@ Automated tests will cover:
 - Cursor selects pane execution by default and headless execution only through the rollback switch.
 - A ready pane receives exactly one anchored prompt.
 - A busy pane waits and sends only after a terminal event makes it idle.
+- An active pane whose user record has not yet been flushed still waits for new terminal evidence.
+- Replacing the prior terminal record does not hide the new request anchor.
 - The adapter binds only to the transcript containing the exact request anchor.
 - Subagent and stale transcript records do not complete the parent job.
 - Assistant text is accumulated and returned on `turn_ended: success`.

--- a/docs/plans/2026-08-11-cursor-visible-pane-execution-plan.md
+++ b/docs/plans/2026-08-11-cursor-visible-pane-execution-plan.md
@@ -293,4 +293,3 @@ git log --oneline --decorate -6
 ```
 
 Commit only any test/support documentation created during smoke testing. Do not push to an upstream repository without an explicitly configured writable fork.
-

--- a/docs/plans/2026-08-11-cursor-visible-pane-execution-plan.md
+++ b/docs/plans/2026-08-11-cursor-visible-pane-execution-plan.md
@@ -1,0 +1,296 @@
+# Cursor Visible Pane Execution Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Execute CCB Cursor jobs in the named interactive Cursor tmux pane, wait safely when that pane is busy, and complete jobs from Cursor's top-level transcript without changing any other provider.
+
+**Architecture:** Keep the existing native Cursor subprocess adapter as an opt-in rollback path. Add a Cursor-only pane adapter that loads the existing `.cursor-session`, defers delivery while the current-session transcript has an unfinished turn, sends one anchored prompt to the bound pane, and incrementally observes only top-level Cursor transcript JSONL files. Bind completion to the exact `CCB_REQ_ID` and require a matching `turn_ended` record.
+
+**Tech Stack:** Python 3.11+, pytest, CCB provider adapter interfaces, tmux terminal backend, Cursor Agent transcript JSONL.
+
+---
+
+## Task 1: Build the Cursor transcript reader
+
+**Files:**
+
+- Create: `test/test_cursor_transcript.py`
+- Create: `lib/provider_backends/cursor/transcript.py`
+
+**Step 1: Write failing discovery and incremental-read tests**
+
+Add tests that construct a managed Cursor home with:
+
+- a top-level transcript at `.cursor/projects/<workspace>/agent-transcripts/<session>/<session>.jsonl`;
+- a nested `subagents/*.jsonl` file that must be excluded;
+- a partial final JSON line that must remain unread until its newline arrives;
+- a second top-level transcript created after the initial offset snapshot.
+
+Assert that `capture_cursor_transcript_offsets()` records only complete top-level files and `read_new_cursor_transcript_records()` returns ordered `(path, record)` pairs without advancing past a partial line.
+
+**Step 2: Run the new tests and confirm RED**
+
+Run: `PYTHONPATH=lib pytest -q test/test_cursor_transcript.py`
+
+Expected: collection fails because `provider_backends.cursor.transcript` does not exist.
+
+**Step 3: Implement the minimal reader**
+
+Implement:
+
+- `cursor_transcript_root(cursor_home)`;
+- `iter_top_level_cursor_transcripts(cursor_home)` using the exact two-level session layout, never `rglob()`;
+- `capture_cursor_transcript_offsets(cursor_home)`;
+- `read_new_cursor_transcript_records(cursor_home, offsets)` with byte offsets, newline framing, malformed-record tolerance, and deterministic mtime/path order;
+- content helpers that extract text from `message.content` lists while ignoring tool records.
+
+**Step 4: Run the reader tests and confirm GREEN**
+
+Run: `PYTHONPATH=lib pytest -q test/test_cursor_transcript.py`
+
+Expected: all tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add test/test_cursor_transcript.py lib/provider_backends/cursor/transcript.py
+git commit -m "feat(cursor): read visible session transcripts"
+```
+
+## Task 2: Model current-session busy and idle state
+
+**Files:**
+
+- Modify: `test/test_cursor_transcript.py`
+- Modify: `lib/provider_backends/cursor/transcript.py`
+
+**Step 1: Write failing turn-state tests**
+
+Cover these cases:
+
+- no transcript is idle;
+- a current-session user record without a later `turn_ended` is busy;
+- `turn_ended: success` and `turn_ended: error` both make the pane idle for the next turn;
+- an incomplete legacy transcript older than the current `.cursor-session` binding is ignored;
+- malformed and subagent records cannot make the parent pane busy.
+
+The session-file modification time is the lower bound for "current session" so a pre-existing legacy transcript without terminal records cannot block forever.
+
+**Step 2: Run the focused tests and confirm RED**
+
+Run: `PYTHONPATH=lib pytest -q test/test_cursor_transcript.py -k 'turn_state or busy or legacy'`
+
+Expected: failures because current-session turn-state classification is missing.
+
+**Step 3: Implement minimal classification**
+
+Add a small immutable turn-state result and `cursor_pane_turn_state(cursor_home, session_started_mtime_ns=...)`. Inspect only the newest eligible top-level transcript. Treat the transcript as busy only when its latest user turn has no later `turn_ended`. Unknown records are ignored.
+
+**Step 4: Run the transcript suite and confirm GREEN**
+
+Run: `PYTHONPATH=lib pytest -q test/test_cursor_transcript.py`
+
+Expected: all tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add test/test_cursor_transcript.py lib/provider_backends/cursor/transcript.py
+git commit -m "feat(cursor): classify visible pane turn state"
+```
+
+## Task 3: Select visible pane execution by default
+
+**Files:**
+
+- Create: `test/test_cursor_provider.py`
+- Modify: `lib/provider_backends/cursor/execution.py`
+
+**Step 1: Write failing adapter-selection tests**
+
+Assert:
+
+- with `CCB_CURSOR_EXECUTION_MODE` unset, `build_execution_adapter()` returns `CursorPaneExecutionAdapter`;
+- `CCB_CURSOR_EXECUTION_MODE=headless` returns the existing `NativeCliSubprocessAdapter`;
+- unexpected values fail closed with a clear `ValueError` instead of silently changing modes;
+- `_build_command()` and `_build_env()` remain available for rollback compatibility.
+
+**Step 2: Run the selection tests and confirm RED**
+
+Run: `PYTHONPATH=lib pytest -q test/test_cursor_provider.py -k execution_adapter`
+
+Expected: the default still returns the headless adapter.
+
+**Step 3: Add a named rollback builder and mode switch**
+
+Refactor the current function into `build_headless_execution_adapter()`. Make `build_execution_adapter()` choose the pane adapter by default and headless only for the explicit environment value. Keep imports lazy enough to avoid a circular dependency.
+
+**Step 4: Run selection and existing rollback tests**
+
+Run: `PYTHONPATH=lib pytest -q test/test_cursor_provider.py test/test_native_cli_provider_execution.py -k 'cursor or execution_adapter'`
+
+Expected: all selected tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add test/test_cursor_provider.py lib/provider_backends/cursor/execution.py
+git commit -m "feat(cursor): default jobs to visible pane"
+```
+
+## Task 4: Send once and complete from the anchored transcript
+
+**Files:**
+
+- Modify: `test/test_cursor_provider.py`
+- Create: `lib/provider_backends/cursor/pane_execution.py`
+
+**Step 1: Write failing ready-pane lifecycle tests**
+
+Use fake session/backend objects and temporary transcript files. Cover:
+
+- the exact named session and pane are resolved;
+- a ready pane receives exactly one prompt containing `CCB_REQ_ID`;
+- offsets are captured before delivery;
+- records in a stale transcript and a subagent transcript are ignored;
+- the adapter binds only to the new top-level transcript containing the exact anchor;
+- assistant text produces progress but not terminal completion by itself;
+- `turn_ended: success` emits `ANCHOR_SEEN`, `ASSISTANT_FINAL`, and `TURN_BOUNDARY`, returning the observed reply;
+- `turn_ended: error` terminates as failed/incomplete with a provider-specific reason;
+- `reply_delivery` completes immediately after visible dispatch;
+- `no_wrap` sends the raw body unchanged.
+
+**Step 2: Run lifecycle tests and confirm RED**
+
+Run: `PYTHONPATH=lib pytest -q test/test_cursor_provider.py -k 'pane or transcript or reply_delivery'`
+
+Expected: failures because `CursorPaneExecutionAdapter` is not implemented.
+
+**Step 3: Implement the minimal pane adapter**
+
+Mirror CCB's existing active-pane contract:
+
+- call `prepare_active_start()` and `ensure_active_pane_alive()`;
+- resolve `cursor_home` from the managed session;
+- wrap ordinary prompts with `wrap_native_prompt()` and the exact request anchor;
+- snapshot transcript offsets before `send_prompt_to_runtime_target()`;
+- persist `matched_transcript_path`, `anchor_seen`, `reply_buffer`, `prompt_sent`, and sequence state;
+- parse only new transcript records and ignore all records before the matched user anchor;
+- complete only on a later `turn_ended` from that same transcript;
+- use `clean_native_reply()` before returning assistant text;
+- interrupt only the bound pane on cancellation after delivery.
+
+Restore diagnostics must state that interrupted in-flight jobs require resubmission.
+
+**Step 4: Run lifecycle tests and confirm GREEN**
+
+Run: `PYTHONPATH=lib pytest -q test/test_cursor_provider.py`
+
+Expected: all tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add test/test_cursor_provider.py lib/provider_backends/cursor/pane_execution.py
+git commit -m "feat(cursor): execute jobs in visible pane"
+```
+
+## Task 5: Defer safely while the Cursor pane is busy
+
+**Files:**
+
+- Modify: `test/test_cursor_provider.py`
+- Modify: `lib/provider_backends/cursor/pane_execution.py`
+
+**Step 1: Write failing deferred-delivery tests**
+
+Cover:
+
+- `start()` accepts a job but sends nothing when the current-session transcript is busy;
+- repeated busy polls do not send;
+- after a new `turn_ended`, the next poll snapshots offsets and dispatches exactly once;
+- the wait timer is distinct from the execution timer;
+- `CCB_CURSOR_READY_TIMEOUT_S` and `CCB_CURSOR_RUN_TIMEOUT_S` accept positive finite values and fall back safely otherwise;
+- readiness timeout terminates without sending;
+- run timeout after anchor/reply evidence terminates without resending;
+- a dead pane fails promptly;
+- cancellation before delivery does not send `Ctrl-C`, while cancellation after delivery interrupts the exact pane.
+
+**Step 2: Run the deferred tests and confirm RED**
+
+Run: `PYTHONPATH=lib pytest -q test/test_cursor_provider.py -k 'busy or defer or timeout or cancel'`
+
+Expected: failures because deferred dispatch and separate timeout handling are incomplete.
+
+**Step 3: Implement deferred dispatch**
+
+Store the pending prompt when busy. On each poll, re-check the current-session turn state. When it becomes idle, capture fresh offsets immediately before a single send and reset `started_at` for the run timeout. Preserve `prompt_sent=False` through readiness timeout and never infer success from elapsed quiet time.
+
+**Step 4: Run Cursor tests and confirm GREEN**
+
+Run: `PYTHONPATH=lib pytest -q test/test_cursor_provider.py test/test_cursor_transcript.py`
+
+Expected: all tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add test/test_cursor_provider.py lib/provider_backends/cursor/pane_execution.py
+git commit -m "feat(cursor): wait for busy panes before dispatch"
+```
+
+## Task 6: Regression verification and authenticated three-Cursor smoke test
+
+**Files:**
+
+- Modify if needed: `docs/plans/2026-08-11-cursor-visible-pane-execution-design.md`
+- Create if useful: `scripts/smoke_cursor_visible_panes.sh`
+
+**Step 1: Run formatting and focused provider suites**
+
+Run:
+
+```bash
+git diff --check
+PYTHONPATH=lib pytest -q test/test_cursor_provider.py test/test_cursor_transcript.py test/test_native_cli_providers.py test/test_native_cli_provider_execution.py test/test_v2_provider_core_registry.py test/test_v2_runtime_launch.py -k 'cursor or native_cli'
+```
+
+Expected: no whitespace errors and all selected tests pass.
+
+**Step 2: Run the broader provider regression suite**
+
+Run:
+
+```bash
+PYTHONPATH=lib pytest -q test/test_grok_provider.py test/test_pi_pane_execution.py test/test_v2_provider_core_registry.py test/test_v2_runtime_launch.py
+```
+
+Expected: all tests pass; no non-Cursor adapter behavior changes.
+
+**Step 3: Run an authenticated source-tree smoke test**
+
+Use a temporary project with three named Cursor agents and distinct `startup_args --model` values. Launch CCB from this worktree, submit concurrent anchored requests to two non-controller agents, and verify all of the following before changing the installed release:
+
+- both target tmux panes visibly show their full execution;
+- neither request creates a headless `agent --print` job process;
+- each returned reply comes from the transcript containing its exact request anchor;
+- a deliberately busy pane queues the next request and dispatches it exactly once after idle;
+- each pane's launch command retains its configured model argument.
+
+If credentials or provider availability block the live smoke test, do not install globally; report the exact blocker and preserve the tested branch.
+
+**Step 4: Install the verified source build and validate the user's project**
+
+After the smoke test passes, install from this worktree using the repository's documented installer, restart the user's CCB project, run `ccb doctor`, and submit one short request to each configured Cursor agent. Confirm visible pane activity and correct anchored replies.
+
+**Step 5: Final verification and commit**
+
+Run:
+
+```bash
+git status --short
+git log --oneline --decorate -6
+```
+
+Commit only any test/support documentation created during smoke testing. Do not push to an upstream repository without an explicitly configured writable fork.
+

--- a/lib/provider_backends/cursor/execution.py
+++ b/lib/provider_backends/cursor/execution.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 from provider_backends.native_cli_support import (
@@ -10,7 +11,18 @@ from provider_backends.native_cli_support import (
 from provider_core.runtime_shared import provider_start_parts
 
 
-def build_execution_adapter() -> NativeCliSubprocessAdapter:
+def build_execution_adapter():
+    mode = str(os.environ.get("CCB_CURSOR_EXECUTION_MODE") or "").strip().lower()
+    if mode in ("", "pane"):
+        from .pane_execution import CursorPaneExecutionAdapter
+
+        return CursorPaneExecutionAdapter()
+    if mode == "headless":
+        return build_headless_execution_adapter()
+    raise ValueError(f"unsupported CCB_CURSOR_EXECUTION_MODE: {mode}")
+
+
+def build_headless_execution_adapter() -> NativeCliSubprocessAdapter:
     return NativeCliSubprocessAdapter(
         NativeCliExecutionConfig(
             provider="cursor",
@@ -61,4 +73,4 @@ def _state_path(request: NativeCliExecutionRequest, key: str, *, fallback: str) 
     return state_dir / fallback
 
 
-__all__ = ["build_execution_adapter"]
+__all__ = ["build_execution_adapter", "build_headless_execution_adapter"]

--- a/lib/provider_backends/cursor/pane_execution.py
+++ b/lib/provider_backends/cursor/pane_execution.py
@@ -1,8 +1,409 @@
 from __future__ import annotations
 
+from dataclasses import replace
+from pathlib import Path
+
+from ccbd.api_models import JobRecord
+from completion.models import (
+    CompletionConfidence,
+    CompletionCursor,
+    CompletionDecision,
+    CompletionItemKind,
+    CompletionSourceKind,
+    CompletionStatus,
+)
+from provider_backends.native_cli_support.prompt import clean_native_reply, wrap_native_prompt
+from provider_core.protocol import request_anchor_for_job
+from provider_execution.active import ensure_active_pane_alive, prepare_active_start
+from provider_execution.base import ProviderPollResult, ProviderRuntimeContext, ProviderSubmission
+from provider_execution.common import (
+    build_item,
+    error_submission,
+    interrupt_and_clear_runtime_target,
+    no_wrap_requested,
+    send_prompt_to_runtime_target,
+)
+from terminal_runtime import get_backend_for_session
+
+from .session import load_project_session
+from .transcript import (
+    capture_cursor_transcript_offsets,
+    cursor_pane_turn_state,
+    cursor_record_text,
+    read_new_cursor_transcript_records,
+)
+
+
+_MODE = "cursor_pane"
+
 
 class CursorPaneExecutionAdapter:
     provider = "cursor"
+
+    def restore_diagnostics(self) -> dict[str, object]:
+        return {
+            "resume_supported": False,
+            "restore_mode": "resubmit_required",
+            "restore_reason": "provider_resume_unsupported",
+            "restore_detail": (
+                "Cursor jobs are bound to the managed visible pane and transcript; "
+                "interrupted in-flight jobs should be resubmitted"
+            ),
+        }
+
+    def start(
+        self,
+        job: JobRecord,
+        *,
+        context: ProviderRuntimeContext | None,
+        now: str,
+    ) -> ProviderSubmission:
+        prepared = prepare_active_start(
+            job,
+            context=context,
+            provider=self.provider,
+            source_kind=CompletionSourceKind.SESSION_EVENT_LOG,
+            now=now,
+            missing_session_reason="missing_cursor_session",
+            load_session_fn=_load_session,
+            backend_for_session_fn=get_backend_for_session,
+        )
+        if isinstance(prepared, ProviderSubmission):
+            return prepared
+
+        cursor_home = _cursor_home(prepared.session.data)
+        if cursor_home is None:
+            return error_submission(
+                job,
+                provider=self.provider,
+                now=now,
+                source_kind=CompletionSourceKind.SESSION_EVENT_LOG,
+                reason="runtime_unavailable",
+                error="cursor_home_missing",
+            )
+
+        request_anchor = request_anchor_for_job(job.job_id)
+        no_wrap = no_wrap_requested(getattr(job, "provider_options", None))
+        prompt = _pane_prompt(job.request.body or "", request_anchor=request_anchor, no_wrap=no_wrap)
+        session_started_mtime_ns = _session_started_mtime_ns(prepared.session)
+        turn_state = cursor_pane_turn_state(
+            cursor_home,
+            session_started_mtime_ns=session_started_mtime_ns,
+        )
+        offsets: dict[str, int] = {}
+        prompt_sent = False
+        if not turn_state.busy:
+            try:
+                offsets = capture_cursor_transcript_offsets(cursor_home)
+                send_prompt_to_runtime_target(prepared.backend, prepared.pane_id, prompt)
+                prompt_sent = True
+            except Exception as exc:
+                return error_submission(
+                    job,
+                    provider=self.provider,
+                    now=now,
+                    source_kind=CompletionSourceKind.SESSION_EVENT_LOG,
+                    reason="cursor_pane_send_failed",
+                    error=f"{type(exc).__name__}: {exc}",
+                )
+
+        reply_delivery = str(job.request.message_type or "").strip().lower() == "reply_delivery"
+        return ProviderSubmission(
+            job_id=job.job_id,
+            agent_name=job.agent_name,
+            provider=self.provider,
+            accepted_at=now,
+            ready_at=now,
+            source_kind=CompletionSourceKind.SESSION_EVENT_LOG,
+            reply="",
+            diagnostics={
+                "provider": self.provider,
+                "mode": _MODE,
+                "workspace_path": str(prepared.work_dir),
+                "pane_id": prepared.pane_id,
+                "prompt_deferred_until_ready": not prompt_sent,
+            },
+            runtime_state={
+                "mode": _MODE,
+                "backend": prepared.backend,
+                "pane_id": prepared.pane_id,
+                "request_anchor": request_anchor,
+                "cursor_home": str(cursor_home),
+                "session_started_mtime_ns": session_started_mtime_ns,
+                "transcript_offsets": offsets,
+                "matched_transcript_path": "",
+                "provider_session_id": "",
+                "reply_buffer": "",
+                "next_seq": 1,
+                "anchor_seen": no_wrap,
+                "no_wrap": no_wrap,
+                "accepted_at": now,
+                "started_at": now if prompt_sent else "",
+                "prompt_sent": prompt_sent,
+                "pending_prompt": prompt,
+                "reply_delivery_complete_on_dispatch": reply_delivery,
+            },
+        )
+
+    def poll(self, submission: ProviderSubmission, *, now: str) -> ProviderPollResult | None:
+        if str(submission.runtime_state.get("mode") or "") != _MODE:
+            return None
+        state = dict(submission.runtime_state)
+        backend = state.get("backend")
+        pane_id = str(state.get("pane_id") or "")
+        if backend is None or not pane_id:
+            return _runtime_error(submission, state, now=now, reason="runtime_state_corrupt")
+        pane_dead = ensure_active_pane_alive(submission, backend=backend, pane_id=pane_id, now=now)
+        if pane_dead is not None:
+            return pane_dead
+
+        if not bool(state.get("prompt_sent")):
+            return None
+        if bool(state.get("reply_delivery_complete_on_dispatch")):
+            return _reply_delivery_result(submission, state, now=now)
+
+        cursor_home = Path(str(state.get("cursor_home") or ""))
+        records, offsets = read_new_cursor_transcript_records(
+            cursor_home,
+            dict(state.get("transcript_offsets") or {}),
+        )
+        state["transcript_offsets"] = offsets
+        items = []
+        matched_path = str(state.get("matched_transcript_path") or "")
+        request_anchor = str(state.get("request_anchor") or submission.job_id)
+        terminal_status = ""
+
+        for record_path, record in records:
+            role = str(record.get("role") or "").strip().lower()
+            if not matched_path:
+                if role != "user" or request_anchor not in cursor_record_text(record):
+                    continue
+                matched_path = record_path
+                state["matched_transcript_path"] = matched_path
+                state["provider_session_id"] = Path(matched_path).parent.name
+                if not bool(state.get("anchor_seen")):
+                    items.append(
+                        build_item(
+                            submission,
+                            kind=CompletionItemKind.ANCHOR_SEEN,
+                            timestamp=now,
+                            seq=_next_seq(state),
+                            payload={
+                                "turn_id": request_anchor,
+                                "source": "cursor_visible_session_user_message",
+                                "provider_session_id": str(state.get("provider_session_id") or ""),
+                            },
+                        )
+                    )
+                    state["anchor_seen"] = True
+                continue
+            if record_path != matched_path:
+                continue
+            if role == "assistant":
+                text = cursor_record_text(record)
+                if text:
+                    state["reply_buffer"] = str(state.get("reply_buffer") or "") + text
+                continue
+            if str(record.get("type") or "").strip().lower() == "turn_ended":
+                terminal_status = str(record.get("status") or "").strip().lower() or "unknown"
+                break
+
+        reply = clean_native_reply(
+            str(state.get("reply_buffer") or ""),
+            request_anchor,
+        )
+        if reply and reply != submission.reply:
+            items.append(
+                build_item(
+                    submission,
+                    kind=CompletionItemKind.ASSISTANT_FINAL,
+                    timestamp=now,
+                    seq=_next_seq(state),
+                    payload={
+                        "text": reply,
+                        "reply": reply,
+                        "final_answer": reply,
+                        "turn_id": request_anchor,
+                        "provider_turn_ref": str(state.get("provider_session_id") or ""),
+                        "finish_reason": terminal_status,
+                    },
+                )
+            )
+
+        updated = replace(submission, reply=reply, runtime_state=state)
+        if terminal_status:
+            items.append(
+                build_item(
+                    updated,
+                    kind=CompletionItemKind.TURN_BOUNDARY,
+                    timestamp=now,
+                    seq=_next_seq(state),
+                    payload={
+                        "turn_id": request_anchor,
+                        "provider_turn_ref": str(state.get("provider_session_id") or ""),
+                        "finish_reason": terminal_status,
+                        "reason": (
+                            "cursor_run_stop"
+                            if terminal_status == "success"
+                            else f"cursor_run_finished:{terminal_status}"
+                        ),
+                    },
+                )
+            )
+            updated = replace(updated, runtime_state=state)
+            return ProviderPollResult(
+                submission=updated,
+                items=tuple(items),
+                decision=_terminal_decision(
+                    updated,
+                    state,
+                    reply=reply,
+                    terminal_status=terminal_status,
+                    now=now,
+                ),
+            )
+
+        if items or updated != submission:
+            return ProviderPollResult(submission=updated, items=tuple(items), decision=None)
+        return None
+
+    def cancel(self, submission: ProviderSubmission) -> None:
+        if not bool(submission.runtime_state.get("prompt_sent")):
+            return
+        backend = submission.runtime_state.get("backend")
+        pane_id = str(submission.runtime_state.get("pane_id") or "")
+        if backend is not None and pane_id:
+            interrupt_and_clear_runtime_target(backend, pane_id)
+
+
+def _load_session(work_dir: Path, *, agent_name: str):
+    return load_project_session(work_dir, instance=agent_name)
+
+
+def _cursor_home(session_data: dict) -> Path | None:
+    raw = str(session_data.get("cursor_home") or "").strip()
+    return Path(raw).expanduser() if raw else None
+
+
+def _session_started_mtime_ns(session: object) -> int:
+    session_file = getattr(session, "session_file", None)
+    if session_file is None:
+        return 0
+    try:
+        return Path(session_file).stat().st_mtime_ns
+    except OSError:
+        return 0
+
+
+def _pane_prompt(body: str, *, request_anchor: str, no_wrap: bool) -> str:
+    if no_wrap:
+        return body
+    return wrap_native_prompt(body, request_anchor)
+
+
+def _reply_delivery_result(
+    submission: ProviderSubmission,
+    state: dict[str, object],
+    *,
+    now: str,
+) -> ProviderPollResult:
+    decision = CompletionDecision(
+        terminal=True,
+        status=CompletionStatus.COMPLETED,
+        reason="reply_delivery_sent",
+        confidence=CompletionConfidence.OBSERVED,
+        reply="",
+        anchor_seen=True,
+        reply_started=False,
+        reply_stable=True,
+        provider_turn_ref=str(state.get("pane_id") or submission.job_id),
+        source_cursor=None,
+        finished_at=now,
+        diagnostics={
+            "reply_delivery": True,
+            "delivery_status": "sent",
+            "submission_mode": _MODE,
+            "provider": submission.provider,
+        },
+    )
+    return ProviderPollResult(submission=submission, decision=decision)
+
+
+def _terminal_decision(
+    submission: ProviderSubmission,
+    state: dict[str, object],
+    *,
+    reply: str,
+    terminal_status: str,
+    now: str,
+) -> CompletionDecision:
+    if terminal_status == "success" and reply:
+        status = CompletionStatus.COMPLETED
+        reason = "cursor_run_stop"
+        confidence = CompletionConfidence.OBSERVED
+    elif terminal_status == "success":
+        status = CompletionStatus.INCOMPLETE
+        reason = "cursor_empty_reply"
+        confidence = CompletionConfidence.DEGRADED
+    else:
+        status = CompletionStatus.INCOMPLETE
+        reason = f"cursor_run_finished:{terminal_status or 'unknown'}"
+        confidence = CompletionConfidence.DEGRADED
+    return CompletionDecision(
+        terminal=True,
+        status=status,
+        reason=reason,
+        confidence=confidence,
+        reply=reply,
+        anchor_seen=bool(state.get("anchor_seen")),
+        reply_started=bool(reply),
+        reply_stable=True,
+        provider_turn_ref=str(state.get("provider_session_id") or submission.job_id),
+        source_cursor=CompletionCursor(
+            source_kind=CompletionSourceKind.SESSION_EVENT_LOG,
+            event_seq=max(0, int(state.get("next_seq") or 1) - 1),
+            updated_at=now,
+        ),
+        finished_at=now,
+        diagnostics={
+            "mode": _MODE,
+            "finish_reason": terminal_status,
+            "transcript_path": str(state.get("matched_transcript_path") or ""),
+            "provider_session_id": str(state.get("provider_session_id") or ""),
+        },
+    )
+
+
+def _runtime_error(
+    submission: ProviderSubmission,
+    state: dict[str, object],
+    *,
+    now: str,
+    reason: str,
+) -> ProviderPollResult:
+    return ProviderPollResult(
+        submission=replace(submission, runtime_state=state),
+        decision=CompletionDecision(
+            terminal=True,
+            status=CompletionStatus.INCOMPLETE,
+            reason=reason,
+            confidence=CompletionConfidence.DEGRADED,
+            reply=submission.reply,
+            anchor_seen=bool(state.get("anchor_seen")),
+            reply_started=bool(submission.reply),
+            reply_stable=False,
+            provider_turn_ref=submission.job_id,
+            source_cursor=None,
+            finished_at=now,
+            diagnostics={"mode": _MODE},
+        ),
+    )
+
+
+def _next_seq(state: dict[str, object]) -> int:
+    seq = max(1, int(state.get("next_seq") or 1))
+    state["next_seq"] = seq + 1
+    return seq
 
 
 __all__ = ["CursorPaneExecutionAdapter"]

--- a/lib/provider_backends/cursor/pane_execution.py
+++ b/lib/provider_backends/cursor/pane_execution.py
@@ -95,9 +95,10 @@ class CursorPaneExecutionAdapter:
             cursor_home,
             session_started_mtime_ns=session_started_mtime_ns,
         )
+        pane_busy = _cursor_pane_busy(prepared.backend, prepared.pane_id)
         offsets: dict[str, int] = {}
         prompt_sent = False
-        if not turn_state.busy:
+        if not turn_state.busy and not pane_busy:
             try:
                 offsets = capture_cursor_transcript_offsets(cursor_home)
                 send_prompt_to_runtime_target(prepared.backend, prepared.pane_id, prompt)
@@ -147,6 +148,7 @@ class CursorPaneExecutionAdapter:
                 "ready_timeout_s": _effective_ready_timeout_s(),
                 "run_timeout_s": _effective_run_timeout_s(),
                 "prompt_sent": prompt_sent,
+                "pane_busy": pane_busy,
                 "pending_prompt": prompt,
                 "reply_delivery_complete_on_dispatch": reply_delivery,
             },
@@ -170,12 +172,14 @@ class CursorPaneExecutionAdapter:
                 cursor_home,
                 session_started_mtime_ns=max(0, int(state.get("session_started_mtime_ns") or 0)),
             )
+            pane_busy = _cursor_pane_busy(backend, pane_id)
             accepted_at = str(state.get("accepted_at") or submission.accepted_at or "")
             ready_timeout_s = float(state.get("ready_timeout_s") or _DEFAULT_READY_TIMEOUT_S)
             ready_wait_s = _elapsed_seconds(accepted_at, now)
             state["ready_wait_s"] = ready_wait_s
             state["busy_transcript_path"] = turn_state.transcript_path
-            if turn_state.busy:
+            state["pane_busy"] = pane_busy
+            if turn_state.busy or pane_busy:
                 if ready_wait_s >= ready_timeout_s:
                     updated = replace(submission, runtime_state=state)
                     return ProviderPollResult(
@@ -364,6 +368,27 @@ def _pane_prompt(body: str, *, request_anchor: str, no_wrap: bool) -> str:
     if no_wrap:
         return body
     return wrap_native_prompt(body, request_anchor)
+
+
+def _cursor_pane_busy(backend: object, pane_id: str) -> bool:
+    get_content = getattr(backend, "get_pane_content", None)
+    if not callable(get_content):
+        return False
+    try:
+        content = str(get_content(pane_id, lines=120) or "")
+    except Exception:
+        return False
+    normalized = content.lower()
+    return any(
+        marker in normalized
+        for marker in (
+            "ctrl+c to stop",
+            " working",
+            "┌─ follow-ups",
+            "do you trust the contents of this directory?",
+            "trusting workspace...",
+        )
+    )
 
 
 def _reply_delivery_result(

--- a/lib/provider_backends/cursor/pane_execution.py
+++ b/lib/provider_backends/cursor/pane_execution.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+
+class CursorPaneExecutionAdapter:
+    provider = "cursor"
+
+
+__all__ = ["CursorPaneExecutionAdapter"]

--- a/lib/provider_backends/cursor/pane_execution.py
+++ b/lib/provider_backends/cursor/pane_execution.py
@@ -38,6 +38,7 @@ from .transcript import (
 
 
 _MODE = "cursor_pane"
+_IDLE_CONFIRM_S = 2.0
 _DEFAULT_READY_TIMEOUT_S = 300.0
 _DEFAULT_RUN_TIMEOUT_S = 900.0
 
@@ -145,6 +146,7 @@ class CursorPaneExecutionAdapter:
                 "no_wrap": no_wrap,
                 "accepted_at": now,
                 "started_at": now if prompt_sent else "",
+                "idle_observed_at": "",
                 "ready_timeout_s": _effective_ready_timeout_s(),
                 "run_timeout_s": _effective_run_timeout_s(),
                 "prompt_sent": prompt_sent,
@@ -180,6 +182,7 @@ class CursorPaneExecutionAdapter:
             state["busy_transcript_path"] = turn_state.transcript_path
             state["pane_busy"] = pane_busy
             if turn_state.busy or pane_busy:
+                state["idle_observed_at"] = ""
                 if ready_wait_s >= ready_timeout_s:
                     updated = replace(submission, runtime_state=state)
                     return ProviderPollResult(
@@ -192,6 +195,21 @@ class CursorPaneExecutionAdapter:
                             timeout_s=ready_timeout_s,
                         ),
                     )
+                return ProviderPollResult(
+                    submission=replace(submission, runtime_state=state),
+                    items=(),
+                    decision=None,
+                )
+
+            idle_observed_at = str(state.get("idle_observed_at") or "")
+            if not idle_observed_at:
+                state["idle_observed_at"] = now
+                return ProviderPollResult(
+                    submission=replace(submission, runtime_state=state),
+                    items=(),
+                    decision=None,
+                )
+            if _elapsed_seconds(idle_observed_at, now) < _IDLE_CONFIRM_S:
                 return ProviderPollResult(
                     submission=replace(submission, runtime_state=state),
                     items=(),

--- a/lib/provider_backends/cursor/pane_execution.py
+++ b/lib/provider_backends/cursor/pane_execution.py
@@ -439,7 +439,7 @@ def _cursor_pane_status(backend: object, pane_id: str) -> str:
         content = str(get_content(pane_id, lines=120) or "")
     except Exception:
         return "idle"
-    normalized = content.lower()
+    normalized = "\n".join(content.splitlines()[-12:]).lower()
     if any(
         marker in normalized
         for marker in ("ctrl+c to stop", " working", "┌─ follow-ups")

--- a/lib/provider_backends/cursor/pane_execution.py
+++ b/lib/provider_backends/cursor/pane_execution.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import replace
+from datetime import datetime
+import math
+import os
 from pathlib import Path
 
 from ccbd.api_models import JobRecord
@@ -35,6 +38,8 @@ from .transcript import (
 
 
 _MODE = "cursor_pane"
+_DEFAULT_READY_TIMEOUT_S = 300.0
+_DEFAULT_RUN_TIMEOUT_S = 900.0
 
 
 class CursorPaneExecutionAdapter:
@@ -139,6 +144,8 @@ class CursorPaneExecutionAdapter:
                 "no_wrap": no_wrap,
                 "accepted_at": now,
                 "started_at": now if prompt_sent else "",
+                "ready_timeout_s": _effective_ready_timeout_s(),
+                "run_timeout_s": _effective_run_timeout_s(),
                 "prompt_sent": prompt_sent,
                 "pending_prompt": prompt,
                 "reply_delivery_complete_on_dispatch": reply_delivery,
@@ -158,7 +165,51 @@ class CursorPaneExecutionAdapter:
             return pane_dead
 
         if not bool(state.get("prompt_sent")):
-            return None
+            cursor_home = Path(str(state.get("cursor_home") or ""))
+            turn_state = cursor_pane_turn_state(
+                cursor_home,
+                session_started_mtime_ns=max(0, int(state.get("session_started_mtime_ns") or 0)),
+            )
+            accepted_at = str(state.get("accepted_at") or submission.accepted_at or "")
+            ready_timeout_s = float(state.get("ready_timeout_s") or _DEFAULT_READY_TIMEOUT_S)
+            ready_wait_s = _elapsed_seconds(accepted_at, now)
+            state["ready_wait_s"] = ready_wait_s
+            state["busy_transcript_path"] = turn_state.transcript_path
+            if turn_state.busy:
+                if ready_wait_s >= ready_timeout_s:
+                    updated = replace(submission, runtime_state=state)
+                    return ProviderPollResult(
+                        submission=updated,
+                        decision=_timeout_decision(
+                            updated,
+                            state,
+                            now=now,
+                            reason="cursor_input_not_ready",
+                            timeout_s=ready_timeout_s,
+                        ),
+                    )
+                return ProviderPollResult(
+                    submission=replace(submission, runtime_state=state),
+                    items=(),
+                    decision=None,
+                )
+
+            pending_prompt = str(state.get("pending_prompt") or "")
+            if not pending_prompt:
+                return _runtime_error(submission, state, now=now, reason="runtime_state_corrupt")
+            try:
+                state["transcript_offsets"] = capture_cursor_transcript_offsets(cursor_home)
+                send_prompt_to_runtime_target(backend, pane_id, pending_prompt)
+            except Exception:
+                return _runtime_error(submission, state, now=now, reason="cursor_pane_send_failed")
+            state["prompt_sent"] = True
+            state["prompt_sent_at"] = now
+            state["started_at"] = now
+            state["prompt_deferred_until_ready"] = False
+            updated = replace(submission, runtime_state=state)
+            if bool(state.get("reply_delivery_complete_on_dispatch")):
+                return _reply_delivery_result(updated, state, now=now)
+            return ProviderPollResult(submission=updated, items=(), decision=None)
         if bool(state.get("reply_delivery_complete_on_dispatch")):
             return _reply_delivery_result(submission, state, now=now)
 
@@ -260,6 +311,20 @@ class CursorPaneExecutionAdapter:
                     reply=reply,
                     terminal_status=terminal_status,
                     now=now,
+                ),
+            )
+
+        run_timeout_s = float(state.get("run_timeout_s") or _DEFAULT_RUN_TIMEOUT_S)
+        if _timeout_elapsed(str(state.get("started_at") or ""), now, run_timeout_s):
+            return ProviderPollResult(
+                submission=updated,
+                items=tuple(items),
+                decision=_timeout_decision(
+                    updated,
+                    state,
+                    now=now,
+                    reason="cursor_run_timeout",
+                    timeout_s=run_timeout_s,
                 ),
             )
 
@@ -398,6 +463,69 @@ def _runtime_error(
             diagnostics={"mode": _MODE},
         ),
     )
+
+
+def _timeout_decision(
+    submission: ProviderSubmission,
+    state: dict[str, object],
+    *,
+    now: str,
+    reason: str,
+    timeout_s: float,
+) -> CompletionDecision:
+    return CompletionDecision(
+        terminal=True,
+        status=CompletionStatus.INCOMPLETE,
+        reason=reason,
+        confidence=CompletionConfidence.DEGRADED,
+        reply=submission.reply,
+        anchor_seen=bool(state.get("anchor_seen")),
+        reply_started=bool(submission.reply),
+        reply_stable=False,
+        provider_turn_ref=str(state.get("provider_session_id") or submission.job_id),
+        source_cursor=None,
+        finished_at=now,
+        diagnostics={
+            "mode": _MODE,
+            "timeout_s": timeout_s,
+            "prompt_sent": bool(state.get("prompt_sent")),
+            "transcript_path": str(state.get("matched_transcript_path") or ""),
+        },
+    )
+
+
+def _effective_ready_timeout_s() -> float:
+    return _positive_finite_env("CCB_CURSOR_READY_TIMEOUT_S", _DEFAULT_READY_TIMEOUT_S)
+
+
+def _effective_run_timeout_s() -> float:
+    return _positive_finite_env("CCB_CURSOR_RUN_TIMEOUT_S", _DEFAULT_RUN_TIMEOUT_S)
+
+
+def _positive_finite_env(name: str, default: float) -> float:
+    raw = str(os.environ.get(name) or "").strip()
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    return value if value > 0.0 and math.isfinite(value) else default
+
+
+def _elapsed_seconds(started_at: str, now: str) -> float:
+    if not started_at or not now:
+        return 0.0
+    try:
+        started = datetime.fromisoformat(started_at.replace("Z", "+00:00"))
+        current = datetime.fromisoformat(now.replace("Z", "+00:00"))
+    except ValueError:
+        return 0.0
+    return max(0.0, (current - started).total_seconds())
+
+
+def _timeout_elapsed(started_at: str, now: str, timeout_s: float) -> bool:
+    return timeout_s > 0.0 and _elapsed_seconds(started_at, now) >= timeout_s
 
 
 def _next_seq(state: dict[str, object]) -> int:

--- a/lib/provider_backends/cursor/pane_execution.py
+++ b/lib/provider_backends/cursor/pane_execution.py
@@ -96,12 +96,14 @@ class CursorPaneExecutionAdapter:
             cursor_home,
             session_started_mtime_ns=session_started_mtime_ns,
         )
-        pane_busy = _cursor_pane_busy(prepared.backend, prepared.pane_id)
+        pane_status = _cursor_pane_status(prepared.backend, prepared.pane_id)
+        pane_busy = pane_status != "idle"
+        readiness_offsets = capture_cursor_transcript_offsets(cursor_home)
         offsets: dict[str, int] = {}
         prompt_sent = False
         if not turn_state.busy and not pane_busy:
             try:
-                offsets = capture_cursor_transcript_offsets(cursor_home)
+                offsets = readiness_offsets
                 send_prompt_to_runtime_target(prepared.backend, prepared.pane_id, prompt)
                 prompt_sent = True
             except Exception as exc:
@@ -138,6 +140,7 @@ class CursorPaneExecutionAdapter:
                 "cursor_home": str(cursor_home),
                 "session_started_mtime_ns": session_started_mtime_ns,
                 "transcript_offsets": offsets,
+                "readiness_transcript_offsets": readiness_offsets,
                 "matched_transcript_path": "",
                 "provider_session_id": "",
                 "reply_buffer": "",
@@ -151,6 +154,11 @@ class CursorPaneExecutionAdapter:
                 "run_timeout_s": _effective_run_timeout_s(),
                 "prompt_sent": prompt_sent,
                 "pane_busy": pane_busy,
+                "pane_status": pane_status,
+                "deferred_requires_terminal": (
+                    not prompt_sent and (turn_state.busy or pane_status == "active")
+                ),
+                "deferred_terminal_seen": False,
                 "pending_prompt": prompt,
                 "reply_delivery_complete_on_dispatch": reply_delivery,
             },
@@ -170,18 +178,33 @@ class CursorPaneExecutionAdapter:
 
         if not bool(state.get("prompt_sent")):
             cursor_home = Path(str(state.get("cursor_home") or ""))
+            readiness_records, readiness_offsets = read_new_cursor_transcript_records(
+                cursor_home,
+                dict(state.get("readiness_transcript_offsets") or {}),
+            )
+            state["readiness_transcript_offsets"] = readiness_offsets
+            if any(
+                str(record.get("type") or "").strip().lower() == "turn_ended"
+                for _, record in readiness_records
+            ):
+                state["deferred_terminal_seen"] = True
             turn_state = cursor_pane_turn_state(
                 cursor_home,
                 session_started_mtime_ns=max(0, int(state.get("session_started_mtime_ns") or 0)),
             )
-            pane_busy = _cursor_pane_busy(backend, pane_id)
+            pane_status = _cursor_pane_status(backend, pane_id)
+            pane_busy = pane_status != "idle"
+            terminal_required = bool(state.get("deferred_requires_terminal"))
+            terminal_seen = bool(state.get("deferred_terminal_seen"))
             accepted_at = str(state.get("accepted_at") or submission.accepted_at or "")
             ready_timeout_s = float(state.get("ready_timeout_s") or _DEFAULT_READY_TIMEOUT_S)
             ready_wait_s = _elapsed_seconds(accepted_at, now)
             state["ready_wait_s"] = ready_wait_s
             state["busy_transcript_path"] = turn_state.transcript_path
             state["pane_busy"] = pane_busy
-            if turn_state.busy or pane_busy:
+            state["pane_status"] = pane_status
+            state["waiting_for_deferred_terminal"] = terminal_required and not terminal_seen
+            if turn_state.busy or pane_busy or (terminal_required and not terminal_seen):
                 state["idle_observed_at"] = ""
                 if ready_wait_s >= ready_timeout_s:
                     updated = replace(submission, runtime_state=state)
@@ -388,25 +411,33 @@ def _pane_prompt(body: str, *, request_anchor: str, no_wrap: bool) -> str:
     return wrap_native_prompt(body, request_anchor)
 
 
-def _cursor_pane_busy(backend: object, pane_id: str) -> bool:
+def _cursor_pane_status(backend: object, pane_id: str) -> str:
     get_content = getattr(backend, "get_pane_content", None)
     if not callable(get_content):
-        return False
+        return "idle"
     try:
         content = str(get_content(pane_id, lines=120) or "")
     except Exception:
-        return False
+        return "idle"
     normalized = content.lower()
-    return any(
+    if any(
+        marker in normalized
+        for marker in ("ctrl+c to stop", " working", "┌─ follow-ups")
+    ):
+        return "active"
+    if any(
         marker in normalized
         for marker in (
-            "ctrl+c to stop",
-            " working",
-            "┌─ follow-ups",
             "do you trust the contents of this directory?",
             "trusting workspace...",
         )
-    )
+    ):
+        return "blocked"
+    return "idle"
+
+
+def _cursor_pane_busy(backend: object, pane_id: str) -> bool:
+    return _cursor_pane_status(backend, pane_id) != "idle"
 
 
 def _reply_delivery_result(

--- a/lib/provider_backends/cursor/pane_execution.py
+++ b/lib/provider_backends/cursor/pane_execution.py
@@ -99,6 +99,17 @@ class CursorPaneExecutionAdapter:
         pane_status = _cursor_pane_status(prepared.backend, prepared.pane_id)
         pane_busy = pane_status != "idle"
         readiness_offsets = capture_cursor_transcript_offsets(cursor_home)
+        existing_records, _ = read_new_cursor_transcript_records(cursor_home, {})
+        excluded_anchor_paths = tuple(
+            sorted(
+                {
+                    record_path
+                    for record_path, record in existing_records
+                    if str(record.get("role") or "").strip().lower() == "user"
+                    and request_anchor in cursor_record_text(record)
+                }
+            )
+        )
         offsets: dict[str, int] = {}
         prompt_sent = False
         if not turn_state.busy and not pane_busy:
@@ -142,6 +153,7 @@ class CursorPaneExecutionAdapter:
                 "transcript_offsets": offsets,
                 "readiness_transcript_offsets": readiness_offsets,
                 "matched_transcript_path": "",
+                "excluded_anchor_paths": excluded_anchor_paths,
                 "provider_session_id": "",
                 "reply_buffer": "",
                 "next_seq": 1,
@@ -259,23 +271,31 @@ class CursorPaneExecutionAdapter:
             return _reply_delivery_result(submission, state, now=now)
 
         cursor_home = Path(str(state.get("cursor_home") or ""))
+        matched_path = str(state.get("matched_transcript_path") or "")
+        scan_from_start = not matched_path
         records, offsets = read_new_cursor_transcript_records(
             cursor_home,
-            dict(state.get("transcript_offsets") or {}),
+            {} if scan_from_start else dict(state.get("transcript_offsets") or {}),
         )
-        state["transcript_offsets"] = offsets
+        if not scan_from_start:
+            state["transcript_offsets"] = offsets
         items = []
-        matched_path = str(state.get("matched_transcript_path") or "")
         request_anchor = str(state.get("request_anchor") or submission.job_id)
         terminal_status = ""
+        excluded_anchor_paths = {
+            str(path) for path in (state.get("excluded_anchor_paths") or ())
+        }
 
         for record_path, record in records:
             role = str(record.get("role") or "").strip().lower()
             if not matched_path:
+                if record_path in excluded_anchor_paths:
+                    continue
                 if role != "user" or request_anchor not in cursor_record_text(record):
                     continue
                 matched_path = record_path
                 state["matched_transcript_path"] = matched_path
+                state["transcript_offsets"] = offsets
                 state["provider_session_id"] = Path(matched_path).parent.name
                 if not bool(state.get("anchor_seen")):
                     items.append(

--- a/lib/provider_backends/cursor/transcript.py
+++ b/lib/provider_backends/cursor/transcript.py
@@ -1,7 +1,15 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 import json
 from pathlib import Path
+
+
+@dataclass(frozen=True)
+class CursorPaneTurnState:
+    busy: bool
+    transcript_path: str = ""
+    terminal_status: str = ""
 
 
 def cursor_transcript_root(cursor_home: Path) -> Path:
@@ -55,6 +63,42 @@ def read_new_cursor_transcript_records(
     return records, next_offsets
 
 
+def cursor_pane_turn_state(
+    cursor_home: Path,
+    *,
+    session_started_mtime_ns: int,
+) -> CursorPaneTurnState:
+    eligible: list[Path] = []
+    for path in iter_top_level_cursor_transcripts(cursor_home):
+        try:
+            if path.stat().st_mtime_ns < max(0, int(session_started_mtime_ns)):
+                continue
+        except OSError:
+            continue
+        eligible.append(path)
+    if not eligible:
+        return CursorPaneTurnState(busy=False)
+
+    path = eligible[-1]
+    records = _read_complete_records(path)
+    last_user = -1
+    last_terminal = -1
+    terminal_status = ""
+    for index, record in enumerate(records):
+        if str(record.get("role") or "").strip().lower() == "user":
+            last_user = index
+        if str(record.get("type") or "").strip().lower() == "turn_ended":
+            last_terminal = index
+            terminal_status = str(record.get("status") or "").strip().lower()
+
+    busy = last_user >= 0 and last_user > last_terminal
+    return CursorPaneTurnState(
+        busy=busy,
+        transcript_path=str(path),
+        terminal_status="" if busy else terminal_status,
+    )
+
+
 def cursor_record_text(record: dict) -> str:
     message = record.get("message")
     if not isinstance(message, dict):
@@ -75,6 +119,25 @@ def _content_text(value: object) -> str:
     return str(text) if isinstance(text, str) else ""
 
 
+def _read_complete_records(path: Path) -> list[dict]:
+    try:
+        chunk = path.read_bytes()
+    except OSError:
+        return []
+    complete_end = chunk.rfind(b"\n") + 1
+    if complete_end <= 0:
+        return []
+    records: list[dict] = []
+    for raw_line in chunk[:complete_end].splitlines():
+        try:
+            payload = json.loads(raw_line.decode("utf-8", errors="strict"))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+        if isinstance(payload, dict):
+            records.append(payload)
+    return records
+
+
 def _path_order(path: Path) -> tuple[int, str]:
     try:
         mtime_ns = path.stat().st_mtime_ns
@@ -84,7 +147,9 @@ def _path_order(path: Path) -> tuple[int, str]:
 
 
 __all__ = [
+    "CursorPaneTurnState",
     "capture_cursor_transcript_offsets",
+    "cursor_pane_turn_state",
     "cursor_record_text",
     "cursor_transcript_root",
     "iter_top_level_cursor_transcripts",

--- a/lib/provider_backends/cursor/transcript.py
+++ b/lib/provider_backends/cursor/transcript.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def cursor_transcript_root(cursor_home: Path) -> Path:
+    return Path(cursor_home).expanduser() / ".cursor" / "projects"
+
+
+def iter_top_level_cursor_transcripts(cursor_home: Path) -> tuple[Path, ...]:
+    root = cursor_transcript_root(cursor_home)
+    if not root.is_dir():
+        return ()
+    paths = root.glob("*/agent-transcripts/*/*.jsonl")
+    return tuple(sorted((path for path in paths if path.is_file()), key=_path_order))
+
+
+def capture_cursor_transcript_offsets(cursor_home: Path) -> dict[str, int]:
+    offsets: dict[str, int] = {}
+    for path in iter_top_level_cursor_transcripts(cursor_home):
+        try:
+            offsets[str(path)] = path.stat().st_size
+        except OSError:
+            continue
+    return offsets
+
+
+def read_new_cursor_transcript_records(
+    cursor_home: Path,
+    offsets: dict[str, int],
+) -> tuple[list[tuple[str, dict]], dict[str, int]]:
+    next_offsets = dict(offsets)
+    records: list[tuple[str, dict]] = []
+    for path in iter_top_level_cursor_transcripts(cursor_home):
+        key = str(path)
+        offset = max(0, int(next_offsets.get(key, 0)))
+        try:
+            with path.open("rb") as handle:
+                handle.seek(offset)
+                chunk = handle.read()
+        except OSError:
+            continue
+        complete_end = chunk.rfind(b"\n") + 1
+        if complete_end <= 0:
+            continue
+        next_offsets[key] = offset + complete_end
+        for raw_line in chunk[:complete_end].splitlines():
+            try:
+                payload = json.loads(raw_line.decode("utf-8", errors="strict"))
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                continue
+            if isinstance(payload, dict):
+                records.append((key, payload))
+    return records, next_offsets
+
+
+def cursor_record_text(record: dict) -> str:
+    message = record.get("message")
+    if not isinstance(message, dict):
+        return ""
+    return _content_text(message.get("content"))
+
+
+def _content_text(value: object) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        return "".join(_content_text(item) for item in value)
+    if not isinstance(value, dict):
+        return ""
+    if str(value.get("type") or "").strip().lower() not in ("", "text"):
+        return ""
+    text = value.get("text")
+    return str(text) if isinstance(text, str) else ""
+
+
+def _path_order(path: Path) -> tuple[int, str]:
+    try:
+        mtime_ns = path.stat().st_mtime_ns
+    except OSError:
+        mtime_ns = 0
+    return mtime_ns, str(path)
+
+
+__all__ = [
+    "capture_cursor_transcript_offsets",
+    "cursor_record_text",
+    "cursor_transcript_root",
+    "iter_top_level_cursor_transcripts",
+    "read_new_cursor_transcript_records",
+]

--- a/test/test_cursor_provider.py
+++ b/test/test_cursor_provider.py
@@ -218,6 +218,39 @@ def test_cursor_pane_adapter_assistant_text_does_not_complete_without_turn_ended
     assert finished.decision.reply == "still running"
 
 
+def test_cursor_pane_adapter_finds_anchor_when_cursor_replaces_previous_terminal_record(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    home, backend, _ = _bind_cursor(monkeypatch, tmp_path)
+    transcript = _cursor_transcript(home)
+    manual_records = [
+        {"role": "user", "message": {"content": [{"type": "text", "text": "manual"}]}},
+        {"role": "assistant", "message": {"content": [{"type": "text", "text": "manual reply"}]}},
+        {"type": "turn_ended", "status": "success"},
+    ]
+    _append_cursor_records(transcript, *manual_records)
+    adapter = CursorPaneExecutionAdapter()
+    submission = adapter.start(_pane_job(), context=_pane_context(tmp_path), now="2026-08-11T00:00:00Z")
+
+    transcript.write_text(
+        "".join(json.dumps(record, ensure_ascii=True) + "\n" for record in manual_records[:-1]),
+        encoding="utf-8",
+    )
+    _append_cursor_records(
+        transcript,
+        {"role": "user", "message": {"content": [{"type": "text", "text": backend.sent[0][1]}]}},
+        {"role": "assistant", "message": {"content": [{"type": "text", "text": "rewritten reply"}]}},
+        {"type": "turn_ended", "status": "success"},
+    )
+
+    result = adapter.poll(submission, now="2026-08-11T00:00:03Z")
+
+    assert result is not None and result.decision is not None
+    assert result.decision.status is CompletionStatus.COMPLETED
+    assert result.decision.reply == "rewritten reply"
+
+
 def test_cursor_pane_adapter_error_turn_fails_closed(monkeypatch, tmp_path: Path) -> None:
     home, backend, _ = _bind_cursor(monkeypatch, tmp_path)
     adapter = CursorPaneExecutionAdapter()

--- a/test/test_cursor_provider.py
+++ b/test/test_cursor_provider.py
@@ -1,7 +1,15 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from completion.models import CompletionItemKind, CompletionSourceKind, CompletionStatus
 from provider_backends.cursor import execution
+from provider_backends.cursor import pane_execution
+from provider_backends.cursor.pane_execution import CursorPaneExecutionAdapter
 from provider_backends.native_cli_support import NativeCliSubprocessAdapter
+from provider_execution.base import ProviderRuntimeContext
 
 
 def test_cursor_execution_adapter_defaults_to_visible_pane(monkeypatch) -> None:
@@ -37,3 +45,215 @@ def test_cursor_headless_command_and_env_builders_remain_available() -> None:
     assert callable(execution.build_headless_execution_adapter)
     assert callable(execution._build_command)
     assert callable(execution._build_env)
+
+
+class _FakeCursorSession:
+    def __init__(self, home: Path, session_file: Path) -> None:
+        self.data = {"cursor_home": str(home)}
+        self.session_file = session_file
+        self.session_file.parent.mkdir(parents=True, exist_ok=True)
+        self.session_file.write_text("{}", encoding="utf-8")
+
+    def ensure_pane(self) -> tuple[bool, str]:
+        return True, "%9"
+
+
+class _FakeCursorBackend:
+    def __init__(self) -> None:
+        self.sent: list[tuple[str, str]] = []
+        self.keys: list[tuple[str, str]] = []
+        self.alive = True
+
+    def send_text_to_pane(self, pane_id: str, text: str) -> None:
+        self.sent.append((pane_id, text))
+
+    def is_tmux_pane_alive(self, pane_id: str) -> bool:
+        return self.alive and pane_id == "%9"
+
+    def send_key(self, pane_id: str, key: str) -> None:
+        self.keys.append((pane_id, key))
+
+
+def _pane_job(*, message_type: str = "ask", no_wrap: bool = False):
+    return SimpleNamespace(
+        job_id="job_cursor_pane_1",
+        agent_name="cursor1",
+        provider="cursor",
+        provider_instance=None,
+        provider_options={"no_wrap": True} if no_wrap else {},
+        request=SimpleNamespace(body="visible request", message_type=message_type),
+    )
+
+
+def _pane_context(tmp_path: Path) -> ProviderRuntimeContext:
+    return ProviderRuntimeContext(
+        agent_name="cursor1",
+        workspace_path=str(tmp_path),
+        backend_type="pane-backed",
+        runtime_ref="%9",
+        session_ref=str(tmp_path / ".ccb" / ".cursor-cursor1-session"),
+    )
+
+
+def _cursor_transcript(home: Path, session_id: str = "session-visible") -> Path:
+    return (
+        home
+        / ".cursor"
+        / "projects"
+        / "repo"
+        / "agent-transcripts"
+        / session_id
+        / f"{session_id}.jsonl"
+    )
+
+
+def _append_cursor_records(path: Path, *records: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record, ensure_ascii=True) + "\n")
+
+
+def _bind_cursor(
+    monkeypatch,
+    tmp_path: Path,
+) -> tuple[Path, _FakeCursorBackend, _FakeCursorSession]:
+    home = tmp_path / "managed-home"
+    session = _FakeCursorSession(home, tmp_path / ".ccb" / ".cursor-cursor1-session")
+    backend = _FakeCursorBackend()
+    monkeypatch.setattr(pane_execution, "_load_session", lambda work_dir, agent_name: session)
+    monkeypatch.setattr(pane_execution, "get_backend_for_session", lambda data: backend)
+    return home, backend, session
+
+
+def test_cursor_pane_adapter_sends_once_and_finishes_from_exact_anchored_transcript(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    home, backend, _ = _bind_cursor(monkeypatch, tmp_path)
+    stale = _cursor_transcript(home, "stale-session")
+    _append_cursor_records(
+        stale,
+        {"role": "user", "message": {"content": [{"type": "text", "text": "CCB_REQ_ID: job_cursor_pane_1"}]}},
+        {"role": "assistant", "message": {"content": [{"type": "text", "text": "stale reply"}]}},
+        {"type": "turn_ended", "status": "success"},
+    )
+    adapter = CursorPaneExecutionAdapter()
+
+    submission = adapter.start(
+        _pane_job(),
+        context=_pane_context(tmp_path),
+        now="2026-08-11T00:00:00Z",
+    )
+
+    assert submission.source_kind is CompletionSourceKind.SESSION_EVENT_LOG
+    assert submission.runtime_state["mode"] == "cursor_pane"
+    assert submission.runtime_state["prompt_sent"] is True
+    assert backend.sent[0][0] == "%9"
+    assert "CCB_REQ_ID: job_cursor_pane_1" in backend.sent[0][1]
+    assert "CCB_DONE" not in backend.sent[0][1]
+
+    subagent = _cursor_transcript(home).parent / "subagents" / "child.jsonl"
+    _append_cursor_records(
+        subagent,
+        {"role": "user", "message": {"content": [{"type": "text", "text": backend.sent[0][1]}]}},
+        {"role": "assistant", "message": {"content": [{"type": "text", "text": "child reply"}]}},
+        {"type": "turn_ended", "status": "success"},
+    )
+    transcript = _cursor_transcript(home)
+    _append_cursor_records(
+        transcript,
+        {"role": "user", "message": {"content": [{"type": "text", "text": backend.sent[0][1]}]}},
+        {"role": "assistant", "message": {"content": [{"type": "text", "text": "visible "}]}},
+        {"role": "assistant", "message": {"content": [{"type": "text", "text": "reply"}]}},
+        {"type": "turn_ended", "status": "success"},
+    )
+
+    result = adapter.poll(submission, now="2026-08-11T00:00:05Z")
+
+    assert len(backend.sent) == 1
+    assert result is not None and result.decision is not None
+    assert result.decision.status is CompletionStatus.COMPLETED
+    assert result.decision.reason == "cursor_run_stop"
+    assert result.decision.reply == "visible reply"
+    assert result.decision.diagnostics["transcript_path"] == str(transcript)
+    assert [item.kind for item in result.items] == [
+        CompletionItemKind.ANCHOR_SEEN,
+        CompletionItemKind.ASSISTANT_FINAL,
+        CompletionItemKind.TURN_BOUNDARY,
+    ]
+
+
+def test_cursor_pane_adapter_assistant_text_does_not_complete_without_turn_ended(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    home, backend, _ = _bind_cursor(monkeypatch, tmp_path)
+    adapter = CursorPaneExecutionAdapter()
+    submission = adapter.start(_pane_job(), context=_pane_context(tmp_path), now="2026-08-11T00:00:00Z")
+    transcript = _cursor_transcript(home)
+    _append_cursor_records(
+        transcript,
+        {"role": "user", "message": {"content": [{"type": "text", "text": backend.sent[0][1]}]}},
+        {"role": "assistant", "message": {"content": [{"type": "text", "text": "still running"}]}},
+    )
+
+    active = adapter.poll(submission, now="2026-08-11T00:00:02Z")
+
+    assert active is not None
+    assert active.decision is None
+    assert active.submission.reply == "still running"
+
+    _append_cursor_records(transcript, {"type": "turn_ended", "status": "success"})
+    finished = adapter.poll(active.submission, now="2026-08-11T00:00:03Z")
+
+    assert finished is not None and finished.decision is not None
+    assert finished.decision.status is CompletionStatus.COMPLETED
+    assert finished.decision.reply == "still running"
+
+
+def test_cursor_pane_adapter_error_turn_fails_closed(monkeypatch, tmp_path: Path) -> None:
+    home, backend, _ = _bind_cursor(monkeypatch, tmp_path)
+    adapter = CursorPaneExecutionAdapter()
+    submission = adapter.start(_pane_job(), context=_pane_context(tmp_path), now="2026-08-11T00:00:00Z")
+    transcript = _cursor_transcript(home)
+    _append_cursor_records(
+        transcript,
+        {"role": "user", "message": {"content": [{"type": "text", "text": backend.sent[0][1]}]}},
+        {"role": "assistant", "message": {"content": [{"type": "text", "text": "partial reply"}]}},
+        {"type": "turn_ended", "status": "error"},
+    )
+
+    result = adapter.poll(submission, now="2026-08-11T00:00:04Z")
+
+    assert result is not None and result.decision is not None
+    assert result.decision.status is CompletionStatus.INCOMPLETE
+    assert result.decision.reason == "cursor_run_finished:error"
+    assert result.decision.reply == "partial reply"
+
+
+def test_cursor_reply_delivery_sends_raw_body_and_completes_on_dispatch(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    _, backend, _ = _bind_cursor(monkeypatch, tmp_path)
+    adapter = CursorPaneExecutionAdapter()
+
+    submission = adapter.start(
+        _pane_job(message_type="reply_delivery", no_wrap=True),
+        context=_pane_context(tmp_path),
+        now="2026-08-11T00:00:00Z",
+    )
+    result = adapter.poll(submission, now="2026-08-11T00:00:01Z")
+
+    assert backend.sent == [("%9", "visible request")]
+    assert result is not None and result.decision is not None
+    assert result.decision.status is CompletionStatus.COMPLETED
+    assert result.decision.reason == "reply_delivery_sent"
+
+
+def test_cursor_pane_restore_requires_resubmission() -> None:
+    diagnostics = CursorPaneExecutionAdapter().restore_diagnostics()
+
+    assert diagnostics["resume_supported"] is False
+    assert diagnostics["restore_mode"] == "resubmit_required"

--- a/test/test_cursor_provider.py
+++ b/test/test_cursor_provider.py
@@ -340,6 +340,9 @@ def test_cursor_busy_pane_defers_then_dispatches_exactly_once_when_idle(
     assert dispatched.submission.runtime_state["started_at"] == "2026-08-11T00:00:09Z"
     assert len(backend.sent) == 1
 
+    assert adapter.poll(dispatched.submission, now="2026-08-11T00:00:10Z") is None
+    assert len(backend.sent) == 1
+
 
 def test_cursor_working_pane_defers_even_before_user_transcript_is_flushed(
     monkeypatch,
@@ -396,7 +399,24 @@ def test_cursor_working_pane_defers_even_before_user_transcript_is_flushed(
     assert dispatched.submission.runtime_state["pane_busy"] is False
     assert len(backend.sent) == 1
 
-    assert adapter.poll(dispatched.submission, now="2026-08-11T00:00:07Z") is None
+
+def test_cursor_pane_status_ignores_busy_markers_left_only_in_scrollback(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    _, backend, _ = _bind_cursor(monkeypatch, tmp_path)
+    backend.pane_text = "ctrl+c to stop\n" + "\n".join(
+        f"idle screen line {index}" for index in range(20)
+    )
+
+    submission = CursorPaneExecutionAdapter().start(
+        _pane_job(),
+        context=_pane_context(tmp_path),
+        now="2026-08-11T00:00:00Z",
+    )
+
+    assert submission.runtime_state["pane_status"] == "idle"
+    assert submission.runtime_state["prompt_sent"] is True
     assert len(backend.sent) == 1
 
 

--- a/test/test_cursor_provider.py
+++ b/test/test_cursor_provider.py
@@ -63,6 +63,7 @@ class _FakeCursorBackend:
         self.sent: list[tuple[str, str]] = []
         self.keys: list[tuple[str, str]] = []
         self.alive = True
+        self.pane_text = ""
 
     def send_text_to_pane(self, pane_id: str, text: str) -> None:
         self.sent.append((pane_id, text))
@@ -72,6 +73,11 @@ class _FakeCursorBackend:
 
     def send_key(self, pane_id: str, key: str) -> None:
         self.keys.append((pane_id, key))
+
+    def get_pane_content(self, pane_id: str, lines: int = 20) -> str:
+        assert pane_id == "%9"
+        assert lines >= 80
+        return self.pane_text
 
 
 def _pane_job(*, message_type: str = "ask", no_wrap: bool = False):
@@ -293,6 +299,38 @@ def test_cursor_busy_pane_defers_then_dispatches_exactly_once_when_idle(
     assert dispatched is not None and dispatched.decision is None
     assert dispatched.submission.runtime_state["prompt_sent"] is True
     assert dispatched.submission.runtime_state["started_at"] == "2026-08-11T00:00:06Z"
+    assert len(backend.sent) == 1
+
+
+def test_cursor_working_pane_defers_even_before_user_transcript_is_flushed(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    _, backend, _ = _bind_cursor(monkeypatch, tmp_path)
+    backend.pane_text = "⠘⠤ Working\n→ Add a follow-up                    ctrl+c to stop"
+    adapter = CursorPaneExecutionAdapter()
+
+    submission = adapter.start(
+        _pane_job(),
+        context=_pane_context(tmp_path),
+        now="2026-08-11T00:00:00Z",
+    )
+
+    assert submission.runtime_state["prompt_sent"] is False
+    assert submission.runtime_state["pane_busy"] is True
+    assert backend.sent == []
+
+    waiting = adapter.poll(submission, now="2026-08-11T00:00:01Z")
+    assert waiting is not None and waiting.decision is None
+    assert waiting.submission.runtime_state["prompt_sent"] is False
+    assert backend.sent == []
+
+    backend.pane_text = "→ Add a follow-up\nGPT-5.6 Sol 1M"
+    dispatched = adapter.poll(waiting.submission, now="2026-08-11T00:00:02Z")
+
+    assert dispatched is not None and dispatched.decision is None
+    assert dispatched.submission.runtime_state["prompt_sent"] is True
+    assert dispatched.submission.runtime_state["pane_busy"] is False
     assert len(backend.sent) == 1
 
     assert adapter.poll(dispatched.submission, now="2026-08-11T00:00:07Z") is None

--- a/test/test_cursor_provider.py
+++ b/test/test_cursor_provider.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from provider_backends.cursor import execution
+from provider_backends.native_cli_support import NativeCliSubprocessAdapter
+
+
+def test_cursor_execution_adapter_defaults_to_visible_pane(monkeypatch) -> None:
+    monkeypatch.delenv("CCB_CURSOR_EXECUTION_MODE", raising=False)
+
+    adapter = execution.build_execution_adapter()
+
+    assert type(adapter).__name__ == "CursorPaneExecutionAdapter"
+    assert getattr(adapter, "provider", "") == "cursor"
+
+
+def test_cursor_execution_adapter_supports_explicit_headless_rollback(monkeypatch) -> None:
+    monkeypatch.setenv("CCB_CURSOR_EXECUTION_MODE", "headless")
+
+    adapter = execution.build_execution_adapter()
+
+    assert isinstance(adapter, NativeCliSubprocessAdapter)
+
+
+def test_cursor_execution_adapter_rejects_unknown_mode(monkeypatch) -> None:
+    monkeypatch.setenv("CCB_CURSOR_EXECUTION_MODE", "mirror")
+
+    try:
+        execution.build_execution_adapter()
+    except ValueError as exc:
+        assert "CCB_CURSOR_EXECUTION_MODE" in str(exc)
+        assert "mirror" in str(exc)
+    else:
+        raise AssertionError("unknown Cursor execution mode must fail closed")
+
+
+def test_cursor_headless_command_and_env_builders_remain_available() -> None:
+    assert callable(execution.build_headless_execution_adapter)
+    assert callable(execution._build_command)
+    assert callable(execution._build_env)

--- a/test/test_cursor_provider.py
+++ b/test/test_cursor_provider.py
@@ -338,17 +338,25 @@ def test_cursor_working_pane_defers_even_before_user_transcript_is_flushed(
     assert transient_idle.submission.runtime_state["prompt_sent"] is False
     assert backend.sent == []
 
-    backend.pane_text = "⠘⠤ Working\n→ Add a follow-up                    ctrl+c to stop"
-    busy_again = adapter.poll(transient_idle.submission, now="2026-08-11T00:00:03Z")
-    assert busy_again is not None and busy_again.decision is None
-    assert busy_again.submission.runtime_state["idle_observed_at"] == ""
+    still_waiting = adapter.poll(transient_idle.submission, now="2026-08-11T00:00:07Z")
+    assert still_waiting is not None and still_waiting.decision is None
+    assert still_waiting.submission.runtime_state["prompt_sent"] is False
+    assert still_waiting.submission.runtime_state["deferred_terminal_seen"] is False
+    assert backend.sent == []
 
-    backend.pane_text = "→ Add a follow-up\nGPT-5.6 Sol 1M"
-    idle_again = adapter.poll(busy_again.submission, now="2026-08-11T00:00:04Z")
-    assert idle_again is not None and idle_again.decision is None
-    assert idle_again.submission.runtime_state["prompt_sent"] is False
+    manual = _cursor_transcript(tmp_path / "managed-home", "manual-session")
+    _append_cursor_records(
+        manual,
+        {"role": "user", "message": {"content": [{"type": "text", "text": "manual work"}]}},
+        {"role": "assistant", "message": {"content": [{"type": "text", "text": "manual done"}]}},
+        {"type": "turn_ended", "status": "success"},
+    )
+    terminal_observed = adapter.poll(still_waiting.submission, now="2026-08-11T00:00:08Z")
+    assert terminal_observed is not None and terminal_observed.decision is None
+    assert terminal_observed.submission.runtime_state["deferred_terminal_seen"] is True
+    assert terminal_observed.submission.runtime_state["prompt_sent"] is False
 
-    dispatched = adapter.poll(idle_again.submission, now="2026-08-11T00:00:07Z")
+    dispatched = adapter.poll(terminal_observed.submission, now="2026-08-11T00:00:11Z")
 
     assert dispatched is not None and dispatched.decision is None
     assert dispatched.submission.runtime_state["prompt_sent"] is True

--- a/test/test_cursor_provider.py
+++ b/test/test_cursor_provider.py
@@ -294,11 +294,17 @@ def test_cursor_busy_pane_defers_then_dispatches_exactly_once_when_idle(
     assert backend.sent == []
 
     _append_cursor_records(manual, {"type": "turn_ended", "status": "success"})
-    dispatched = adapter.poll(waiting.submission, now="2026-08-11T00:00:06Z")
+    idle_observed = adapter.poll(waiting.submission, now="2026-08-11T00:00:06Z")
+
+    assert idle_observed is not None and idle_observed.decision is None
+    assert idle_observed.submission.runtime_state["prompt_sent"] is False
+    assert backend.sent == []
+
+    dispatched = adapter.poll(idle_observed.submission, now="2026-08-11T00:00:09Z")
 
     assert dispatched is not None and dispatched.decision is None
     assert dispatched.submission.runtime_state["prompt_sent"] is True
-    assert dispatched.submission.runtime_state["started_at"] == "2026-08-11T00:00:06Z"
+    assert dispatched.submission.runtime_state["started_at"] == "2026-08-11T00:00:09Z"
     assert len(backend.sent) == 1
 
 
@@ -326,7 +332,23 @@ def test_cursor_working_pane_defers_even_before_user_transcript_is_flushed(
     assert backend.sent == []
 
     backend.pane_text = "→ Add a follow-up\nGPT-5.6 Sol 1M"
-    dispatched = adapter.poll(waiting.submission, now="2026-08-11T00:00:02Z")
+    transient_idle = adapter.poll(waiting.submission, now="2026-08-11T00:00:02Z")
+
+    assert transient_idle is not None and transient_idle.decision is None
+    assert transient_idle.submission.runtime_state["prompt_sent"] is False
+    assert backend.sent == []
+
+    backend.pane_text = "⠘⠤ Working\n→ Add a follow-up                    ctrl+c to stop"
+    busy_again = adapter.poll(transient_idle.submission, now="2026-08-11T00:00:03Z")
+    assert busy_again is not None and busy_again.decision is None
+    assert busy_again.submission.runtime_state["idle_observed_at"] == ""
+
+    backend.pane_text = "→ Add a follow-up\nGPT-5.6 Sol 1M"
+    idle_again = adapter.poll(busy_again.submission, now="2026-08-11T00:00:04Z")
+    assert idle_again is not None and idle_again.decision is None
+    assert idle_again.submission.runtime_state["prompt_sent"] is False
+
+    dispatched = adapter.poll(idle_again.submission, now="2026-08-11T00:00:07Z")
 
     assert dispatched is not None and dispatched.decision is None
     assert dispatched.submission.runtime_state["prompt_sent"] is True
@@ -429,8 +451,10 @@ def test_cursor_cancel_interrupts_only_after_prompt_delivery(monkeypatch, tmp_pa
     assert backend.keys == []
 
     _append_cursor_records(manual, {"type": "turn_ended", "status": "success"})
-    dispatched = adapter.poll(deferred, now="2026-08-11T00:00:01Z")
-    assert dispatched is not None
+    idle_observed = adapter.poll(deferred, now="2026-08-11T00:00:01Z")
+    assert idle_observed is not None
+    dispatched = adapter.poll(idle_observed.submission, now="2026-08-11T00:00:04Z")
+    assert dispatched is not None and dispatched.submission.runtime_state["prompt_sent"] is True
 
     adapter.cancel(dispatched.submission)
 

--- a/test/test_cursor_provider.py
+++ b/test/test_cursor_provider.py
@@ -257,3 +257,143 @@ def test_cursor_pane_restore_requires_resubmission() -> None:
 
     assert diagnostics["resume_supported"] is False
     assert diagnostics["restore_mode"] == "resubmit_required"
+
+
+def test_cursor_busy_pane_defers_then_dispatches_exactly_once_when_idle(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    home, backend, _ = _bind_cursor(monkeypatch, tmp_path)
+    manual = _cursor_transcript(home, "manual-session")
+    _append_cursor_records(
+        manual,
+        {"role": "user", "message": {"content": [{"type": "text", "text": "manual work"}]}},
+    )
+    adapter = CursorPaneExecutionAdapter()
+
+    submission = adapter.start(
+        _pane_job(),
+        context=_pane_context(tmp_path),
+        now="2026-08-11T00:00:00Z",
+    )
+
+    assert submission.runtime_state["prompt_sent"] is False
+    assert submission.runtime_state["started_at"] == ""
+    assert backend.sent == []
+
+    waiting = adapter.poll(submission, now="2026-08-11T00:00:05Z")
+
+    assert waiting is not None and waiting.decision is None
+    assert waiting.submission.runtime_state["prompt_sent"] is False
+    assert backend.sent == []
+
+    _append_cursor_records(manual, {"type": "turn_ended", "status": "success"})
+    dispatched = adapter.poll(waiting.submission, now="2026-08-11T00:00:06Z")
+
+    assert dispatched is not None and dispatched.decision is None
+    assert dispatched.submission.runtime_state["prompt_sent"] is True
+    assert dispatched.submission.runtime_state["started_at"] == "2026-08-11T00:00:06Z"
+    assert len(backend.sent) == 1
+
+    assert adapter.poll(dispatched.submission, now="2026-08-11T00:00:07Z") is None
+    assert len(backend.sent) == 1
+
+
+def test_cursor_busy_pane_ready_timeout_never_sends(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("CCB_CURSOR_READY_TIMEOUT_S", "2")
+    home, backend, _ = _bind_cursor(monkeypatch, tmp_path)
+    manual = _cursor_transcript(home, "manual-session")
+    _append_cursor_records(
+        manual,
+        {"role": "user", "message": {"content": [{"type": "text", "text": "manual work"}]}},
+    )
+    adapter = CursorPaneExecutionAdapter()
+    submission = adapter.start(_pane_job(), context=_pane_context(tmp_path), now="2026-08-11T00:00:00Z")
+
+    result = adapter.poll(submission, now="2026-08-11T00:00:03Z")
+
+    assert result is not None and result.decision is not None
+    assert result.decision.status is CompletionStatus.INCOMPLETE
+    assert result.decision.reason == "cursor_input_not_ready"
+    assert result.decision.diagnostics["prompt_sent"] is False
+    assert backend.sent == []
+
+
+def test_cursor_run_timeout_preserves_observed_reply_without_resending(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("CCB_CURSOR_RUN_TIMEOUT_S", "2")
+    home, backend, _ = _bind_cursor(monkeypatch, tmp_path)
+    adapter = CursorPaneExecutionAdapter()
+    submission = adapter.start(_pane_job(), context=_pane_context(tmp_path), now="2026-08-11T00:00:00Z")
+    transcript = _cursor_transcript(home)
+    _append_cursor_records(
+        transcript,
+        {"role": "user", "message": {"content": [{"type": "text", "text": backend.sent[0][1]}]}},
+        {"role": "assistant", "message": {"content": [{"type": "text", "text": "partial reply"}]}},
+    )
+    active = adapter.poll(submission, now="2026-08-11T00:00:01Z")
+    assert active is not None and active.decision is None
+
+    result = adapter.poll(active.submission, now="2026-08-11T00:00:03Z")
+
+    assert result is not None and result.decision is not None
+    assert result.decision.status is CompletionStatus.INCOMPLETE
+    assert result.decision.reason == "cursor_run_timeout"
+    assert result.decision.reply == "partial reply"
+    assert result.decision.anchor_seen is True
+    assert len(backend.sent) == 1
+
+
+def test_cursor_timeout_configuration_requires_positive_finite_values(monkeypatch) -> None:
+    monkeypatch.setenv("CCB_CURSOR_READY_TIMEOUT_S", "nan")
+    monkeypatch.setenv("CCB_CURSOR_RUN_TIMEOUT_S", "inf")
+
+    assert pane_execution._effective_ready_timeout_s() == pane_execution._DEFAULT_READY_TIMEOUT_S
+    assert pane_execution._effective_run_timeout_s() == pane_execution._DEFAULT_RUN_TIMEOUT_S
+
+    monkeypatch.setenv("CCB_CURSOR_READY_TIMEOUT_S", "2.5")
+    monkeypatch.setenv("CCB_CURSOR_RUN_TIMEOUT_S", "7")
+
+    assert pane_execution._effective_ready_timeout_s() == 2.5
+    assert pane_execution._effective_run_timeout_s() == 7.0
+
+
+def test_cursor_dead_pane_fails_promptly(monkeypatch, tmp_path: Path) -> None:
+    _, backend, _ = _bind_cursor(monkeypatch, tmp_path)
+    adapter = CursorPaneExecutionAdapter()
+    submission = adapter.start(_pane_job(), context=_pane_context(tmp_path), now="2026-08-11T00:00:00Z")
+    backend.alive = False
+
+    result = adapter.poll(submission, now="2026-08-11T00:00:01Z")
+
+    assert result is not None and result.decision is not None
+    assert result.decision.status is CompletionStatus.FAILED
+    assert result.decision.reason == "pane_dead"
+
+
+def test_cursor_cancel_interrupts_only_after_prompt_delivery(monkeypatch, tmp_path: Path) -> None:
+    home, backend, _ = _bind_cursor(monkeypatch, tmp_path)
+    manual = _cursor_transcript(home, "manual-session")
+    _append_cursor_records(
+        manual,
+        {"role": "user", "message": {"content": [{"type": "text", "text": "manual work"}]}},
+    )
+    adapter = CursorPaneExecutionAdapter()
+    deferred = adapter.start(_pane_job(), context=_pane_context(tmp_path), now="2026-08-11T00:00:00Z")
+
+    adapter.cancel(deferred)
+
+    assert backend.keys == []
+
+    _append_cursor_records(manual, {"type": "turn_ended", "status": "success"})
+    dispatched = adapter.poll(deferred, now="2026-08-11T00:00:01Z")
+    assert dispatched is not None
+
+    adapter.cancel(dispatched.submission)
+
+    assert backend.keys == [("%9", "C-c"), ("%9", "Escape"), ("%9", "C-u")]

--- a/test/test_cursor_transcript.py
+++ b/test/test_cursor_transcript.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 from provider_backends.cursor.transcript import (
     capture_cursor_transcript_offsets,
+    cursor_pane_turn_state,
     iter_top_level_cursor_transcripts,
     read_new_cursor_transcript_records,
 )
@@ -99,3 +101,71 @@ def test_cursor_transcript_reader_skips_malformed_complete_records(tmp_path: Pat
 
     assert records == [(str(path), {"type": "turn_ended", "status": "error"})]
     assert offsets[str(path)] == path.stat().st_size
+
+
+def test_cursor_pane_turn_state_without_transcript_is_idle(tmp_path: Path) -> None:
+    state = cursor_pane_turn_state(tmp_path / "managed-home", session_started_mtime_ns=1)
+
+    assert state.busy is False
+    assert state.transcript_path == ""
+    assert state.terminal_status == ""
+
+
+def test_cursor_pane_turn_state_is_busy_until_success_terminal_record(tmp_path: Path) -> None:
+    home = tmp_path / "managed-home"
+    path = _transcript(home, "current-session")
+    _append(path, {"role": "user", "message": {"content": [{"type": "text", "text": "manual"}]}})
+
+    busy = cursor_pane_turn_state(home, session_started_mtime_ns=1)
+
+    assert busy.busy is True
+    assert busy.transcript_path == str(path)
+    assert busy.terminal_status == ""
+
+    _append(path, {"type": "turn_ended", "status": "success"})
+    idle = cursor_pane_turn_state(home, session_started_mtime_ns=1)
+
+    assert idle.busy is False
+    assert idle.transcript_path == str(path)
+    assert idle.terminal_status == "success"
+
+
+def test_cursor_pane_turn_state_error_terminal_record_makes_next_turn_idle(tmp_path: Path) -> None:
+    home = tmp_path / "managed-home"
+    path = _transcript(home, "current-session")
+    _append(
+        path,
+        {"role": "user", "message": {"content": [{"type": "text", "text": "manual"}]}},
+        {"type": "turn_ended", "status": "error"},
+    )
+
+    state = cursor_pane_turn_state(home, session_started_mtime_ns=1)
+
+    assert state.busy is False
+    assert state.terminal_status == "error"
+
+
+def test_cursor_pane_turn_state_ignores_incomplete_legacy_transcript(tmp_path: Path) -> None:
+    home = tmp_path / "managed-home"
+    path = _transcript(home, "legacy-session")
+    _append(path, {"role": "user", "message": {"content": [{"type": "text", "text": "legacy"}]}})
+    os.utime(path, ns=(1_000, 1_000))
+
+    state = cursor_pane_turn_state(home, session_started_mtime_ns=2_000)
+
+    assert state.busy is False
+    assert state.transcript_path == ""
+
+
+def test_cursor_pane_turn_state_ignores_malformed_and_subagent_records(tmp_path: Path) -> None:
+    home = tmp_path / "managed-home"
+    parent = _transcript(home, "current-session")
+    parent.parent.mkdir(parents=True, exist_ok=True)
+    parent.write_text("not-json\n", encoding="utf-8")
+    subagent = parent.parent / "subagents" / "child.jsonl"
+    _append(subagent, {"role": "user", "message": {"content": [{"type": "text", "text": "busy"}]}})
+
+    state = cursor_pane_turn_state(home, session_started_mtime_ns=1)
+
+    assert state.busy is False
+    assert state.transcript_path == str(parent)

--- a/test/test_cursor_transcript.py
+++ b/test/test_cursor_transcript.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from provider_backends.cursor.transcript import (
+    capture_cursor_transcript_offsets,
+    iter_top_level_cursor_transcripts,
+    read_new_cursor_transcript_records,
+)
+
+
+def _transcript(home: Path, session_id: str, *, workspace: str = "repo") -> Path:
+    return (
+        home
+        / ".cursor"
+        / "projects"
+        / workspace
+        / "agent-transcripts"
+        / session_id
+        / f"{session_id}.jsonl"
+    )
+
+
+def _append(path: Path, *records: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record, ensure_ascii=True) + "\n")
+
+
+def test_cursor_transcript_discovery_excludes_subagents(tmp_path: Path) -> None:
+    home = tmp_path / "managed-home"
+    parent = _transcript(home, "parent-session")
+    subagent = parent.parent / "subagents" / "child-session.jsonl"
+    _append(parent, {"role": "user", "message": {"content": []}})
+    _append(subagent, {"role": "assistant", "message": {"content": []}})
+
+    paths = iter_top_level_cursor_transcripts(home)
+    offsets = capture_cursor_transcript_offsets(home)
+
+    assert paths == (parent,)
+    assert offsets == {str(parent): parent.stat().st_size}
+
+
+def test_cursor_transcript_reader_finds_appends_and_new_top_level_files(tmp_path: Path) -> None:
+    home = tmp_path / "managed-home"
+    first = _transcript(home, "first-session")
+    _append(first, {"role": "user", "message": {"content": [{"type": "text", "text": "old"}]}})
+    offsets = capture_cursor_transcript_offsets(home)
+
+    _append(first, {"type": "turn_ended", "status": "success"})
+    second = _transcript(home, "second-session")
+    new_user = {"role": "user", "message": {"content": [{"type": "text", "text": "new"}]}}
+    _append(second, new_user)
+
+    records, next_offsets = read_new_cursor_transcript_records(home, offsets)
+
+    assert records == [
+        (str(first), {"type": "turn_ended", "status": "success"}),
+        (str(second), new_user),
+    ]
+    assert next_offsets[str(first)] == first.stat().st_size
+    assert next_offsets[str(second)] == second.stat().st_size
+
+
+def test_cursor_transcript_reader_does_not_advance_past_partial_line(tmp_path: Path) -> None:
+    home = tmp_path / "managed-home"
+    path = _transcript(home, "partial-session")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    complete = json.dumps({"role": "assistant", "message": {"content": []}}) + "\n"
+    path.write_bytes(complete.encode("utf-8") + b'{"type":"turn_')
+
+    records, offsets = read_new_cursor_transcript_records(home, {})
+
+    assert records == [
+        (str(path), {"role": "assistant", "message": {"content": []}}),
+    ]
+    assert offsets[str(path)] == len(complete.encode("utf-8"))
+
+    with path.open("ab") as handle:
+        handle.write(b'ended","status":"success"}\n')
+    records, offsets = read_new_cursor_transcript_records(home, offsets)
+
+    assert records == [(str(path), {"type": "turn_ended", "status": "success"})]
+    assert offsets[str(path)] == path.stat().st_size
+
+
+def test_cursor_transcript_reader_skips_malformed_complete_records(tmp_path: Path) -> None:
+    home = tmp_path / "managed-home"
+    path = _transcript(home, "malformed-session")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "not-json\n" + json.dumps({"type": "turn_ended", "status": "error"}) + "\n",
+        encoding="utf-8",
+    )
+
+    records, offsets = read_new_cursor_transcript_records(home, {})
+
+    assert records == [(str(path), {"type": "turn_ended", "status": "error"})]
+    assert offsets[str(path)] == path.stat().st_size

--- a/test/test_native_cli_provider_execution.py
+++ b/test/test_native_cli_provider_execution.py
@@ -10,6 +10,9 @@ import pytest
 from ccbd.api_models import DeliveryScope, JobRecord, JobStatus, MessageEnvelope
 from completion.models import CompletionItemKind, CompletionSourceKind, CompletionStatus
 from provider_backends.copilot.execution import _build_env as build_copilot_env
+from provider_backends.cursor.execution import (
+    build_headless_execution_adapter as build_cursor_headless_execution_adapter,
+)
 from provider_backends.grok import home as grok_home
 from provider_backends.grok.execution import (
     _grok_session_id_for_job,
@@ -107,6 +110,8 @@ def _write_session(provider: str, work_dir: Path) -> None:
 
 
 def _adapter(provider: str):
+    if provider == "cursor":
+        return build_cursor_headless_execution_adapter()
     if provider == "pi":
         return build_pi_headless_execution_adapter()
     backend = build_default_backend_registry(include_optional=True, include_test_doubles=False).get(provider)


### PR DESCRIPTION
## Summary

- execute Cursor jobs in the managed interactive pane by default
- wait safely when a user or agent turn is already running
- collect results from the exact top-level Cursor transcript, excluding stale and subagent transcripts
- retain the previous headless behavior behind `CCB_CURSOR_EXECUTION_MODE=headless`

## Why

The Cursor adapter previously inherited the native CLI path and launched a second `agent --print` process for every CCB job. The managed Cursor pane therefore appeared idle, execution was invisible to the user, and pane startup model arguments were bypassed.

This change makes the visible pane the source of execution and completion while keeping an explicit rollback path. Non-Cursor providers keep their existing execution behavior.

## Implementation notes

The pane runner:

- classifies visible pane state before dispatch
- waits for active turns to finish and for a stable idle window
- anchors completion to the submitted request
- tolerates delayed transcript flushes and Cursor rewriting the previous trailing `turn_ended`
- ignores subagent transcripts and stale scrollback busy markers

The accompanying design and implementation plan document the behavior, compatibility boundary, and rollout strategy.

## Validation

- `129 passed, 112 deselected` — Cursor/provider execution suite
- `167 passed` — non-Cursor regression suite
- `git diff --check origin/main...HEAD`
- live three-Cursor smoke test on macOS:
  - Opus, Sol, and Grok executed in their visible panes
  - configured pane models were preserved
  - concurrent and already-busy pane behavior completed correctly
  - no `agent --print` subprocess was used
