### PR TITLE
fix(mobile): expose Pi native session history

### DIFF
--- a/lib/mobile_gateway/service.py
+++ b/lib/mobile_gateway/service.py
@@ -31,6 +31,7 @@ from ccbd.api_models import DeliveryScope, MessageEnvelope
 from platforms.windows.herdr.ccbd_surface_projection import herdr_surface_projection_passes_gate
 from ccbd.socket_client import CcbdClientError
 from cli.services.config_ui import config_ui_provider_capabilities
+from project.identity import normalize_work_dir
 from provider_control import (
     ProviderQuotaService,
     ProviderSettingsError,
@@ -3327,11 +3328,11 @@ def _agent_conversation_items(
         limit=limit,
         cursor=cursor,
     )
-    # Codex/Claude files are the authority whenever those providers are in
+    # Provider-native files are the authority whenever those providers are in
     # use, including an intentionally empty native history. Other providers do
     # not all expose a native transcript, so retain the safe structured CCB
     # records. Terminal scrollback is deliberately excluded from this path.
-    if provider_key in {'', 'codex', 'claude'} or native_items.items:
+    if provider_key in {'', 'codex', 'claude', 'pi'} or native_items.items:
         return native_items
     return _agent_structured_fallback_conversation_items(
         view_payload,
@@ -3457,8 +3458,17 @@ def _agent_native_conversation_items(
         if codex_items.items:
             return codex_items
     if provider_key in {'', 'claude'}:
+        claude_items = _claude_native_conversation_items(
+            project_root,
+            project_id=project_id,
+            agent=agent,
+            mobile_files_dir=mobile_files_dir,
+        )
+        if provider_key == 'claude' or claude_items:
+            return _ConversationItemsResult(claude_items)
+    if provider_key in {'', 'pi'}:
         return _ConversationItemsResult(
-            _claude_native_conversation_items(
+            _pi_native_conversation_items(
                 project_root,
                 project_id=project_id,
                 agent=agent,
@@ -3489,6 +3499,13 @@ def _agent_native_conversation_cache_fingerprint(
         )
         if claude_fingerprint:
             return claude_fingerprint
+    if provider_key in {'', 'pi'}:
+        pi_fingerprint = _pi_native_conversation_cache_fingerprint(
+            project_root,
+            agent=agent,
+        )
+        if pi_fingerprint:
+            return pi_fingerprint
     return ()
 
 
@@ -3527,6 +3544,209 @@ def _conversation_page_has_provider_native_items(page: dict[str, object]) -> boo
         if source.startswith('provider_native/'):
             return True
     return False
+
+
+def _pi_native_conversation_items(
+    project_root: Path,
+    *,
+    project_id: str,
+    agent: str,
+    mobile_files_dir: Path | None = None,
+) -> list[dict[str, object]]:
+    session_paths = _pi_native_session_paths(project_root, agent=agent)
+    if not session_paths:
+        return []
+    file_roots = [
+        path
+        for path in (
+            mobile_files_dir,
+            project_root / '.ccb' / 'ccbd' / 'mobile' / 'files',
+        )
+        if path is not None
+    ]
+    items: list[dict[str, object]] = []
+    for session_order, session_path in enumerate(session_paths):
+        try:
+            lines = session_path.open(encoding='utf-8-sig')
+            fallback_timestamp = f'{int(session_path.stat().st_mtime):020d}'
+        except Exception:
+            continue
+        parent_by_id: dict[str, str | None] = {}
+        visible_by_id: dict[str, dict[str, object]] = {}
+        visible_order: list[str] = []
+        latest_record_id: str | None = None
+        session_id = _native_id_part(session_path.stem, fallback='session')
+        with lines:
+            for line_number, line in enumerate(lines, start=1):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    record = _map(json.loads(line))
+                except Exception:
+                    continue
+                record_id = _optional_text(record.get('id'))
+                if not record_id:
+                    continue
+                latest_record_id = record_id
+                parent_by_id[record_id] = _optional_text(record.get('parentId'))
+                if record.get('type') == 'session':
+                    session_id = _native_id_part(record_id, fallback=session_id)
+                    continue
+                if record.get('type') != 'message':
+                    continue
+                message = _map(record.get('message'))
+                role = str(message.get('role') or '').strip().lower()
+                if role not in {'user', 'assistant'}:
+                    continue
+                body = _pi_message_content_text(message.get('content'))
+                body = _inject_workspace_artifacts(
+                    body,
+                    project_root=project_root,
+                    project_id=project_id,
+                    agent=agent,
+                    mobile_files_dir=mobile_files_dir,
+                )
+                body = _clean_native_message_text(body)
+                if not body:
+                    continue
+                item_id = (
+                    f'pi-{session_id}-{line_number}-'
+                    f'{_native_id_part(record_id, fallback=role)}-{role}'
+                )
+                if role == 'user':
+                    item = {
+                        'id': item_id,
+                        'agent': agent,
+                        'kind': 'user_message',
+                        'title': 'You',
+                        'body': body,
+                        'format': 'markdown',
+                        'source': 'provider_native/pi',
+                        'state': 'sent',
+                        'attachments': [],
+                    }
+                else:
+                    item = {
+                        'id': item_id,
+                        'agent': agent,
+                        'kind': 'agent_reply',
+                        'title': 'Agent reply',
+                        'body': body,
+                        'format': 'markdown',
+                        'source': 'provider_native/pi',
+                        'attachments': _artifact_link_attachments(
+                            body,
+                            file_roots=file_roots,
+                            project_id=project_id,
+                            agent=agent,
+                        ),
+                    }
+                _set_native_sort_fields(
+                    item,
+                    record,
+                    fallback_timestamp=fallback_timestamp,
+                    thread_order=session_order,
+                    line_number=line_number,
+                )
+                visible_by_id[record_id] = item
+                visible_order.append(record_id)
+        active_record_ids = _pi_active_record_ids(
+            latest_record_id,
+            parent_by_id=parent_by_id,
+        )
+        items.extend(
+            visible_by_id[record_id]
+            for record_id in visible_order
+            if record_id in active_record_ids
+        )
+    sorted_items = [
+        item
+        for _, item in sorted(
+            enumerate(items),
+            key=lambda indexed: (
+                _optional_text(indexed[1].get('_native_sort_timestamp')) or '',
+                int(indexed[1].get('_native_thread_order') or 0),
+                int(indexed[1].get('_native_line_number') or 0),
+                indexed[0],
+            ),
+        )
+    ]
+    return [
+        _without_native_sort_fields(item)
+        for item in _coalesce_pi_native_agent_replies(sorted_items)
+    ]
+
+
+def _pi_native_session_paths(project_root: Path, *, agent: str) -> list[Path]:
+    session_dir = (
+        project_root / '.ccb' / 'agents' / agent / 'provider-state' / 'pi' / 'sessions'
+    )
+    if session_dir.is_symlink() or not session_dir.is_dir():
+        return []
+    project_work_dir = normalize_work_dir(project_root)
+    candidates: list[tuple[str, str, Path]] = []
+    try:
+        for path in session_dir.glob('*.jsonl'):
+            if path.is_symlink() or not path.is_file():
+                continue
+            try:
+                with path.open(encoding='utf-8-sig') as lines:
+                    header = _map(json.loads(lines.readline()))
+            except Exception:
+                continue
+            if header.get('type') != 'session':
+                continue
+            recorded_work_dir = _optional_text(header.get('cwd'))
+            if not recorded_work_dir or normalize_work_dir(recorded_work_dir) != project_work_dir:
+                continue
+            candidates.append((
+                _optional_text(header.get('timestamp')) or '',
+                path.name,
+                path,
+            ))
+    except Exception:
+        return []
+    return [path for _, _, path in sorted(candidates)]
+
+
+def _pi_native_conversation_cache_fingerprint(
+    project_root: Path,
+    *,
+    agent: str,
+) -> tuple[tuple[str, int, int], ...]:
+    return tuple(
+        entry
+        for path in _pi_native_session_paths(project_root, agent=agent)
+        if (entry := _conversation_file_fingerprint_entry(path)) is not None
+    )
+
+
+def _pi_active_record_ids(
+    latest_record_id: str | None,
+    *,
+    parent_by_id: Mapping[str, str | None],
+) -> set[str]:
+    active: set[str] = set()
+    current = latest_record_id
+    while current and current not in active:
+        active.add(current)
+        current = parent_by_id.get(current)
+    return active
+
+
+def _pi_message_content_text(value: object) -> str:
+    if isinstance(value, str):
+        return value
+    parts: list[str] = []
+    for item in _iterable(value):
+        content = _map(item)
+        if content.get('type') != 'text':
+            continue
+        text = _optional_text(content.get('text')) or ''
+        if text:
+            parts.append(text)
+    return '\n\n'.join(parts)
 
 
 def _claude_native_conversation_items(
@@ -4573,6 +4793,15 @@ def _coalesce_claude_native_agent_replies(
     return _coalesce_provider_native_agent_replies(
         items,
         source='provider_native/claude',
+    )
+
+
+def _coalesce_pi_native_agent_replies(
+    items: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    return _coalesce_provider_native_agent_replies(
+        items,
+        source='provider_native/pi',
     )
 
 

--- a/test/test_mobile_gateway_service.py
+++ b/test/test_mobile_gateway_service.py
@@ -319,10 +319,24 @@ class _FakeCcbdClientWithConversationComms(_FakeCcbdClient):
         return payload
 
 
+class _FakePiCcbdClientWithConversationComms(_FakeCcbdClientWithConversationComms):
+    def project_view(self, *, schema_version: int = 1) -> dict[str, object]:
+        payload = super().project_view(schema_version=schema_version)
+        payload['view']['agents'][0]['provider'] = 'pi'
+        return payload
+
+
 class _FakeClaudeCcbdClient(_FakeCcbdClient):
     def project_view(self, *, schema_version: int = 1) -> dict[str, object]:
         payload = super().project_view(schema_version=schema_version)
         payload['view']['agents'][0]['provider'] = 'claude'
+        return payload
+
+
+class _FakePiCcbdClient(_FakeCcbdClient):
+    def project_view(self, *, schema_version: int = 1) -> dict[str, object]:
+        payload = super().project_view(schema_version=schema_version)
+        payload['view']['agents'][0]['provider'] = 'pi'
         return payload
 
 
@@ -2382,6 +2396,275 @@ def test_agent_conversation_completes_codex_response_assistant_from_task_marker(
     assert native_items[1]['completed_at'] == '2026-06-25T12:00:05.000Z'
     assert native_items[1]['sent_at'] == '2026-06-25T12:00:05.000Z'
     assert native_items[1]['duration_ms'] == 4000
+
+
+def test_agent_conversation_prefers_pi_native_transcript_and_refreshes_cache(
+    tmp_path: Path,
+) -> None:
+    project_root = tmp_path / 'repo'
+    jobs_dir = project_root / '.ccb' / 'agents' / 'mobile'
+    jobs_dir.mkdir(parents=True)
+    (jobs_dir / 'jobs.jsonl').write_text(
+        json.dumps(
+            {
+                'job_id': 'stale-pi-job',
+                'status': 'completed',
+                'agent_name': 'mobile',
+                'request': {'body': 'stale structured prompt'},
+            }
+        )
+        + '\n',
+        encoding='utf-8',
+    )
+    transcript_path = _write_pi_transcript(
+        project_root,
+        agent='mobile',
+        session_id='pi-session-native',
+        records=[
+            {
+                'type': 'model_change',
+                'id': 'pi-config',
+                'parentId': None,
+                'timestamp': '2026-06-25T12:00:00.000Z',
+            },
+            {
+                'type': 'message',
+                'id': 'pi-user-1',
+                'parentId': 'pi-config',
+                'timestamp': '2026-06-25T12:00:01.000Z',
+                'message': {
+                    'role': 'user',
+                    'content': [{'type': 'text', 'text': 'pi native question'}],
+                },
+            },
+            {
+                'type': 'message',
+                'id': 'pi-assistant-1',
+                'parentId': 'pi-user-1',
+                'timestamp': '2026-06-25T12:00:02.000Z',
+                'message': {
+                    'role': 'assistant',
+                    'content': [
+                        {'type': 'thinking', 'thinking': 'hidden pi thinking'},
+                        {'type': 'text', 'text': 'pi native answer'},
+                        {
+                            'type': 'toolCall',
+                            'id': 'call-hidden',
+                            'name': 'bash',
+                            'arguments': {'command': 'hidden tool command'},
+                        },
+                    ],
+                },
+            },
+            {
+                'type': 'message',
+                'id': 'pi-branch-user',
+                'parentId': 'pi-user-1',
+                'timestamp': '2026-06-25T12:00:03.000Z',
+                'message': {
+                    'role': 'user',
+                    'content': [{'type': 'text', 'text': 'inactive branch question'}],
+                },
+            },
+            {
+                'type': 'message',
+                'id': 'pi-branch-assistant',
+                'parentId': 'pi-branch-user',
+                'timestamp': '2026-06-25T12:00:04.000Z',
+                'message': {
+                    'role': 'assistant',
+                    'content': [{'type': 'text', 'text': 'inactive branch answer'}],
+                },
+            },
+            {
+                'type': 'message',
+                'id': 'pi-user-2',
+                'parentId': 'pi-assistant-1',
+                'timestamp': '2026-06-25T12:00:05.000Z',
+                'message': {
+                    'role': 'user',
+                    'content': [
+                        {
+                            'type': 'text',
+                            'text': (
+                                'CCB_REQ_ID: pi-request\n\n'
+                                'clean pi prompt\n\n'
+                                'CCB reply guidance:\n'
+                                '- Answer directly and concisely.\n'
+                            ),
+                        }
+                    ],
+                },
+            },
+            {
+                'type': 'message',
+                'id': 'pi-assistant-2a',
+                'parentId': 'pi-user-2',
+                'timestamp': '2026-06-25T12:00:06.000Z',
+                'message': {
+                    'role': 'assistant',
+                    'content': [{'type': 'text', 'text': 'step one'}],
+                },
+            },
+            {
+                'type': 'message',
+                'id': 'pi-tool-result',
+                'parentId': 'pi-assistant-2a',
+                'timestamp': '2026-06-25T12:00:07.000Z',
+                'message': {
+                    'role': 'toolResult',
+                    'content': [{'type': 'text', 'text': 'hidden tool result'}],
+                },
+            },
+            {
+                'type': 'message',
+                'id': 'pi-assistant-2b',
+                'parentId': 'pi-tool-result',
+                'timestamp': '2026-06-25T12:00:08.000Z',
+                'message': {
+                    'role': 'assistant',
+                    'content': [{'type': 'text', 'text': 'step two'}],
+                },
+            },
+        ],
+        partial_tail='{"type":"message","id":"partial"',
+    )
+    _write_pi_transcript(
+        project_root,
+        agent='mobile',
+        session_id='wrong-project',
+        cwd=tmp_path / 'other-repo',
+        records=[
+            {
+                'type': 'message',
+                'id': 'wrong-user',
+                'parentId': None,
+                'timestamp': '2026-06-25T11:00:01.000Z',
+                'message': {
+                    'role': 'user',
+                    'content': [{'type': 'text', 'text': 'wrong project history'}],
+                },
+            },
+        ],
+    )
+
+    service = _service(
+        _FakePiCcbdClient(),
+        project_root=project_root,
+        mobile_dir=tmp_path / 'mobile',
+    )
+    pairing = service.create_pairing_payload(
+        gateway_url='http://127.0.0.1:8787',
+        scopes=('view',),
+    )
+    _, claim = service.dispatch_post(
+        '/v1/pairing/claim',
+        {'pairing_code': str(pairing['pairing_code'])},
+    )
+    route = '/v1/projects/proj-demo/agents/mobile/conversation?namespace_epoch=4&limit=20'
+    headers = {'Authorization': f'Bearer {claim["device_token"]}'}
+
+    status, payload = service.dispatch_get(route, headers)
+
+    assert status == 200
+    items = payload['conversation']['items']
+    assert [item.get('source') for item in items] == ['provider_native/pi'] * 4
+    assert [(item['kind'], item['body']) for item in items] == [
+        ('user_message', 'pi native question'),
+        ('agent_reply', 'pi native answer'),
+        ('user_message', 'clean pi prompt'),
+        ('agent_reply', 'step one\n\nstep two'),
+    ]
+    assert items[0]['sent_at'] == '2026-06-25T12:00:01.000Z'
+    assert items[1]['completed_at'] == '2026-06-25T12:00:02.000Z'
+    public_json = json.dumps(payload)
+    for hidden in (
+        'hidden pi thinking',
+        'hidden tool command',
+        'hidden tool result',
+        'inactive branch question',
+        'inactive branch answer',
+        'wrong project history',
+        'CCB_REQ_ID',
+        'CCB reply guidance',
+        'stale structured prompt',
+    ):
+        assert hidden not in public_json
+
+    with transcript_path.open('a', encoding='utf-8') as stream:
+        stream.write('\n')
+        stream.write(json.dumps({
+            'type': 'message',
+            'id': 'pi-user-3',
+            'parentId': 'pi-assistant-2b',
+            'timestamp': '2026-06-25T12:00:09.000Z',
+            'message': {
+                'role': 'user',
+                'content': [{'type': 'text', 'text': 'new pi question'}],
+            },
+        }) + '\n')
+        stream.write(json.dumps({
+            'type': 'message',
+            'id': 'pi-assistant-3',
+            'parentId': 'pi-user-3',
+            'timestamp': '2026-06-25T12:00:10.000Z',
+            'message': {
+                'role': 'assistant',
+                'content': [{'type': 'text', 'text': 'new pi answer'}],
+            },
+        }) + '\n')
+
+    _, refreshed = service.dispatch_get(route, headers)
+    assert [(item['kind'], item['body']) for item in refreshed['conversation']['items'][-2:]] == [
+        ('user_message', 'new pi question'),
+        ('agent_reply', 'new pi answer'),
+    ]
+
+
+def test_agent_conversation_does_not_fallback_for_pi_without_native_transcript(
+    tmp_path: Path,
+) -> None:
+    project_root = tmp_path / 'repo'
+    snapshot_dir = project_root / '.ccb' / 'ccbd' / 'snapshots'
+    snapshot_dir.mkdir(parents=True)
+    (snapshot_dir / 'job_mobile_reply.json').write_text(
+        json.dumps({'latest_decision': {'reply': 'stale pi completion'}}),
+        encoding='utf-8',
+    )
+    jobs_dir = project_root / '.ccb' / 'agents' / 'mobile'
+    jobs_dir.mkdir(parents=True)
+    (jobs_dir / 'jobs.jsonl').write_text(
+        json.dumps({
+            'job_id': 'stale-pi-job',
+            'status': 'completed',
+            'agent_name': 'mobile',
+            'request': {'body': 'stale pi job prompt'},
+        }) + '\n',
+        encoding='utf-8',
+    )
+    service = _service(
+        _FakePiCcbdClientWithConversationComms(),
+        project_root=project_root,
+        mobile_dir=tmp_path / 'mobile',
+    )
+    pairing = service.create_pairing_payload(
+        gateway_url='http://127.0.0.1:8787',
+        scopes=('view',),
+    )
+    _, claim = service.dispatch_post(
+        '/v1/pairing/claim',
+        {'pairing_code': str(pairing['pairing_code'])},
+    )
+
+    _, payload = service.dispatch_get(
+        '/v1/projects/proj-demo/agents/mobile/conversation?namespace_epoch=4&limit=20',
+        {'Authorization': f'Bearer {claim["device_token"]}'},
+    )
+
+    assert payload['conversation']['items'] == []
+    assert 'stale pi completion' not in json.dumps(payload)
+    assert 'stale pi job prompt' not in json.dumps(payload)
+    assert 'question from phone' not in json.dumps(payload)
 
 
 def test_agent_conversation_prefers_claude_native_transcript(tmp_path: Path) -> None:
@@ -5898,6 +6181,37 @@ def test_http_server_exposes_g1_get_endpoints(tmp_path: Path) -> None:
         server.shutdown()
         server.server_close()
         thread.join(timeout=2)
+
+
+def _write_pi_transcript(
+    project_root: Path,
+    *,
+    agent: str,
+    session_id: str,
+    records: list[dict[str, object]],
+    cwd: Path | None = None,
+    partial_tail: str | None = None,
+) -> Path:
+    session_dir = (
+        project_root / '.ccb' / 'agents' / agent / 'provider-state' / 'pi' / 'sessions'
+    )
+    transcript_path = session_dir / f'2026-06-25T12-00-00-000Z_{session_id}.jsonl'
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
+    header = {
+        'type': 'session',
+        'version': 3,
+        'id': session_id,
+        'timestamp': '2026-06-25T12:00:00.000Z',
+        'cwd': str(cwd or project_root),
+    }
+    content = ''.join(
+        f'{json.dumps(record)}\n'
+        for record in (header, *records)
+    )
+    if partial_tail is not None:
+        content += partial_tail
+    transcript_path.write_text(content, encoding='utf-8')
+    return transcript_path
 
 
 def _write_codex_rollout(


### PR DESCRIPTION
## Problem

The mobile conversation view could not display Pi Agent conversation history. The mobile gateway only read Codex and Claude native transcripts, so Pi projects returned an empty conversation even though Pi session JSONL files existed on the host.

## Fix

- Read Pi native transcripts from `.ccb/agents/<agent>/provider-state/pi/sessions/*.jsonl`.
- Validate session type, project cwd, regular-file boundaries, and current project ownership.
- Expose only user and assistant text content.
- Filter Pi internal records such as thinking, tool calls, and tool results.
- Ignore incomplete JSONL tail records and non-active branches.
- Merge consecutive assistant text messages.
- Refresh cached conversation data when the transcript fingerprint changes.
- Preserve artifact and link injection behavior.
- Keep jobs/Comms as fallback only when no native Pi transcript exists.

## Compatibility and scope

The change is limited to the mobile gateway conversation-history reader and its tests. Existing Codex and Claude transcript behavior remains unchanged. Pi native transcripts remain the authoritative source when available.

Transcript parsing is performed by the host mobile gateway rather than inside the mobile application. The Android APK was rebuilt from the latest upstream `origin/main` as a debug build for functional verification.

## Verification

- `python -m pytest -q test/test_mobile_gateway_service.py`
  - 89 passed
- Pi-specific coverage includes native transcript precedence, branch filtering, internal-content filtering, partial JSONL writes, project isolation, cache refresh, and no-transcript fallback behavior.
- `python -m compileall -q lib/mobile_gateway/service.py test/test_mobile_gateway_service.py`
- `git diff --check`
- Verified the running host gateway at `127.0.0.1:8787`:
  - `master`: 13 Pi conversation messages
  - `archi`: 2 Pi conversation messages
  - source: `provider_native/pi`
  - `loader` Codex project: no regression
- Rebuilt the Android APK from upstream commit `7a008597`.
- APK metadata verified: `versionName=8.6.1`, `versionCode=8060001`.
- APK v2 signature verification passed.
- Manual mobile functional verification passed.

## Limitations

The APK was built as a debug APK because no release keystore was available. Direct APK UI automation was not run because no Android device or emulator was connected; the host gateway endpoint and the mobile functional path were verified separately.

## Related

Related to the previously merged Pi session-history work in #289; this PR adds mobile gateway projection of Pi native transcript history.
