### PR TITLE
fix(windows): 原生 Windows 下进程存活判定与命令行解析适配

### DIFF
--- a/lib/cli/kill_runtime/processes.py
+++ b/lib/cli/kill_runtime/processes.py
@@ -28,6 +28,8 @@ def kill_pid(pid: int, *, force: bool = False) -> bool:
 def is_pid_alive(pid: int) -> bool:
     if pid <= 0:
         return False
+    if os.name == "nt":
+        return _is_pid_alive_windows(pid)
     try:
         os.kill(pid, 0)
     except ProcessLookupError:
@@ -39,6 +41,28 @@ def is_pid_alive(pid: int) -> bool:
     if _proc_pid_state(pid) == "Z":
         return False
     return True
+
+
+def _is_pid_alive_windows(pid: int) -> bool:
+    try:
+        import ctypes
+        from ctypes import wintypes
+    except Exception:
+        return False
+
+    process_query_limited_information = 0x1000
+    still_active = 259
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    handle = kernel32.OpenProcess(process_query_limited_information, False, int(pid))
+    if not handle:
+        return False
+    try:
+        exit_code = wintypes.DWORD()
+        if not kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+            return False
+        return int(exit_code.value) == still_active
+    finally:
+        kernel32.CloseHandle(handle)
 
 
 def terminate_pid_tree(

--- a/lib/runtime_accelerator/ownership.py
+++ b/lib/runtime_accelerator/ownership.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import shlex
 import shutil
 import subprocess
@@ -522,7 +523,7 @@ def _resolve_executable(value: str, *, cwd: Path | None) -> Path | None:
 
 def _split_cmdline(value: str) -> tuple[str, ...]:
     try:
-        return tuple(shlex.split(value))
+        return tuple(shlex.split(value, posix=os.name != "nt"))
     except ValueError:
         return ()
 

--- a/test/test_cli_kill_runtime_processes.py
+++ b/test/test_cli_kill_runtime_processes.py
@@ -42,7 +42,7 @@ def test_kill_pid_tree_once_prefers_process_group_on_posix(monkeypatch) -> None:
     _patch_process_os_name(monkeypatch, 'posix')
     monkeypatch.setattr(processes, '_safe_getpgid', lambda pid: 900)
     monkeypatch.setattr(processes, '_safe_getpgrp', lambda: 901)
-    monkeypatch.setattr(processes.os, 'killpg', lambda pgid, sig: killed.append((pgid, sig)))
+    monkeypatch.setattr(processes.os, 'killpg', lambda pgid, sig: killed.append((pgid, sig)), raising=False)
     monkeypatch.setattr(processes, 'kill_pid', lambda pid, force=False: kill_pid_calls.append((pid, force)) or True)
 
     assert processes._kill_pid_tree_once(123, force=False) is True
@@ -149,6 +149,7 @@ def test_collect_project_process_candidates_finds_legacy_accelerator_by_exact_cw
             start_token='proc:100',
         ),
     )
+    monkeypatch.setattr('runtime_accelerator.ownership.is_pid_alive', lambda pid: pid == 707)
 
     candidates = collect_project_process_candidates(
         project_root,

--- a/test/test_cli_kill_runtime_zombies.py
+++ b/test/test_cli_kill_runtime_zombies.py
@@ -1,10 +1,20 @@
 from __future__ import annotations
 
+import sys
+from types import SimpleNamespace
+
 import cli.kill_runtime.processes as processes
 import cli.kill_runtime.zombies as zombies
 
 
+def _patch_process_os_name(monkeypatch, name: str) -> None:
+    os_proxy = SimpleNamespace(**vars(processes.os))
+    os_proxy.name = name
+    monkeypatch.setattr(processes, 'os', os_proxy)
+
+
 def test_is_pid_alive_treats_procfs_zombie_as_dead(monkeypatch) -> None:
+    _patch_process_os_name(monkeypatch, 'posix')
     monkeypatch.setattr(processes.os, 'kill', lambda pid, sig: None)
     monkeypatch.setattr(processes, '_proc_pid_state', lambda pid: 'Z')
 
@@ -12,10 +22,42 @@ def test_is_pid_alive_treats_procfs_zombie_as_dead(monkeypatch) -> None:
 
 
 def test_is_pid_alive_keeps_uninterruptible_process_alive(monkeypatch) -> None:
+    _patch_process_os_name(monkeypatch, 'posix')
     monkeypatch.setattr(processes.os, 'kill', lambda pid, sig: None)
     monkeypatch.setattr(processes, '_proc_pid_state', lambda pid: 'D')
 
     assert processes.is_pid_alive(123) is True
+
+
+def test_is_pid_alive_uses_windows_exit_code(monkeypatch) -> None:
+    class _FakeDWORD:
+        def __init__(self) -> None:
+            self.value = 0
+
+    class _FakeKernel32:
+        def OpenProcess(self, _access, _inherit, pid):
+            return 99 if pid == 123 else 0
+
+        def GetExitCodeProcess(self, _handle, code_ref):
+            code_ref._obj.value = 259
+            return True
+
+        def CloseHandle(self, _handle):
+            return True
+
+    fake_wintypes = SimpleNamespace(DWORD=_FakeDWORD)
+    fake_ctypes = SimpleNamespace(
+        WinDLL=lambda _name, use_last_error=True: _FakeKernel32(),
+        byref=lambda obj: SimpleNamespace(_obj=obj),
+        wintypes=fake_wintypes,
+    )
+
+    _patch_process_os_name(monkeypatch, 'nt')
+    monkeypatch.setitem(sys.modules, 'ctypes', fake_ctypes)
+    monkeypatch.setitem(sys.modules, 'ctypes.wintypes', fake_wintypes)
+
+    assert processes.is_pid_alive(123) is True
+    assert processes.is_pid_alive(456) is False
 
 
 def test_find_all_zombie_sessions_filters_dead_parents() -> None:


### PR DESCRIPTION
## 背景

Win 原生（`os.name == 'nt'`）下若干进程/命令行处理仍按 POSIX 假设工作，导致 kill 流程与进程判定出现偏差。

## 改动

- `lib/cli/kill_runtime/processes.py`：`is_pid_alive()` 在 Windows 下改用 `OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION)` + `GetExitCodeProcess` 判定存活（兼容 STILL_ACTIVE=259），规避 `os.kill(pid, 0)` 在 Windows 上的语义差异。
- `lib/runtime_accelerator/ownership.py`：`shlex.split(value, posix=os.name != 'nt')`，适配 Windows 原生 cmdline 解析。
- 新增/修正测试：Windows 退出码存活判定、kill 相关回归。

## 验证

- `test_cli_kill_runtime_processes.py`、`test_cli_kill_runtime_zombies.py`：**15 passed**
