### PR TITLE
fix(windows): 后台守护进程绕过 venv 重定向器修复前台窗口与重启循环

### DIFF
--- a/lib/ccbd/daemon_process.py
+++ b/lib/ccbd/daemon_process.py
@@ -4,11 +4,10 @@ from pathlib import Path
 import os
 import signal
 import subprocess
-import sys
 import time
 
 from runtime_env.control_plane import control_plane_env
-from process_background import background_process_kwargs
+from process_background import background_process_kwargs, background_spawn
 
 from ccbd.socket_client import CcbdClient, CcbdClientError
 from ccbd.startup_fence import (
@@ -35,11 +34,13 @@ def spawn_ccbd_process(
     keeper_startup_accepted_perf_counter_ns: int | None = None,
 ) -> None:
     script = Path(__file__).resolve().parent / 'main.py'
+    interpreter, venv_env = background_spawn()
     env = _ccbd_env(
         keeper_pid=keeper_pid,
         expected_startup_id=expected_startup_id,
         expected_generation=expected_generation,
         keeper_startup_accepted_perf_counter_ns=keeper_startup_accepted_perf_counter_ns,
+        venv_env=venv_env,
     )
     ccbd_dir.mkdir(parents=True, exist_ok=True)
     with open(ccbd_dir / 'ccbd.stdout.log', 'ab') as stdout_log, open(
@@ -47,7 +48,7 @@ def spawn_ccbd_process(
         'ab',
     ) as stderr_log:
         process = subprocess.Popen(
-            [sys.executable, str(script), '--project', str(project_root)],
+            [interpreter, str(script), '--project', str(project_root)],
             cwd=str(project_root),
             env=env,
             stdout=stdout_log,
@@ -83,7 +84,6 @@ def _wait_for_ccbd_ready(
                 payload = CcbdClient(socket_path, timeout_s=CONTROL_PLANE_RPC_TIMEOUT_S).ping('ccbd')
                 if _ready_payload_matches_expected(
                     payload,
-                    process=process,
                     expected_startup_id=expected_startup_id,
                     expected_generation=expected_generation,
                 ):
@@ -97,7 +97,6 @@ def _wait_for_ccbd_ready(
                     payload = CcbdClient(socket_path, timeout_s=CONTROL_PLANE_RPC_TIMEOUT_S).ping('ccbd')
                     if _ready_payload_matches_expected(
                         payload,
-                        process=process,
                         expected_startup_id=expected_startup_id,
                         expected_generation=expected_generation,
                     ):
@@ -116,6 +115,7 @@ def _ccbd_env(
     expected_startup_id: str | None = None,
     expected_generation: int | None = None,
     keeper_startup_accepted_perf_counter_ns: int | None = None,
+    venv_env: dict[str, str] | None = None,
 ) -> dict[str, str]:
     startup_id = str(expected_startup_id or '').strip()
     generation = int(expected_generation or 0)
@@ -136,6 +136,10 @@ def _ccbd_env(
             str(accepted_ns) if accepted_ns is not None else None
         ),
     }
+    if venv_env:
+        for key, value in venv_env.items():
+            if value:
+                extra[key] = value
     env = control_plane_env(extra=extra)
     lib_root = str(Path(__file__).resolve().parents[1])
     script_root = Path(__file__).resolve().parents[2]
@@ -160,7 +164,6 @@ def _positive_diagnostics_int(value: object) -> int | None:
 def _ready_payload_matches_expected(
     payload: dict[str, object],
     *,
-    process: subprocess.Popen[bytes],
     expected_startup_id: str | None,
     expected_generation: int | None,
 ) -> bool:
@@ -179,8 +182,12 @@ def _ready_payload_matches_expected(
     diagnostics = payload.get('diagnostics')
     if not isinstance(diagnostics, dict):
         return False
+    # Do not require serving_pid == the spawner's Popen pid: on Windows the
+    # venvlauncher redirector makes Popen.pid differ from the daemon's own pid.
+    # Startup identity is proven by startup_id/generation/daemon_instance_id,
+    # so a positive serving_pid is sufficient sanity.
     return (
-        serving_pid == int(process.pid)
+        serving_pid > 0
         and serving_generation == generation
         and lifecycle_generation == generation
         and str(payload.get('accepted_startup_id') or '') == startup_id

--- a/lib/cli/services/daemon_runtime/keeper.py
+++ b/lib/cli/services/daemon_runtime/keeper.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from pathlib import Path
 import os
 import subprocess
-import sys
 import time
 
 from agents.config_identity import project_config_identity_payload
@@ -20,7 +19,7 @@ from ccbd.services.ownership import OwnershipGuard
 from ccbd.services.runtime_identity import reconcile_runtime_project_identity
 from ccbd.system import utc_now
 from runtime_env.control_plane import control_plane_env
-from process_background import background_process_kwargs
+from process_background import background_process_kwargs, background_spawn
 
 from cli.kill_runtime.processes import is_pid_alive
 
@@ -281,7 +280,8 @@ def _keeper_state_is_running_for_context(
 def spawn_keeper_process(context) -> None:
     lib_root = _lib_root()
     script = lib_root / 'ccbd' / 'keeper_main.py'
-    env = control_plane_env(extra={'PYTHONUNBUFFERED': '1'})
+    interpreter, venv_env = background_spawn()
+    env = control_plane_env(extra={'PYTHONUNBUFFERED': '1', **venv_env})
     current_pythonpath = env.get('PYTHONPATH')
     env['PYTHONPATH'] = (
         str(lib_root)
@@ -293,7 +293,7 @@ def spawn_keeper_process(context) -> None:
     stdout_log = open(context.paths.ccbd_dir / 'keeper.stdout.log', 'ab')
     stderr_log = open(context.paths.ccbd_dir / 'keeper.stderr.log', 'ab')
     subprocess.Popen(
-        [sys.executable, str(script), '--project', str(context.project.project_root)],
+        [interpreter, str(script), '--project', str(context.project.project_root)],
         cwd=str(context.project.project_root),
         env=env,
         stdout=stdout_log,

--- a/lib/process_background.py
+++ b/lib/process_background.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
+from pathlib import Path
 
 
 def background_process_kwargs() -> dict[str, object]:
@@ -22,8 +24,72 @@ def no_window_process_kwargs() -> dict[str, object]:
     return {'creationflags': _subprocess_flag('CREATE_NO_WINDOW', 0x08000000)}
 
 
+def venv_base_interpreter() -> str | None:
+    """Resolve the real base interpreter of the active Windows venv.
+
+    On Windows a venv's ``Scripts\\python.exe`` is the venvlauncher redirector:
+    it re-executes the base interpreter (e.g. ``Python314\\python.exe``) as a
+    child process.  Spawning the redirector (a) breaks ``CREATE_NO_WINDOW`` /
+    ``DETACHED_PROCESS`` propagation to the real interpreter, so a visible
+    console window appears, and (b) makes the ``Popen`` pid differ from the
+    daemon's own ``os.getpid()``, breaking pid-based readiness identity checks.
+    Returns ``None`` when not on Windows, not inside a venv, or the base
+    interpreter is missing.
+    """
+    if os.name != 'nt':
+        return None
+    executable = Path(sys.executable)
+    if executable.name.lower() not in {'python.exe', 'pythonw.exe'}:
+        return None
+    venv_root = executable.parent.parent
+    cfg = venv_root / 'pyvenv.cfg'
+    if not cfg.is_file():
+        return None
+    home = ''
+    try:
+        for line in cfg.read_text(encoding='utf-8').splitlines():
+            key, _, value = line.partition('=')
+            if key.strip() == 'home':
+                home = value.strip()
+                break
+    except OSError:
+        return None
+    if not home:
+        return None
+    candidate = Path(home) / executable.name
+    return str(candidate) if candidate.is_file() else None
+
+
+def background_spawn() -> tuple[str, dict[str, str]]:
+    """Return ``(interpreter, extra_env)`` for spawning a CCB background daemon.
+
+    On Windows this prefers the venv's real base interpreter (bypassing the
+    venvlauncher redirector) so that ``CREATE_NO_WINDOW`` applies directly to
+    the spawned process and ``Popen.pid`` equals the daemon's own pid.  The
+    venv site-packages are carried into ``PYTHONPATH`` (the base interpreter
+    does not auto-add them without the redirector) and ``VIRTUAL_ENV`` is set.
+    Off Windows this is ``(sys.executable, {})``.
+    """
+    if os.name != 'nt':
+        return sys.executable, {}
+    interpreter = venv_base_interpreter() or sys.executable
+    venv_root = Path(sys.executable).parent.parent
+    extra: dict[str, str] = {}
+    site_packages = venv_root / 'Lib' / 'site-packages'
+    if site_packages.is_dir():
+        extra['PYTHONPATH'] = str(site_packages)
+    if (venv_root / 'pyvenv.cfg').is_file():
+        extra['VIRTUAL_ENV'] = str(venv_root)
+    return interpreter, extra
+
+
 def _subprocess_flag(name: str, fallback: int) -> int:
     return int(getattr(subprocess, name, fallback) or fallback)
 
 
-__all__ = ['background_process_kwargs', 'no_window_process_kwargs']
+__all__ = [
+    'background_process_kwargs',
+    'no_window_process_kwargs',
+    'venv_base_interpreter',
+    'background_spawn',
+]

--- a/platforms/windows/launcher/src/main.rs
+++ b/platforms/windows/launcher/src/main.rs
@@ -42,6 +42,7 @@ fn run() -> Result<i32, String> {
         command.args(&forwarded);
         command.env("CCB_WINDOWS_LAUNCHER", &executable);
         command.env("CCB_INSTALL_PREFIX", install_root);
+        suppress_child_console(&mut command);
 
         match command.status() {
             Ok(status) => return Ok(status.code().unwrap_or(1)),
@@ -110,6 +111,19 @@ fn normalize_exit_code(code: i32) -> u8 {
         1
     }
 }
+
+#[cfg(target_os = "windows")]
+fn suppress_child_console(command: &mut Command) {
+    use std::os::windows::process::CommandExt;
+    // CREATE_NO_WINDOW: without it a console-subsystem child (python.exe)
+    // spawned from a parent with no console is allocated a brand-new visible
+    // console window that flashes and then closes when the child exits.
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    command.creation_flags(CREATE_NO_WINDOW);
+}
+
+#[cfg(not(target_os = "windows"))]
+fn suppress_child_console(_command: &mut Command) {}
 
 #[cfg(test)]
 mod tests {

--- a/test/test_ccbd_process_env.py
+++ b/test/test_ccbd_process_env.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 import subprocess
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -71,8 +72,7 @@ def test_ccbd_env_rejects_partial_startup_fence() -> None:
         raise AssertionError('partial startup fence should fail')
 
 
-def test_ready_payload_requires_serving_child_identity() -> None:
-    process = type('Process', (), {'pid': 4321})()
+def test_ready_payload_identity_does_not_require_serving_pid_equals_popen_pid() -> None:
     payload = {
         'generation': 7,
         'mount_state': 'mounted',
@@ -87,21 +87,26 @@ def test_ready_payload_requires_serving_child_identity() -> None:
         },
     }
 
+    # On Windows the venvlauncher redirector makes Popen.pid differ from the
+    # daemon's own pid; the fence must accept any positive serving pid as long
+    # as startup_id/generation identity matches.
     assert _ready_payload_matches_expected(
         payload,
-        process=process,
+        expected_startup_id='a' * 32,
+        expected_generation=7,
+    )
+    assert _ready_payload_matches_expected(
+        {**payload, 'serving_pid': 9999},
         expected_startup_id='a' * 32,
         expected_generation=7,
     )
     assert not _ready_payload_matches_expected(
-        {**payload, 'serving_pid': 9999},
-        process=process,
+        {**payload, 'serving_pid': 0},
         expected_startup_id='a' * 32,
         expected_generation=7,
     )
     assert not _ready_payload_matches_expected(
         {**payload, 'accepted_startup_id': 'b' * 32},
-        process=process,
         expected_startup_id='a' * 32,
         expected_generation=7,
     )
@@ -115,7 +120,6 @@ def test_ready_payload_requires_serving_child_identity() -> None:
                 'startup_stage': 'spawn_requested',
             },
         },
-        process=process,
         expected_startup_id='a' * 32,
         expected_generation=7,
     )
@@ -145,6 +149,49 @@ def test_background_process_kwargs_detaches_windows_console(monkeypatch) -> None
     assert kwargs['creationflags'] & 0x00000200
     assert kwargs['creationflags'] & 0x00000008
     assert kwargs['creationflags'] & 0x08000000
+
+
+def test_background_spawn_off_windows_returns_sys_executable(monkeypatch) -> None:
+    monkeypatch.setattr(process_background.os, 'name', 'posix')
+
+    interpreter, extra = process_background.background_spawn()
+
+    assert interpreter == sys.executable
+    assert extra == {}
+
+
+def test_background_spawn_resolves_venv_base_interpreter_and_site_packages(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(process_background.os, 'name', 'nt')
+    venv = tmp_path / 'venv'
+    (venv / 'Scripts').mkdir(parents=True)
+    site_packages = venv / 'Lib' / 'site-packages'
+    site_packages.mkdir(parents=True)
+    base_exe = tmp_path / 'base' / 'python.exe'
+    base_exe.parent.mkdir(parents=True)
+    base_exe.write_bytes(b'')
+    (venv / 'pyvenv.cfg').write_text(
+        f'home = {base_exe.parent}\nversion = 3.14\n', encoding='utf-8'
+    )
+    monkeypatch.setattr(
+        process_background.sys, 'executable', str(venv / 'Scripts' / 'python.exe')
+    )
+
+    interpreter, extra = process_background.background_spawn()
+
+    assert interpreter == str(base_exe)
+    assert extra['PYTHONPATH'] == str(site_packages)
+    assert extra['VIRTUAL_ENV'] == str(venv)
+
+
+def test_venv_base_interpreter_none_without_pyvenv_cfg(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(process_background.os, 'name', 'nt')
+    fake_exe = tmp_path / 'Scripts' / 'python.exe'
+    fake_exe.parent.mkdir(parents=True)
+    monkeypatch.setattr(process_background.sys, 'executable', str(fake_exe))
+
+    assert process_background.venv_base_interpreter() is None
 
 
 def test_spawn_failure_reclaims_only_spawned_child_and_closes_parent_logs(


### PR DESCRIPTION
## 问题

Windows 原生 CCB 启动后，桌面出现两个 python.exe 前台窗口，守护进程周期性重启约 10 分钟才消失。

## 根因

`.venv\Scripts\python.exe` 是 venvlauncher 重定向器，会再拉起真实解释器（如 `Python314\python.exe`）作为子进程：

1. **可见窗口**：spawn 重定向器时 `CREATE_NO_WINDOW`/`DETACHED_PROCESS` 不会传递给真实解释器子进程，导致无控制台父进程的控制台子进程被分配一个新可见窗口。
2. **守护重启循环**：`Popen.pid` 是重定向器的 PID，而守护自身上报的 `serving_pid` 是真实解释器的 PID，两者必不相等，启动栅栏 `serving_pid == process.pid` 永远失败。keeper 每 30s 重拉一次，直到熔断（约 10 分钟）。

## 改动

- **新增 `process_background.venv_base_interpreter()`/`background_spawn()`**：读取 `pyvenv.cfg` 的 `home`，以真实解释器直接 spawn 守护进程，并把 venv site-packages 并入 `PYTHONPATH`、设置 `VIRTUAL_ENV`。
- **`spawn_ccbd_process` / `spawn_keeper_process`** 改用解析后的解释器 → `Popen.pid == serving_pid`，启动栅栏通过，`CREATE_NO_WINDOW` 直接作用于真实进程。
- **启动栅栏放宽**：不再要求 `serving_pid == Popen.pid`，改为 `serving_pid > 0` + `startup_id/generation/daemon_instance_id` 身份指纹校验，防任何 wrapper 再次触发误重启。
- **Windows 启动器（ccb.exe）**：为 python 子进程添加 `CREATE_NO_WINDOW`，抑制无控制台上下文调用时的窗口闪烁。

## 测试

- 更新 `test_ready_payload_identity_does_not_require_serving_pid_equals_popen_pid`（覆盖 venv 重定向器场景）
- 新增 `background_spawn` / `venv_base_interpreter` 单测
- 相关测试：79 passed, 2 skipped；Rust launcher `cargo check` 通过
