### PR TITLE
feat(herdr): 支持重连已持久化的 Herdr 会话

### DIFF
--- a/lib/platforms/windows/herdr/backend.py
+++ b/lib/platforms/windows/herdr/backend.py
@@ -380,6 +380,31 @@ class HerdrBackend(TerminalBackend):
         self._drop_namespace_refs(namespace_ref)
         return evidence
 
+    def attach_persisted_session(
+        self,
+        namespace: Mapping[str, object],
+        *,
+        pane_id: str | None = None,
+        pane_ref: Mapping[str, object] | None = None,
+    ) -> None:
+        namespace_ref = self._register_namespace(
+            self._namespace_ref_from_mapping(dict(namespace), operation="attach_persisted_session")
+        )
+        setattr(self, "_ccb_project_namespace_ref", namespace_ref)
+        pane_text = str((pane_ref or {}).get("pane_id") or pane_id or "").strip()
+        if not pane_text:
+            return
+        session_name = str((pane_ref or {}).get("session_name") or namespace_ref["session_name"]).strip()
+        pane = make_pane_ref(
+            backend_impl="herdr",
+            pane_id=pane_text,
+            session_name=session_name,
+            window_name=_optional_text((pane_ref or {}).get("window_name")),
+            agent_slug=_optional_text((pane_ref or {}).get("agent_slug")),
+        )
+        self._panes[pane_text] = pane
+        self._pane_namespaces[pane_text] = namespace_ref
+
     def namespace_ref(self, session_name: str, namespace_id: str) -> MuxNamespaceRefV2:
         return self._register_namespace(
             make_namespace_ref(
@@ -807,6 +832,11 @@ class HerdrBackend(TerminalBackend):
 
 def _token_value(tokens: Mapping[str, object], key: str) -> str:
     return str(tokens.get(str(key).lstrip("@")) or "").strip()
+
+
+def _optional_text(value: object) -> str | None:
+    text = str(value or "").strip()
+    return text or None
 
 
 def _root_pane_from_metadata(

--- a/lib/terminal_runtime/api.py
+++ b/lib/terminal_runtime/api.py
@@ -191,6 +191,7 @@ def get_backend_for_session(session_data: dict) -> Optional[TerminalBackend]:
         session_data=session_data,
         detect_terminal_fn=detect_terminal,
         tmux_backend_factory=TmuxBackend,
+        herdr_backend_factory=_herdr_backend_for_persisted_session_factory,
     )
 
 
@@ -237,6 +238,21 @@ def _herdr_backend_factory() -> HerdrBackend:
     )
 
 
+def _herdr_backend_for_persisted_session_factory() -> HerdrBackend:
+    capabilities = _herdr_persisted_session_capability_report()
+    request_adapter = _herdr_request_adapter()
+    return HerdrBackend(
+        client=HerdrSocketClient(
+            request_fn=request_adapter,
+            socket_ref=request_adapter.socket_ref,
+            allow_session_scoped_ipc_refs=bool(
+                getattr(request_adapter, "allow_session_scoped_ipc_refs", False)
+            ),
+        ),
+        capability_gate=_herdr_capability_gate(capabilities),
+    )
+
+
 def get_backend_for_namespace_teardown(namespace_ref: Mapping[str, object]) -> HerdrBackend:
     """Build a Herdr backend that can tear down an already-persisted namespace.
 
@@ -261,6 +277,93 @@ def get_backend_for_namespace_teardown(namespace_ref: Mapping[str, object]) -> H
     )
     setattr(backend, "_ccb_project_namespace_ref", dict(namespace_ref))
     return backend
+
+
+def _herdr_persisted_session_capability_report() -> dict[str, object]:
+    """Capability evidence for re-attaching to an already persisted Herdr session."""
+    statuses = {
+        "session_attach": "supported",
+        "pane_spawn": "supported",
+        "send_input": "supported",
+        "read_output": "supported",
+        "kill_pane": "supported",
+        "workspace_create": "supported",
+        "workspace_list": "supported",
+        "workspace_focus": "supported",
+        "workspace_close": "supported",
+        "workspace_metadata": "supported",
+        "pane_metadata": "supported",
+        "pane_list": "supported",
+        "pane_split": "supported",
+        "pane_run": "supported",
+    }
+    report: dict[str, object] = {
+        "backend_impl": "herdr",
+        "command_status": dict(statuses),
+        "semantic_status": dict(statuses),
+        "blocking_gaps": [],
+        "windows_beta_gaps": [],
+        "adapter_recommendation": "continue-with-gaps",
+        "verdict": "partial",
+        "failure_class": "windows-beta-gap",
+        "source_ref": "persisted-session",
+    }
+    live_report = _herdr_capability_report()
+    if live_report is None:
+        return report
+    if live_report.get("blocked") is True:
+        return dict(live_report)
+    return _intersect_herdr_capability_reports(report, live_report)
+
+
+def _intersect_herdr_capability_reports(
+    persisted_report: dict[str, object],
+    live_report: Mapping[str, object],
+) -> dict[str, object]:
+    merged = dict(persisted_report)
+    merged["source_ref"] = (
+        str(live_report.get("source_ref") or "").strip()
+        or str(persisted_report.get("source_ref") or "").strip()
+    )
+    for key in ("command_status", "semantic_status"):
+        persisted_status = persisted_report.get(key)
+        live_status = live_report.get(key)
+        if not isinstance(persisted_status, Mapping) or not isinstance(live_status, Mapping):
+            merged[key] = {}
+            continue
+        merged[key] = {
+            str(name): (
+                "supported"
+                if status == "supported" and live_status.get(name) == "supported"
+                else str(live_status.get(name) or "unsupported")
+            )
+            for name, status in persisted_status.items()
+        }
+    merged["blocking_gaps"] = sorted(
+        {
+            str(item)
+            for item in _list_items(persisted_report.get("blocking_gaps"))
+            + _list_items(live_report.get("blocking_gaps"))
+            if str(item).strip()
+        }
+    )
+    merged["windows_beta_gaps"] = sorted(
+        {
+            str(item)
+            for item in _list_items(persisted_report.get("windows_beta_gaps"))
+            + _list_items(live_report.get("windows_beta_gaps"))
+            if str(item).strip()
+        }
+    )
+    for key in ("adapter_recommendation", "verdict", "failure_class"):
+        value = live_report.get(key)
+        if isinstance(value, str) and value.strip():
+            merged[key] = value
+    return {str(key): value for key, value in merged.items()}
+
+
+def _list_items(value: object) -> list[object]:
+    return list(value) if isinstance(value, list) else []
 
 
 def _herdr_teardown_capability_report() -> dict[str, object]:

--- a/lib/terminal_runtime/api_selection.py
+++ b/lib/terminal_runtime/api_selection.py
@@ -30,10 +30,12 @@ def resolve_backend_for_session(
     session_data: dict,
     detect_terminal_fn,
     tmux_backend_factory,
+    herdr_backend_factory=None,
 ):
     return TerminalBackendSelection(
         detect_terminal_fn=detect_terminal_fn,
         tmux_backend_factory=tmux_backend_factory,
+        herdr_backend_factory=herdr_backend_factory,
     ).get_backend_for_session(session_data)
 
 

--- a/lib/terminal_runtime/backend_selection.py
+++ b/lib/terminal_runtime/backend_selection.py
@@ -10,6 +10,7 @@ from provider_runtime.session_payload import (
     backend_impl_from_session,
     namespace_ref_from_session,
     pane_id_from_session,
+    pane_ref_from_session,
 )
 from terminal_runtime.backend_resolver import resolve_mux_backend_v2
 from terminal_runtime.layouts import LayoutResult, create_tmux_auto_layout
@@ -120,7 +121,15 @@ class TerminalBackendSelection:
             backend = self.herdr_backend_factory()
             namespace_ref = namespace_ref_from_session(session_data)
             if namespace_ref is not None:
-                setattr(backend, '_ccb_project_namespace_ref', namespace_ref)
+                attach = getattr(backend, 'attach_persisted_session', None)
+                if callable(attach):
+                    attach(
+                        namespace_ref,
+                        pane_id=pane_id_from_session(session_data),
+                        pane_ref=pane_ref_from_session(session_data),
+                    )
+                else:
+                    setattr(backend, '_ccb_project_namespace_ref', namespace_ref)
             return backend
         if backend_impl not in {None, 'tmux', 'rmux', 'psmux'}:
             raise ValueError(f'unsupported session backend_impl: {backend_impl}')

--- a/test/test_claude_session_ensure_pane.py
+++ b/test/test_claude_session_ensure_pane.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+import terminal_runtime.api as terminal_api
 from provider_backends.claude.session_runtime.model import ClaudeProjectSession
 from provider_backends.pane_log_support import lifecycle
 
@@ -24,6 +25,24 @@ class _HerdrBackend:
     def respawn_pane(self, *args, **kwargs) -> None:
         self.respawn_calls.append((args, kwargs))
         raise AssertionError('Claude Herdr ensure_pane must not use tmux rebound respawn')
+
+
+class _FakeHerdrRequestAdapter:
+    socket_ref = 'herdr://local'
+
+    def __call__(self, operation: str, payload: dict[str, object]) -> dict[str, object]:
+        if operation == 'server_info':
+            return {
+                'version': 'herdr 0.7.5-preview',
+                'api_schema': 'Herdr API',
+                'platform': 'windows',
+                'arch': 'x64',
+            }
+        if operation == 'capture_pane':
+            assert payload['pane_id'] == 'pane-claude-2'
+            assert payload['session_name'] == 'ccb-demo'
+            return {'status': 'ok', 'pane_id': payload['pane_id'], 'text': 'ready'}
+        raise AssertionError(f'unexpected Herdr operation: {operation}')
 
 
 def test_claude_herdr_ensure_pane_uses_backend_neutral_pane_ref(
@@ -65,3 +84,41 @@ def test_claude_herdr_ensure_pane_uses_backend_neutral_pane_ref(
     assert backend.is_alive_calls == [pane_ref]
     assert backend.ensure_log_calls == [pane_ref]
     assert backend.respawn_calls == []
+
+
+def test_claude_herdr_ensure_pane_uses_session_backend_wrapper_for_persisted_session(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv('CCB_HERDR_CAPABILITY_REPORT', raising=False)
+    monkeypatch.setattr(terminal_api, '_herdr_request_adapter', lambda: _FakeHerdrRequestAdapter())
+
+    def _fail_tmux_ownership(*args, **kwargs):
+        raise AssertionError('Claude Herdr ensure_pane must not inspect tmux ownership')
+
+    monkeypatch.setattr(lifecycle, 'inspect_tmux_pane_ownership', _fail_tmux_ownership)
+    session = ClaudeProjectSession(
+        session_file=tmp_path / '.claude-session',
+        data={
+            'ccb_session_id': 'ccb-claude1-1',
+            'agent_name': 'claude1',
+            'terminal': 'mux',
+            'backend_impl': 'herdr',
+            'namespace_ref': {
+                'backend_family': 'herdr-native',
+                'backend_impl': 'herdr',
+                'namespace_id': 'wC',
+                'session_name': 'ccb-demo',
+                'ipc_kind': 'herdr_socket',
+                'ipc_ref': 'herdr://local',
+            },
+            'pane_id': 'pane-claude-2',
+            'runtime_dir': str(tmp_path),
+            'work_dir': str(tmp_path),
+            'active': True,
+        },
+    )
+
+    ok, pane = session.ensure_pane()
+
+    assert (ok, pane) == (True, 'pane-claude-2')

--- a/test/test_herdr_backend_client.py
+++ b/test/test_herdr_backend_client.py
@@ -1670,6 +1670,69 @@ def test_terminal_api_get_backend_threads_production_herdr_wiring(monkeypatch) -
     assert isinstance(backend, HerdrBackend)
 
 
+def test_terminal_api_get_backend_for_session_reattaches_persisted_herdr_pane_without_env(
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("CCB_HERDR_CAPABILITY_REPORT", raising=False)
+    monkeypatch.setattr(terminal_api, "_herdr_request_adapter", lambda: _FakeRequestAdapter())
+
+    backend = terminal_api.get_backend_for_session(
+        {
+            "terminal": "mux",
+            "backend_impl": "herdr",
+            "namespace_ref": {
+                "backend_family": "herdr-native",
+                "backend_impl": "herdr",
+                "namespace_id": "wC",
+                "session_name": "ccb-demo",
+                "ipc_kind": "herdr_socket",
+                "ipc_ref": "herdr://local",
+            },
+            "pane_id": "wC:p1",
+        }
+    )
+
+    assert isinstance(backend, HerdrBackend)
+    assert backend.is_alive("wC:p1") is True
+    backend.send_text("wC:p1", "secret typed text")
+    assert getattr(backend, "_ccb_project_namespace_ref")["namespace_id"] == "wC"
+    backend._capability_gate.require_supported("capture_pane")
+    backend._capability_gate.require_supported("send_text")
+
+
+def test_terminal_api_get_backend_for_session_preserves_stricter_live_capability_report(
+    monkeypatch,
+) -> None:
+    capabilities = dict(_supported_gate().capabilities or {})
+    capabilities["command_status"] = dict(capabilities["command_status"])
+    capabilities["semantic_status"] = dict(capabilities["semantic_status"])
+    capabilities["command_status"]["send_input"] = "unsupported"
+    capabilities["semantic_status"]["send_input"] = "unsupported"
+    monkeypatch.setattr(terminal_api, "_herdr_capability_report", lambda: capabilities)
+    monkeypatch.setattr(terminal_api, "_herdr_request_adapter", lambda: _FakeRequestAdapter())
+
+    backend = terminal_api.get_backend_for_session(
+        {
+            "terminal": "mux",
+            "backend_impl": "herdr",
+            "namespace_ref": {
+                "backend_family": "herdr-native",
+                "backend_impl": "herdr",
+                "namespace_id": "wC",
+                "session_name": "ccb-demo",
+                "ipc_kind": "herdr_socket",
+                "ipc_ref": "herdr://local",
+            },
+            "pane_id": "wC:p1",
+        }
+    )
+
+    with pytest.raises(MuxCommandErrorV2) as exc_info:
+        backend.send_text("wC:p1", "secret typed text")
+
+    assert exc_info.value.category == "unsupported"
+
+
 def test_terminal_api_get_backend_herdr_defaults_fail_closed(monkeypatch) -> None:
     monkeypatch.setattr(terminal_api, "_backend_cache", None)
     monkeypatch.delenv("CCB_HERDR_CAPABILITY_REPORT", raising=False)

--- a/test/test_terminal_runtime_backend_selection.py
+++ b/test/test_terminal_runtime_backend_selection.py
@@ -13,6 +13,17 @@ class _FakeBackend:
         self.name = name
 
 
+class _FakeHerdrBackend(_FakeBackend):
+    def __init__(self) -> None:
+        super().__init__('herdr')
+        self.persisted_sessions: list[dict[str, object]] = []
+
+    def attach_persisted_session(self, namespace_ref, *, pane_id=None, pane_ref=None) -> None:
+        self.persisted_sessions.append(
+            {'namespace_ref': namespace_ref, 'pane_id': pane_id, 'pane_ref': pane_ref}
+        )
+
+
 def test_backend_selection_caches_detected_backend() -> None:
     calls: list[str] = []
     selection = TerminalBackendSelection(
@@ -91,6 +102,37 @@ def test_backend_selection_uses_herdr_session_payload_without_tmux_fallback() ->
     assert backend.name == 'herdr'
     assert getattr(backend, '_ccb_project_namespace_ref') == namespace_ref
     assert tmux_calls == []
+
+
+def test_backend_selection_attaches_persisted_herdr_pane_without_pane_ref() -> None:
+    namespace_ref = {
+        'backend_family': 'herdr-native',
+        'backend_impl': 'herdr',
+        'namespace_id': 'ns-1',
+        'session_name': 'ccb-demo',
+        'ipc_kind': 'herdr_socket',
+        'ipc_ref': 'herdr://local',
+    }
+    backend = _FakeHerdrBackend()
+    selection = TerminalBackendSelection(
+        detect_terminal_fn=lambda: None,
+        tmux_backend_factory=lambda: _FakeBackend('tmux'),
+        herdr_backend_factory=lambda: backend,
+    )
+
+    resolved = selection.get_backend_for_session(
+        {
+            'terminal': 'mux',
+            'backend_impl': 'herdr',
+            'namespace_ref': namespace_ref,
+            'pane_id': 'pane-1',
+        }
+    )
+
+    assert resolved is backend
+    assert backend.persisted_sessions == [
+        {'namespace_ref': namespace_ref, 'pane_id': 'pane-1', 'pane_ref': None}
+    ]
 
 
 def test_backend_selection_uses_provider_runtime_backend_ref_for_herdr_session() -> None:

--- a/test/test_v2_runtime_launch.py
+++ b/test/test_v2_runtime_launch.py
@@ -1137,6 +1137,48 @@ def test_binding_runtime_alive_rejects_title_based_runtime_ref(monkeypatch) -> N
     assert calls == []
 
 
+def test_herdr_liveness_check_reattaches_persisted_session_without_capability_env(monkeypatch) -> None:
+    import terminal_runtime.api as terminal_api
+
+    class FakeHerdrRequestAdapter:
+        socket_ref = 'herdr://local'
+
+        def __call__(self, operation: str, payload: dict[str, object]) -> dict[str, object]:
+            if operation == 'server_info':
+                return {
+                    'version': 'herdr 0.7.5-preview',
+                    'api_schema': 'Herdr API',
+                    'platform': 'windows',
+                    'arch': 'x64',
+                }
+            if operation == 'capture_pane':
+                assert payload['pane_id'] == 'wC:p1'
+                assert payload['session_name'] == 'ccb-demo'
+                return {'status': 'ok', 'pane_id': payload['pane_id'], 'text': 'ready'}
+            raise AssertionError(f'unexpected Herdr operation: {operation}')
+
+    monkeypatch.delenv('CCB_HERDR_CAPABILITY_REPORT', raising=False)
+    monkeypatch.setattr(terminal_api, '_herdr_request_adapter', lambda: FakeHerdrRequestAdapter())
+    binding = SimpleNamespace(
+        pane_id='wC:p1',
+        session_ref={
+            'terminal': 'mux',
+            'backend_impl': 'herdr',
+            'namespace_ref': {
+                'backend_family': 'herdr-native',
+                'backend_impl': 'herdr',
+                'namespace_id': 'wC',
+                'session_name': 'ccb-demo',
+                'ipc_kind': 'herdr_socket',
+                'ipc_ref': 'herdr://local',
+            },
+            'pane_id': 'wC:p1',
+        },
+    )
+
+    assert runtime_launch._herdr_liveness_check(binding) is True
+
+
 def test_ensure_agent_runtime_resumes_named_codex_session_by_agent_name(monkeypatch, tmp_path: Path) -> None:
     project_root = tmp_path / 'repo-codex-resume'
     ccb_dir = project_root / '.ccb'


### PR DESCRIPTION
## Summary
- Add runtime API support for reconnecting persisted Herdr sessions.
- Wire Herdr backend/runtime selection for the reconnect path.
- Add focused tests for session pane handling, Herdr backend client behavior, backend selection, and runtime launch.

## Commit
- a8d69741 feat(herdr): 支持重连已持久化的 Herdr 会话

## Verification
- Not run in this PR creation step.