### PR TITLE
fix(mobile): 修复 Windows 原生下移动网关项目注册与就绪等待并加固描述符校验

### DIFF
--- a/lib/cli/services/mobile_host.py
+++ b/lib/cli/services/mobile_host.py
@@ -43,6 +43,7 @@ MOBILE_HOST_STOP_TIMEOUT_S = 2.0
 MOBILE_HOST_PORT_RELEASE_TIMEOUT_S = 3.0
 MOBILE_HOST_HEALTH_TIMEOUT_S = 10.0
 MOBILE_HOST_HEALTH_REQUEST_TIMEOUT_S = 2.0
+MOBILE_HOST_STATE_READY_TIMEOUT_S = MOBILE_HOST_HEALTH_TIMEOUT_S
 
 
 class MobileHostServiceError(RuntimeError):
@@ -274,10 +275,14 @@ def start_or_replace_mobile_host_service(
             if pid > 0:
                 _terminate_managed_mobile_host(pid, terminate_pid_tree_fn=terminate_pid_tree_fn)
             raise
-        state = _matching_spawned_state(
-            read_mobile_host_service_state(paths.state_path),
+        state = _wait_for_mobile_host_state_ready(
+            paths,
+            process=process,
             pid=pid,
             generation=generation,
+            timeout_s=MOBILE_HOST_STATE_READY_TIMEOUT_S,
+            sleep_fn=sleep_fn,
+            monotonic_fn=monotonic_fn,
         )
         return MobileHostServiceResult(
             status='replaced' if replaced_pid is not None else 'started',
@@ -451,6 +456,9 @@ def detect_loopback_port_owner(listen: str) -> PortOwner | None:
         raise MobileHostServiceError(
             'mobile gateway listen port must be between 1 and 65535'
         )
+    owner = _detect_loopback_port_owner_netstat(host=host, port=port)
+    if owner is not None:
+        return owner
     owner = _detect_loopback_port_owner_ss(host=host, port=port)
     if owner is not None:
         return owner
@@ -459,6 +467,39 @@ def detect_loopback_port_owner(listen: str) -> PortOwner | None:
         return owner
     if _loopback_port_accepts_connection(host=host, port=port):
         return PortOwner(pid=0, command='unknown loopback listener')
+    return None
+
+
+def _detect_loopback_port_owner_netstat(*, host: str, port: int) -> PortOwner | None:
+    if os.name != 'nt':
+        return None
+    try:
+        result = subprocess.run(
+            ['netstat', '-ano', '-p', 'tcp'],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=1.0,
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    for line in (result.stdout or '').splitlines():
+        fields = line.split()
+        if len(fields) < 5 or fields[0].upper() != 'TCP':
+            continue
+        local_address = fields[1]
+        state = fields[3].upper()
+        if state != 'LISTENING':
+            continue
+        if not _listen_address_matches(local_address, host=host, port=port):
+            continue
+        try:
+            pid = int(fields[4])
+        except ValueError:
+            return PortOwner(pid=0, command='unknown loopback listener')
+        return PortOwner(pid=pid, command=_process_cmdline(pid))
     return None
 
 
@@ -617,6 +658,50 @@ def _wait_for_mobile_host_health(
     raise MobileHostServiceError(f'mobile host service did not become healthy: {local_gateway_url}/v1/health')
 
 
+def _wait_for_mobile_host_state_ready(
+    paths: MobileHostServicePaths,
+    *,
+    process: object,
+    pid: int,
+    generation: int,
+    timeout_s: float,
+    sleep_fn: Callable[[float], None],
+    monotonic_fn: Callable[[], float],
+) -> dict[str, object]:
+    deadline = monotonic_fn() + max(0.0, timeout_s)
+    last_state: dict[str, object] | None = None
+    while monotonic_fn() < deadline:
+        poll = getattr(process, 'poll', None)
+        if callable(poll):
+            exit_code = poll()
+            if exit_code is not None:
+                detail = (
+                    'mobile host service exited before publishing pairing state: '
+                    f'exit_code={exit_code}'
+                )
+                log_tail = _mobile_host_log_tail(paths.log_path)
+                if log_tail:
+                    detail += f'; log_tail={log_tail}'
+                raise MobileHostServiceError(detail)
+        state = _matching_spawned_state(
+            read_mobile_host_service_state(paths.state_path),
+            pid=pid,
+            generation=generation,
+        )
+        if state is not None:
+            last_state = state
+            if _state_pairing(state) is not None:
+                return state
+        sleep_fn(0.05)
+    if last_state is not None:
+        raise MobileHostServiceError(
+            f'mobile host service did not publish pairing state: {paths.state_path}'
+        )
+    raise MobileHostServiceError(
+        f'mobile host service did not publish matching state: {paths.state_path}'
+    )
+
+
 def _mobile_host_log_tail(path: Path, *, max_chars: int = 1200) -> str:
     try:
         text = Path(path).read_text(encoding='utf-8', errors='replace')
@@ -679,7 +764,7 @@ def _legacy_mobile_gateway_process(
 ) -> bool:
     """Recognize the pre-service foreground mobile gateway for safe takeover."""
     try:
-        tokens = shlex.split(cmdline)
+        tokens = shlex.split(cmdline, posix=os.name != 'nt')
     except ValueError:
         return False
     expected_script = str((Path(script_root) / 'ccb.py').expanduser().resolve())
@@ -707,6 +792,29 @@ def _legacy_mobile_gateway_process(
 def _process_cmdline(pid: int) -> str:
     if pid <= 0:
         return ''
+    if os.name == 'nt':
+        try:
+            command = [
+                'powershell',
+                '-NoProfile',
+                '-Command',
+                (
+                    'Get-CimInstance Win32_Process -Filter '
+                    f'"ProcessId = {pid}" | Select-Object -ExpandProperty CommandLine'
+                ),
+            ]
+            result = subprocess.run(
+                command,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                text=True,
+                timeout=1.0,
+            )
+        except Exception:
+            return ''
+        if result.returncode != 0:
+            return ''
+        return (result.stdout or '').strip()
     proc_cmdline = Path('/proc') / str(pid) / 'cmdline'
     try:
         text = proc_cmdline.read_bytes().replace(b'\x00', b' ').decode('utf-8', errors='replace').strip()

--- a/lib/mobile_gateway/project_registry.py
+++ b/lib/mobile_gateway/project_registry.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Callable
 
 from ccbd.socket_client import CcbdClient
+from ccbd.control_plane_transport.endpoint_store import read_endpoint
 from storage.atomic import atomic_write_json
 
 
@@ -164,7 +165,7 @@ def discover_running_mobile_gateway_projects(
             socket_path = _ccbd_socket_path_for_project(project_root)
         except Exception:
             continue
-        if not socket_path.is_socket():
+        if not _control_plane_endpoint_is_structurally_valid(socket_path):
             continue
         discovered[project_id] = MobileGatewayProject(
             project_id=project_id,
@@ -213,7 +214,7 @@ def _project_from_record(record: dict[str, object]) -> MobileGatewayProject | No
     socket_path = Path(socket_text).expanduser()
     if not project_root.is_absolute() or not socket_path.is_absolute():
         return None
-    if not project_root.exists() or not socket_path.is_socket():
+    if not project_root.exists() or not _control_plane_endpoint_is_structurally_valid(socket_path):
         return None
     display_name = str(record.get('display_name') or '').strip() or None
     return MobileGatewayProject(
@@ -276,6 +277,18 @@ def _ccbd_socket_path_for_project(project_root: Path) -> Path:
     from storage.paths import PathLayout
 
     return PathLayout(project_root).ccbd_socket_path
+
+
+def _control_plane_endpoint_is_structurally_valid(socket_path: Path) -> bool:
+    if socket_path.is_socket():
+        return True
+    if not socket_path.is_file():
+        return False
+    try:
+        endpoint = read_endpoint(socket_path)
+    except (OSError, ValueError):
+        return False
+    return endpoint is not None and endpoint.get('kind') == 'tcp_loopback'
 
 
 __all__ = [

--- a/lib/mobile_gateway/project_registry.py
+++ b/lib/mobile_gateway/project_registry.py
@@ -288,7 +288,16 @@ def _control_plane_endpoint_is_structurally_valid(socket_path: Path) -> bool:
         endpoint = read_endpoint(socket_path)
     except (OSError, ValueError):
         return False
-    return endpoint is not None and endpoint.get('kind') == 'tcp_loopback'
+    if not isinstance(endpoint, dict):
+        return False
+    if endpoint.get('kind') != 'tcp_loopback':
+        return False
+    # token 是 Windows TCP 控制平面认证的必要项，缺失则 CcbdClient 必然连不上。
+    if not str(endpoint.get('token_ref') or endpoint.get('auth_ref') or '').strip():
+        return False
+    # tcp_loopback 仅允许 127.0.0.1（与 WindowsTcpControlPlaneTransport 安全模型一致）。
+    host = str(endpoint.get('host') or '').strip() or '127.0.0.1'
+    return host == '127.0.0.1'
 
 
 __all__ = [

--- a/test/test_mobile_cli_service.py
+++ b/test/test_mobile_cli_service.py
@@ -11,6 +11,8 @@ from urllib.request import Request, urlopen
 
 import pytest
 
+from ccbd.control_plane_transport.endpoint import endpoint_from_record
+from ccbd.control_plane_transport.endpoint_store import write_endpoint
 from cli.services.mobile import _public_gateway_url, prepare_server_mobile_gateway
 from mobile_gateway import (
     MobileGatewayProject,
@@ -20,6 +22,12 @@ from mobile_gateway import (
     publish_mobile_gateway_project,
 )
 from project.ids import compute_project_id
+
+
+requires_af_unix = pytest.mark.skipif(
+    not hasattr(socket, 'AF_UNIX'),
+    reason='requires AF_UNIX socket support',
+)
 
 
 class _FakeCcbdClient:
@@ -84,6 +92,7 @@ def test_public_gateway_url_rejects_non_origin_url(value: str, message: str) -> 
         _public_gateway_url(value, fallback='unused')
 
 
+@requires_af_unix
 def test_host_project_registry_publish_and_loads_redacted_projects(tmp_path: Path) -> None:
     registry_path = tmp_path / 'mobile' / 'projects.json'
     project_root = tmp_path / 'one'
@@ -132,6 +141,64 @@ def test_host_project_registry_omits_stale_persisted_projects(tmp_path: Path) ->
         load_mobile_gateway_project_registry(registry_path=registry_path)
 
 
+def test_host_project_registry_loads_windows_tcp_marker_without_connecting(tmp_path: Path) -> None:
+    registry_path = tmp_path / 'mobile' / 'projects.json'
+    project_root = tmp_path / 'windows-project'
+    project_root.mkdir()
+    socket_path = project_root / '.ccb' / 'ccbd' / 'ccbd.sock'
+    socket_path.parent.mkdir(parents=True)
+    socket_path.touch()
+    write_endpoint(
+        endpoint_from_record(
+            {
+                'kind': 'tcp_loopback',
+                'host': '127.0.0.1',
+                'port': 32123,
+                'token_ref': str(socket_path.parent / 'control-plane-token-test.json'),
+                'generation': 'test',
+                'acl_status': 'windows-icacls-user-read',
+                'fingerprint': 'deadbeefcafebabe',
+            }
+        ),
+        legacy_socket_path=socket_path,
+    )
+    publish_mobile_gateway_project(
+        project_id='proj-windows',
+        project_root=project_root,
+        ccbd_socket_path=socket_path,
+        display_name='windows-project',
+        registry_path=registry_path,
+    )
+
+    registry = load_mobile_gateway_project_registry(registry_path=registry_path)
+
+    assert [project.project_id for project in registry.projects()] == ['proj-windows']
+    assert registry.default_project.public_display_name == 'windows-project'
+
+
+def test_host_project_registry_omits_windows_marker_with_invalid_endpoint(tmp_path: Path) -> None:
+    registry_path = tmp_path / 'mobile' / 'projects.json'
+    project_root = tmp_path / 'windows-project'
+    project_root.mkdir()
+    socket_path = project_root / '.ccb' / 'ccbd' / 'ccbd.sock'
+    socket_path.parent.mkdir(parents=True)
+    socket_path.touch()
+    (socket_path.parent / 'control-plane-endpoint.json').write_text(
+        '{"kind":"tcp_loopback","host":"0.0.0.0"}',
+        encoding='utf-8',
+    )
+    publish_mobile_gateway_project(
+        project_id='proj-windows-invalid',
+        project_root=project_root,
+        ccbd_socket_path=socket_path,
+        registry_path=registry_path,
+    )
+
+    with pytest.raises(ValueError, match='cannot be empty'):
+        load_mobile_gateway_project_registry(registry_path=registry_path)
+
+
+@requires_af_unix
 def test_running_project_discovery_reads_ccbd_main_project_cmdline(tmp_path: Path, monkeypatch) -> None:
     project_root = tmp_path / 'running-project'
     project_root.mkdir()
@@ -160,6 +227,7 @@ def test_running_project_discovery_reads_ccbd_main_project_cmdline(tmp_path: Pat
     assert projects[0].public_display_name == 'running-project'
 
 
+@requires_af_unix
 def test_host_project_registry_can_merge_running_projects(tmp_path: Path, monkeypatch) -> None:
     registry_path = tmp_path / 'mobile' / 'projects.json'
     persisted_root = tmp_path / 'persisted'
@@ -370,6 +438,7 @@ def test_server_cli_reuses_handoff_and_update_rotation_preserves_claimed_device(
         thread.join(timeout=2)
 
 
+@requires_af_unix
 def test_prepare_server_mobile_gateway_uses_published_registry_without_proc(
     tmp_path: Path,
     monkeypatch,

--- a/test/test_mobile_cli_service.py
+++ b/test/test_mobile_cli_service.py
@@ -21,6 +21,7 @@ from mobile_gateway import (
     load_mobile_gateway_project_registry,
     publish_mobile_gateway_project,
 )
+from mobile_gateway.project_registry import _control_plane_endpoint_is_structurally_valid
 from project.ids import compute_project_id
 
 
@@ -28,6 +29,28 @@ requires_af_unix = pytest.mark.skipif(
     not hasattr(socket, 'AF_UNIX'),
     reason='requires AF_UNIX socket support',
 )
+
+
+def _windows_tcp_loopback_endpoint(*, token_ref: str, **overrides) -> dict:
+    endpoint = {
+        'kind': 'tcp_loopback',
+        'host': '127.0.0.1',
+        'port': 32123,
+        'token_ref': token_ref,
+        'generation': 'test',
+        'acl_status': 'windows-icacls-user-read',
+        'fingerprint': 'deadbeefcafebabe',
+    }
+    endpoint.update(overrides)
+    return endpoint
+
+
+def _write_windows_tcp_marker(project_root: Path, *, endpoint: dict) -> Path:
+    socket_path = project_root / '.ccb' / 'ccbd' / 'ccbd.sock'
+    socket_path.parent.mkdir(parents=True)
+    socket_path.touch()
+    write_endpoint(endpoint_from_record(endpoint), legacy_socket_path=socket_path)
+    return socket_path
 
 
 class _FakeCcbdClient:
@@ -189,6 +212,121 @@ def test_host_project_registry_omits_windows_marker_with_invalid_endpoint(tmp_pa
     )
     publish_mobile_gateway_project(
         project_id='proj-windows-invalid',
+        project_root=project_root,
+        ccbd_socket_path=socket_path,
+        registry_path=registry_path,
+    )
+
+    with pytest.raises(ValueError, match='cannot be empty'):
+        load_mobile_gateway_project_registry(registry_path=registry_path)
+
+
+def test_windows_tcp_marker_without_endpoint_descriptor_is_invalid(tmp_path: Path) -> None:
+    socket_path = tmp_path / '.ccb' / 'ccbd' / 'ccbd.sock'
+    socket_path.parent.mkdir(parents=True)
+    socket_path.touch()
+
+    assert _control_plane_endpoint_is_structurally_valid(socket_path) is False
+
+
+def test_windows_tcp_marker_with_unix_kind_descriptor_is_invalid(tmp_path: Path) -> None:
+    socket_path = tmp_path / '.ccb' / 'ccbd' / 'ccbd.sock'
+    socket_path.parent.mkdir(parents=True)
+    socket_path.touch()
+    (socket_path.parent / 'control-plane-endpoint.json').write_text(
+        json.dumps({'kind': 'unix_socket', 'address': str(socket_path)}),
+        encoding='utf-8',
+    )
+
+    assert _control_plane_endpoint_is_structurally_valid(socket_path) is False
+
+
+def test_windows_tcp_marker_missing_token_ref_is_invalid(tmp_path: Path) -> None:
+    socket_path = _write_windows_tcp_marker(
+        tmp_path,
+        endpoint=_windows_tcp_loopback_endpoint(token_ref=''),
+    )
+
+    assert _control_plane_endpoint_is_structurally_valid(socket_path) is False
+
+
+def test_windows_tcp_marker_with_off_loopback_host_is_invalid(tmp_path: Path) -> None:
+    socket_path = _write_windows_tcp_marker(
+        tmp_path,
+        endpoint=_windows_tcp_loopback_endpoint(token_ref='token', host='192.168.2.11'),
+    )
+
+    assert _control_plane_endpoint_is_structurally_valid(socket_path) is False
+
+
+def test_windows_tcp_marker_with_valid_descriptor_is_valid(tmp_path: Path) -> None:
+    socket_path = _write_windows_tcp_marker(
+        tmp_path,
+        endpoint=_windows_tcp_loopback_endpoint(token_ref=str(tmp_path / 'token.json')),
+    )
+
+    assert _control_plane_endpoint_is_structurally_valid(socket_path) is True
+
+
+@requires_af_unix
+def test_real_unix_socket_is_valid_without_endpoint_descriptor(tmp_path: Path) -> None:
+    socket_path = tmp_path / 'ccbd.sock'
+    unix_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    unix_socket.bind(str(socket_path))
+    try:
+        assert _control_plane_endpoint_is_structurally_valid(socket_path) is True
+    finally:
+        unix_socket.close()
+        socket_path.unlink(missing_ok=True)
+
+
+def test_host_project_registry_omits_windows_marker_without_descriptor(tmp_path: Path) -> None:
+    registry_path = tmp_path / 'mobile' / 'projects.json'
+    project_root = tmp_path / 'windows-project'
+    project_root.mkdir()
+    socket_path = project_root / '.ccb' / 'ccbd' / 'ccbd.sock'
+    socket_path.parent.mkdir(parents=True)
+    socket_path.touch()
+    publish_mobile_gateway_project(
+        project_id='proj-windows-noendpoint',
+        project_root=project_root,
+        ccbd_socket_path=socket_path,
+        registry_path=registry_path,
+    )
+
+    with pytest.raises(ValueError, match='cannot be empty'):
+        load_mobile_gateway_project_registry(registry_path=registry_path)
+
+
+def test_host_project_registry_omits_windows_marker_without_token_ref(tmp_path: Path) -> None:
+    registry_path = tmp_path / 'mobile' / 'projects.json'
+    project_root = tmp_path / 'windows-project'
+    project_root.mkdir()
+    socket_path = _write_windows_tcp_marker(
+        project_root,
+        endpoint=_windows_tcp_loopback_endpoint(token_ref=''),
+    )
+    publish_mobile_gateway_project(
+        project_id='proj-windows-notoken',
+        project_root=project_root,
+        ccbd_socket_path=socket_path,
+        registry_path=registry_path,
+    )
+
+    with pytest.raises(ValueError, match='cannot be empty'):
+        load_mobile_gateway_project_registry(registry_path=registry_path)
+
+
+def test_host_project_registry_omits_windows_marker_with_off_loopback_host(tmp_path: Path) -> None:
+    registry_path = tmp_path / 'mobile' / 'projects.json'
+    project_root = tmp_path / 'windows-project'
+    project_root.mkdir()
+    socket_path = _write_windows_tcp_marker(
+        project_root,
+        endpoint=_windows_tcp_loopback_endpoint(token_ref='token', host='192.168.2.11'),
+    )
+    publish_mobile_gateway_project(
+        project_id='proj-windows-offloop',
         project_root=project_root,
         ccbd_socket_path=socket_path,
         registry_path=registry_path,

--- a/test/test_mobile_host_service.py
+++ b/test/test_mobile_host_service.py
@@ -63,6 +63,39 @@ def _claimable_pairing_payload(state_dir: Path) -> dict[str, object]:
     )
 
 
+def _write_spawned_child_state(
+    state_dir: Path,
+    *,
+    pid: int = 222,
+    generation: int = 1,
+    listen: str = '127.0.0.1:8787',
+    gateway_url: str = 'https://desktop.tailnet.ts.net:8787',
+    route_provider: str = 'tailnet',
+) -> None:
+    paths = mobile_host_service_paths(state_dir)
+    write_mobile_host_service_state(
+        paths.state_path,
+        {
+            'schema_version': 1,
+            'record_type': MOBILE_HOST_SERVICE_RECORD_TYPE,
+            'pid': pid,
+            'generation': generation,
+            'listen': listen,
+            'local_gateway_url': f'http://{listen}',
+            'gateway_url': gateway_url,
+            'route_provider': route_provider,
+            'pairing': {
+                **_pairing_payload(),
+                'gateway_url': gateway_url,
+                'claim_endpoint': f'{gateway_url}/v1/pairing/claim',
+                'route_provider': route_provider,
+            },
+            'state_dir': str(state_dir),
+            'command_kind': 'ccb_mobile_host_serve',
+        },
+    )
+
+
 def test_mobile_host_service_clears_stale_state_and_starts(tmp_path: Path) -> None:
     state_dir = tmp_path / 'mobile'
     paths = mobile_host_service_paths(state_dir)
@@ -80,6 +113,8 @@ def test_mobile_host_service_clears_stale_state_and_starts(tmp_path: Path) -> No
 
     def _spawn(command, **kwargs):
         spawned.append({'command': command, **kwargs})
+        generation = int(command[command.index('--generation') + 1])
+        _write_spawned_child_state(state_dir, generation=generation)
         return _FakeProcess(222)
 
     result = start_or_replace_mobile_host_service(
@@ -102,7 +137,7 @@ def test_mobile_host_service_clears_stale_state_and_starts(tmp_path: Path) -> No
     assert spawned[0]['cwd'] == str(Path.cwd())
     assert spawned[0]['env']['CCB_MOBILE_HOST_STATE_HOME'] == str(state_dir)
     assert spawned[0]['env']['CCB_SOURCE_RUNTIME_OK'] == '1'
-    assert not paths.state_path.exists()
+    assert paths.state_path.exists()
 
 
 def test_mobile_host_health_check_tolerates_server_wide_health_latency() -> None:
@@ -189,26 +224,10 @@ def test_mobile_host_service_returns_pairing_written_by_spawned_child(
     tmp_path: Path,
 ) -> None:
     state_dir = tmp_path / 'mobile'
-    paths = mobile_host_service_paths(state_dir)
 
     def _spawn(command, **_kwargs):
         generation = int(command[command.index('--generation') + 1])
-        write_mobile_host_service_state(
-            paths.state_path,
-            {
-                'schema_version': 1,
-                'record_type': MOBILE_HOST_SERVICE_RECORD_TYPE,
-                'pid': 222,
-                'generation': generation,
-                'listen': '127.0.0.1:8787',
-                'local_gateway_url': 'http://127.0.0.1:8787',
-                'gateway_url': 'https://desktop.tailnet.ts.net:8787',
-                'route_provider': 'tailnet',
-                'pairing': _pairing_payload(),
-                'state_dir': str(state_dir),
-                'command_kind': 'ccb_mobile_host_serve',
-            },
-        )
+        _write_spawned_child_state(state_dir, generation=generation)
         return _FakeProcess(222)
 
     result = start_or_replace_mobile_host_service(
@@ -465,6 +484,11 @@ def test_mobile_host_service_replaces_live_managed_process(tmp_path: Path) -> No
         alive.discard(pid)
         return True
 
+    def _spawn(command, **_kwargs):
+        generation = int(command[command.index('--generation') + 1])
+        _write_spawned_child_state(state_dir, generation=generation)
+        return _FakeProcess(222)
+
     result = start_or_replace_mobile_host_service(
         script_root=tmp_path / 'source',
         listen='127.0.0.1:8787',
@@ -475,7 +499,7 @@ def test_mobile_host_service_replaces_live_managed_process(tmp_path: Path) -> No
         process_cmdline_fn=lambda pid: f'python ccb.py {MOBILE_HOST_SERVE_COMMAND} --state-dir {state_dir}' if pid == 111 else '',
         terminate_pid_tree_fn=_terminate,
         port_owner_fn=lambda _listen: None,
-        spawn_fn=lambda *_args, **_kwargs: _FakeProcess(222),
+        spawn_fn=_spawn,
         health_check_fn=lambda _url: True,
     )
 
@@ -483,6 +507,65 @@ def test_mobile_host_service_replaces_live_managed_process(tmp_path: Path) -> No
     assert result.status == 'replaced'
     assert result.replaced_pid == 111
     assert result.generation == 5
+
+
+def test_mobile_host_service_waits_for_pairing_state_after_health_ready(
+    tmp_path: Path,
+) -> None:
+    state_dir = tmp_path / 'mobile'
+    paths = mobile_host_service_paths(state_dir)
+    reads = 0
+    tick = -0.01
+
+    def _spawn(command, **_kwargs):
+        generation = int(command[command.index('--generation') + 1])
+        write_mobile_host_service_state(
+            paths.state_path,
+            {
+                'schema_version': 1,
+                'record_type': MOBILE_HOST_SERVICE_RECORD_TYPE,
+                'pid': 222,
+                'generation': generation,
+                'listen': '127.0.0.1:8787',
+                'local_gateway_url': 'http://127.0.0.1:8787',
+                'gateway_url': 'https://desktop.tailnet.ts.net:8787',
+                'route_provider': 'tailnet',
+                'state_dir': str(state_dir),
+                'command_kind': 'ccb_mobile_host_serve',
+            },
+        )
+        return _FakeProcess(222)
+
+    def _monotonic() -> float:
+        nonlocal tick
+        tick += 0.01
+        return tick
+
+    def _sleep(_seconds: float) -> None:
+        nonlocal reads
+        reads += 1
+        if reads == 1:
+            state = json.loads(paths.state_path.read_text(encoding='utf-8'))
+            state['pairing'] = _pairing_payload()
+            write_mobile_host_service_state(paths.state_path, state)
+
+    result = start_or_replace_mobile_host_service(
+        script_root=tmp_path / 'source',
+        listen='127.0.0.1:8787',
+        public_url='https://desktop.tailnet.ts.net:8787',
+        route_provider='tailnet',
+        state_dir=state_dir,
+        process_exists_fn=lambda _pid: False,
+        port_owner_fn=lambda _listen: None,
+        spawn_fn=_spawn,
+        health_check_fn=lambda _url: True,
+        sleep_fn=_sleep,
+        monotonic_fn=_monotonic,
+    )
+
+    assert result.status == 'started'
+    assert result.pairing == _pairing_payload()
+    assert reads == 1
 
 
 def test_mobile_host_service_refuses_external_port_owner(tmp_path: Path) -> None:
@@ -509,6 +592,7 @@ def test_mobile_host_service_refuses_external_port_owner(tmp_path: Path) -> None
 
 def test_mobile_host_service_replaces_legacy_foreground_gateway(tmp_path: Path) -> None:
     source_root = tmp_path / 'source'
+    state_dir = tmp_path / 'mobile'
     legacy_command = (
         f'python {source_root / "ccb.py"} install mobile '
         '--listen 127.0.0.1:8787 --route-provider lan'
@@ -521,19 +605,29 @@ def test_mobile_host_service_replaces_legacy_foreground_gateway(tmp_path: Path) 
         alive.discard(pid)
         return True
 
+    def _spawn(command, **_kwargs):
+        generation = int(command[command.index('--generation') + 1])
+        _write_spawned_child_state(
+            state_dir,
+            generation=generation,
+            gateway_url='http://127.0.0.1:8787',
+            route_provider='lan',
+        )
+        return _FakeProcess(222)
+
     result = start_or_replace_mobile_host_service(
         script_root=source_root,
         listen='127.0.0.1:8787',
         public_url=None,
         route_provider='lan',
-        state_dir=tmp_path / 'mobile',
+        state_dir=state_dir,
         process_exists_fn=lambda pid: pid in alive,
         process_cmdline_fn=lambda pid: legacy_command if pid == 333 else '',
         terminate_pid_tree_fn=_terminate,
         port_owner_fn=lambda _listen: (
             PortOwner(pid=333, command=legacy_command) if 333 in alive else None
         ),
-        spawn_fn=lambda *_args, **_kwargs: _FakeProcess(222),
+        spawn_fn=_spawn,
         health_check_fn=lambda _url: True,
     )
 
@@ -640,7 +734,13 @@ def test_mobile_host_service_waits_for_concurrent_update_to_finish(tmp_path: Pat
 
     def _sleep(seconds: float) -> None:
         sleeps.append(seconds)
-        paths.lock_path.unlink()
+        if paths.lock_path.exists():
+            paths.lock_path.unlink()
+
+    def _spawn(*_args, **_kwargs):
+        spawned.append(1)
+        _write_spawned_child_state(paths.state_dir)
+        return _FakeProcess(222)
 
     result = start_or_replace_mobile_host_service(
         script_root=tmp_path / 'source',
@@ -650,7 +750,7 @@ def test_mobile_host_service_waits_for_concurrent_update_to_finish(tmp_path: Pat
         state_dir=paths.state_dir,
         process_exists_fn=lambda pid: pid == 999,
         port_owner_fn=lambda _listen: None,
-        spawn_fn=lambda *_args, **_kwargs: spawned.append(1) or _FakeProcess(222),
+        spawn_fn=_spawn,
         health_check_fn=lambda _url: True,
         sleep_fn=_sleep,
         monotonic_fn=_monotonic,
@@ -747,6 +847,34 @@ def test_detect_loopback_port_owner_uses_lsof_when_ss_is_missing(monkeypatch: py
     assert owner == PortOwner(pid=444, command='python gateway.py')
 
 
+def test_detect_loopback_port_owner_uses_windows_netstat(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _run(command, **_kwargs):
+        assert command == ['netstat', '-ano', '-p', 'tcp']
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=(
+                '  Proto  Local Address          Foreign Address        State           PID\n'
+                '  TCP    127.0.0.1:8787         0.0.0.0:0              LISTENING       111\n'
+                '  TCP    192.168.31.155:8787    0.0.0.0:0              LISTENING       555\n'
+            ),
+            stderr='',
+        )
+
+    monkeypatch.setattr(mobile_host.os, 'name', 'nt')
+    monkeypatch.setattr(mobile_host.subprocess, 'run', _run)
+    monkeypatch.setattr(mobile_host, '_process_cmdline', lambda pid: 'python mobile.py' if pid == 555 else '')
+
+    owner = mobile_host._detect_loopback_port_owner_netstat(
+        host='192.168.31.155',
+        port=8787,
+    )
+
+    assert owner == PortOwner(pid=555, command='python mobile.py')
+
+
 def test_detect_loopback_port_owner_accepts_specific_private_lan_address(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -780,7 +908,11 @@ def test_mobile_host_service_rejects_private_listen_for_non_lan_route(
 def test_detect_loopback_port_owner_reports_unknown_when_tools_are_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    def _run(command, **_kwargs):
+        return subprocess.CompletedProcess(command, 0, stdout='', stderr='')
+
     monkeypatch.setattr(mobile_host.shutil, 'which', lambda _name: None)
+    monkeypatch.setattr(mobile_host.subprocess, 'run', _run)
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server:
         server.bind(('127.0.0.1', 0))
         server.listen()


### PR DESCRIPTION
## 背景

Windows 原生环境（herdr-native 后端）下执行：

```
ccb update mobile --route-provider lan --listen <LAN_IP>:8787
```

会失败：`ValueError: no running CCB projects found for mobile server setup`。

**根因**：Win 原生 ccbd 控制平面是 `tcp_loopback`（127.0.0.1 + token），`.sock` 仅为 0 字节 marker 文件，真实连接信息在旁边的 `control-plane-endpoint.json`。但 mobile host 项目注册表加载时用 `Path.is_socket()` 校验记录，把 Windows marker 误判为不可用而过滤掉，最终注册表为空、网关无法服务任何项目。

**实测结论**：`CcbdClient(.ccb/ccbd/ccbd.sock).ping('ccbd')` 在 Win 原生下可用（客户端层已适配 Windows TCP loopback），断点仅在注册表加载层的 `is_socket()` 误判。

## 改动（2 个提交）

### 1. 引入结构校验 + host 就绪等待
- `lib/mobile_gateway/project_registry.py`：新增 `_control_plane_endpoint_is_structurally_valid()` —— 真实 unix socket 直接通过；否则读取 `control-plane-endpoint.json` 判定 Windows TCP 描述符。两处 `is_socket()` 校验统一替换。
- `lib/cli/services/mobile_host.py`：等待子进程发布配对状态（`_wait_for_mobile_host_state_ready`），提前退出时携带 `exit_code` 与日志尾部；Windows 下用 `netstat -ano` 检测环回端口占用、PowerShell `Get-CimInstance` 读取进程命令行；`shlex.split` 按平台选择 posix 模式。
- 新增对应测试。

### 2. 加固结构校验
- 结构校验新增 `token_ref`/`auth_ref` 存在性与 `127.0.0.1` loopback host 判定，拒绝必然无法连接的记录；仍为纯文件读、加载期不发起网络连接。
- 新增结构校验单元测试与 registry 过滤集成测试（无描述符 / unix_socket kind / 缺 token / off-loopback host 均被过滤）。

## 验证

- `test_mobile_cli_service.py`、`test_mobile_host_service.py`：**52 passed, 5 skipped**（AF_UNIX 环境跳过）
- 修复后 `ccb update mobile --route-provider lan --listen <LAN_IP>:8787` 可正常出 QR/配对码

## 影响

LAN / Tailscale / 官方 Relay / 自建 Relay 四种路由共用同一项目发现入口，本修复为其共同前置；POSIX 行为不变（真实 unix socket 硬校验保留）。
