### PR TITLE
fix(claude): 长提示粘贴后激活丢失时有界补发一次 Enter

### DIFF
--- a/lib/provider_backends/claude/execution.py
+++ b/lib/provider_backends/claude/execution.py
@@ -84,6 +84,7 @@ class ClaudeProviderAdapter:
             'prompt_sent_at': submission.runtime_state.get('prompt_sent_at'),
             'activation_enter_count': submission.runtime_state.get('activation_enter_count'),
             'activation_enter_at': submission.runtime_state.get('activation_enter_at'),
+            'activation_enter_evidence': submission.runtime_state.get('activation_enter_evidence'),
             'reply_delivery_complete_on_dispatch': submission.runtime_state.get('reply_delivery_complete_on_dispatch'),
             'reply_delivery_require_ready': submission.runtime_state.get('reply_delivery_require_ready'),
             'ready_wait_started_at': submission.runtime_state.get('ready_wait_started_at'),

--- a/lib/provider_backends/claude/execution.py
+++ b/lib/provider_backends/claude/execution.py
@@ -82,6 +82,8 @@ class ClaudeProviderAdapter:
             'prompt_text': submission.runtime_state.get('prompt_text'),
             'prompt_sent': submission.runtime_state.get('prompt_sent'),
             'prompt_sent_at': submission.runtime_state.get('prompt_sent_at'),
+            'activation_enter_count': submission.runtime_state.get('activation_enter_count'),
+            'activation_enter_at': submission.runtime_state.get('activation_enter_at'),
             'reply_delivery_complete_on_dispatch': submission.runtime_state.get('reply_delivery_complete_on_dispatch'),
             'reply_delivery_require_ready': submission.runtime_state.get('reply_delivery_require_ready'),
             'ready_wait_started_at': submission.runtime_state.get('ready_wait_started_at'),

--- a/lib/provider_backends/claude/execution_runtime/polling.py
+++ b/lib/provider_backends/claude/execution_runtime/polling.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import re
 from dataclasses import replace
 
@@ -79,6 +80,16 @@ def poll_submission(
     )
     if pane_terminal is not None:
         return _merge_poll_result_items(pane_terminal, prefix_items=dispatch_items)
+    # Bounded one-time activation retry: re-send Enter once for a prompt that was
+    # pasted but never activated (see _maybe_resend_activation_enter).
+    activation_retry = _maybe_resend_activation_enter(
+        submission,
+        prepared=prepared,
+        poll=poll,
+        now=now,
+    )
+    if activation_retry is not None:
+        submission = activation_retry
     return _merge_poll_result_items(
         finalize_poll_result(submission, poll, state=state),
         prefix_items=dispatch_items,
@@ -309,6 +320,142 @@ def _pane_observably_idle(prepared) -> bool:
     if "esc to interrupt" in text.lower():
         return False
     return _has_idle_input_box(text)
+
+
+def _activation_grace_s() -> float:
+    """Seconds to wait after dispatch before a lost Enter is retried once."""
+    try:
+        return max(0.0, float(os.environ.get("CCB_CLAUDE_ACTIVATION_GRACE_S", 6.0)))
+    except Exception:
+        return 6.0
+
+
+def _activation_retry_window() -> tuple[float, float]:
+    """Bounded retry window ``[start_s, end_s)`` measured from ``prompt_sent_at``.
+
+    The retry Enter is only eligible inside this window: not before ``start_s``
+    (the initial paste may still be inserting, so a second Enter could be eaten
+    or become a stray newline) and not after ``end_s`` (give up; an operator
+    intervenes manually). Default ``[6.0, 12.0)`` for
+    ``CCB_CLAUDE_ACTIVATION_GRACE_S=6``.
+    """
+    grace_s = _activation_grace_s()
+    return grace_s, grace_s * 2.0
+
+
+def _elapsed_since(from_at: str, now: str) -> float | None:
+    try:
+        return (parse_utc_timestamp(now) - parse_utc_timestamp(from_at)).total_seconds()
+    except Exception:
+        return None
+
+
+def _pane_holds_current_job_marker(text: str, submission: ProviderSubmission) -> bool:
+    """True when the pane text still shows a recognizable marker of *this* job.
+
+    The wrapped prompt is ``CCB_REQ_ID: <request_anchor>``; ``no_wrap`` prompts
+    carry the anchor (job id) directly. An empty composer or a different job's
+    text must not match, so a retry Enter can never submit the wrong prompt.
+    """
+    if not str(text or ""):
+        return False
+    anchor = str(
+        submission.runtime_state.get("request_anchor")
+        or submission.job_id
+        or ""
+    ).strip()
+    if not anchor:
+        return False
+    if f"CCB_REQ_ID: {anchor}" in text:
+        return True
+    if "CCB_BEGIN" in text and anchor in text:
+        return True
+    return anchor in text
+
+
+def _maybe_resend_activation_enter(
+    submission: ProviderSubmission,
+    *,
+    prepared,
+    poll,
+    now: str,
+) -> ProviderSubmission | None:
+    """Bounded one-time activation Enter re-send for a sent-but-stuck prompt.
+
+    Root cause: tmux ``paste-buffer`` returns once bytes hit the pty, but the
+    Claude TUI consumes/renders a bracketed-paste stream asynchronously. For a
+    long (often multi-KB Unicode) prompt the initial Enter, sent
+    ``CCB_TMUX_ENTER_DELAY`` later, can land while the composer is still
+    inserting and be swallowed — the prompt stays in the composer, no request
+    anchor ever appears, and the job hangs in ``delivering`` until an operator
+    presses Enter manually.
+
+    There is no paste ACK in the TUI, so the request anchor is the only real
+    activation proof. This monitor re-sends Enter **at most once**, and only
+    while every one of these holds:
+
+    * the prompt was already dispatched (``prompt_sent``) with a timestamp;
+    * the current job is not yet activated (no ``prompt_activated``/``anchor_seen``);
+    * the elapsed time since dispatch is inside the bounded grace window;
+    * the pane is not busy (no ``esc to interrupt``) and still holds this job's
+      recognizable prompt/anchor text (an empty composer cannot match);
+    * this job has not already re-sent Enter (``activation_enter_count < 1``).
+
+    Any failing guard disables the retry: activated, empty composer, busy pane,
+    text that does not belong to this job, an expired grace window, or a prior
+    re-send. On a successful ``send_key`` the runtime state bumps
+    ``activation_enter_count`` so later polls never re-send. (``_has_idle_input_box``
+    only recognizes the empty ready box and would never fire for the stuck
+    composer that still holds the prompt text, so the marker check is the
+    effective "still this job, still submittable" guard.)
+    """
+    state = submission.runtime_state
+    if not bool(state.get("prompt_sent", False)):
+        return None
+    prompt_sent_at = str(state.get("prompt_sent_at") or "").strip()
+    if not prompt_sent_at:
+        return None
+    if int(state.get("activation_enter_count", 0) or 0) >= 1:
+        return None
+    if poll is not None and (
+        bool(getattr(poll, "anchor_seen", False))
+        or bool(getattr(poll, "prompt_activated", False))
+    ):
+        return None
+    elapsed = _elapsed_since(prompt_sent_at, now)
+    if elapsed is None:
+        return None
+    grace_start, grace_end = _activation_retry_window()
+    if elapsed < grace_start or elapsed >= grace_end:
+        return None
+    pane_id = getattr(prepared, "pane_id", None)
+    backend = getattr(prepared, "backend", None)
+    get_pane_content = getattr(backend, "get_pane_content", None)
+    send_key = getattr(backend, "send_key", None)
+    if not pane_id or not callable(get_pane_content) or not callable(send_key):
+        return None
+    try:
+        pane_text = str(get_pane_content(pane_id, lines=200) or "")
+    except Exception:
+        return None
+    if "esc to interrupt" in pane_text.lower():
+        return None
+    if not _pane_holds_current_job_marker(pane_text, submission):
+        return None
+    try:
+        sent = send_key(pane_id, "Enter")
+    except Exception:
+        return None
+    if not sent:
+        return None
+    return replace(
+        submission,
+        runtime_state={
+            **state,
+            "activation_enter_count": int(state.get("activation_enter_count", 0) or 0) + 1,
+            "activation_enter_at": now,
+        },
+    )
 
 
 def _merge_poll_result_items(result: ProviderPollResult, *, prefix_items: tuple) -> ProviderPollResult:

--- a/lib/provider_backends/claude/execution_runtime/polling.py
+++ b/lib/provider_backends/claude/execution_runtime/polling.py
@@ -364,6 +364,33 @@ def _elapsed_since(from_at: str, now: str) -> float | None:
 # composer row is the only evidence that this job's prompt is still pending.
 _PASTED_PLACEHOLDER_RE = re.compile(r"\[Pasted text #\d+\s+\+\s*\d+\s+lines?\]")
 
+# --- Prompt-tail fingerprint (third activation evidence) ---------------------
+# A long pasted prompt whose head (and request anchor) scrolled out of the pane
+# capture leaves only its *tail* visible in the expanded multi-line composer.
+# The tail of the submitted prompt — not the anchor and not the folded
+# placeholder — is then the only remaining proof that *this* job's input is
+# still pending. Generic control lines never form the fingerprint, and only the
+# current composer block is inspected, so a matching tail in scrollback/history
+# can never trigger.
+_GENERIC_CONTROL_LINE_RE = re.compile(
+    r"\b(?:CCB_REQ_ID|CCB_REPLY_MODE|CCB_BEGIN|CCB_END)\b",
+    re.IGNORECASE,
+)
+_TAIL_FRAGMENT_CHARS = 48        # tail fragment contributed per business line
+_TAIL_FINGERPRINT_MAX_LINES = 3  # last up-to-3 business lines
+_TAIL_MIN_LINE_CHARS = 10        # a business line must be this long to count as "long enough"
+_TAIL_MIN_TOTAL_CHARS = 28       # combined tail specificity floor
+_TAIL_MIN_MATCH = 2              # at least this many fragments must land, in order
+
+# Composer block boundaries: hint/status rows are never part of the input.
+_STATUS_HINT_RE = re.compile(
+    r"for shortcuts|esc to interrupt|type your message|for commands",
+    re.IGNORECASE,
+)
+_ARROW_ROW_RE = re.compile(r"^\s*[❯>]\s?(.*)$")
+_BOXED_ROW_RE = re.compile(r"^\s*[│|]\s*[❯>]?\s?(.*?)\s*[│|]\s*$")
+_TRANSCRIPT_ROLE_RE = re.compile(r"^\s*(?:user|assistant|system)\b", re.IGNORECASE)
+
 
 def _current_composer_content(text: str) -> str | None:
     """Content of the current Claude composer input row, decorations removed.
@@ -425,6 +452,175 @@ def _pane_holds_current_job_marker(text: str, submission: ProviderSubmission) ->
     return anchor in text
 
 
+def _collapse_whitespace(text: str) -> str:
+    """Collapse any whitespace run (incl. ``\\xa0``) to a single space."""
+    return " ".join(str(text).replace("\xa0", " ").split())
+
+
+def _strip_all_whitespace(text: str) -> str:
+    """Remove *all* whitespace — used for wrap-tolerant fingerprint matching.
+
+    A TUI-wrapped prompt line renders as several visual rows; stripping every
+    whitespace char on both sides lets a single logical line still match across
+    the wrap boundary (and across composer indentation).
+    """
+    return "".join(str(text).replace("\xa0", " ").split())
+
+
+def _prompt_tail_fingerprint(prompt_text: str) -> tuple[str, ...] | None:
+    """Stable, non-generic tail fingerprint of a submitted prompt.
+
+    Returns the tail fragments of the last 2-3 non-blank, non-control business
+    lines (``CCB_REQ_ID:`` / ``CCB_REPLY_MODE:`` / ``CCB_BEGIN`` / ``CCB_END``
+    are excluded). A line longer than ``_TAIL_FRAGMENT_CHARS`` contributes only
+    its trailing fragment, because an expanded composer shows the *tail* of a
+    long pasted prompt. Returns ``None`` when fewer than two usable lines remain
+    or the combined tail is too short to be specific.
+    """
+    business: list[str] = []
+    for raw in (prompt_text or "").splitlines():
+        line = _collapse_whitespace(raw)
+        if not line:
+            continue
+        if _GENERIC_CONTROL_LINE_RE.search(line):
+            continue
+        business.append(line)
+    if len(business) < 2:
+        return None
+    # Prefer the last up-to-3 business lines that are each long enough to be
+    # specific; otherwise fall back to the last business lines so a short final
+    # line can still anchor the tail.
+    long_lines = [line for line in business if len(line) >= _TAIL_MIN_LINE_CHARS]
+    tail = (
+        long_lines[-_TAIL_FINGERPRINT_MAX_LINES:]
+        if len(long_lines) >= 2
+        else business[-_TAIL_FINGERPRINT_MAX_LINES:]
+    )
+    fragments = tuple(
+        line[-_TAIL_FRAGMENT_CHARS:] if len(line) > _TAIL_FRAGMENT_CHARS else line
+        for line in tail
+    )
+    if len("".join(fragments)) < _TAIL_MIN_TOTAL_CHARS:
+        return None
+    return fragments
+
+
+def _composer_row_content(line: str) -> str:
+    """Content of a composer row with arrow/box decoration removed."""
+    arrow = _ARROW_ROW_RE.match(line)
+    if arrow:
+        return arrow.group(1)
+    boxed = _BOXED_ROW_RE.match(line)
+    if boxed:
+        return boxed.group(1)
+    return line
+
+
+def _is_composer_anchor_row(line: str) -> bool:
+    return bool(_ARROW_ROW_RE.match(line)) or bool(_BOXED_ROW_RE.match(line))
+
+
+def _is_input_block_boundary(line: str) -> bool:
+    """True when a row above/below the anchor is *not* part of this composer.
+
+    Boxed rows (``│ … │``) are always input; indented arrow-style continuation
+    rows are input; blank lines, hint/status rows, transcript-turn rows, and
+    col-0 (non-boxed) history lines are boundaries.
+    """
+    if not line.strip():
+        return True
+    if _is_composer_anchor_row(line):
+        return True  # a different (empty) composer row
+    if _BOXED_ROW_RE.match(line):
+        return False  # boxed rows are input, never a boundary
+    if _STATUS_HINT_RE.search(line):
+        return True
+    if _TRANSCRIPT_ROLE_RE.match(line):
+        return True
+    if not line[0].isspace():
+        return True  # col-0 non-boxed line = transcript/history boundary
+    return False
+
+
+def _current_composer_block(text: str) -> str | None:
+    """Full text of the *current* composer input block, decorations removed.
+
+    Supports the expanded multi-line composer and TUI-wrapped rows: the block is
+    the bottom-most composer anchor (``❯ ...`` / boxed ``│ ... │``) plus every
+    contiguous input row above and below it, stopping at the first boundary
+    (blank line, hint/status row, a transcript-turn row, or another composer
+    anchor). Returns ``None`` when no composer input is visible. Only the
+    current input region is inspected, so a marker, placeholder, or prompt tail
+    in scrollback/history can never match.
+    """
+    tail = text.splitlines()[-64:]
+    anchor = None
+    for i in range(len(tail) - 1, -1, -1):
+        line = tail[i].replace("\xa0", " ").rstrip()
+        if _is_composer_anchor_row(line):
+            anchor = i
+            break
+    if anchor is None:
+        return None
+    rows: list[str] = []
+    j = anchor - 1
+    while j >= 0:
+        line = tail[j].replace("\xa0", " ").rstrip()
+        if _is_input_block_boundary(line):
+            break
+        rows.insert(0, _composer_row_content(line))
+        j -= 1
+    rows.append(_composer_row_content(tail[anchor]))
+    k = anchor + 1
+    while k < len(tail):
+        line = tail[k].replace("\xa0", " ").rstrip()
+        if _is_input_block_boundary(line):
+            break
+        rows.append(_composer_row_content(line))
+        k += 1
+    return "\n".join(rows)
+
+
+def _wrap_tolerant_match(block: str, fingerprint: tuple[str, ...]) -> bool:
+    """Ordered, wrap-tolerant containment of the fingerprint in a composer block.
+
+    All whitespace is removed on both sides so a TUI-wrap newline or indentation
+    cannot break a fragment. At least ``_TAIL_MIN_MATCH`` fragments must appear
+    in prompt order (a single short line is not enough).
+    """
+    block_key = _strip_all_whitespace(block)
+    pos = 0
+    matched = 0
+    for frag in fingerprint:
+        key = _strip_all_whitespace(frag)
+        if not key:
+            continue
+        idx = block_key.find(key, pos)
+        if idx < 0:
+            continue
+        pos = idx + len(key)
+        matched += 1
+        if matched >= _TAIL_MIN_MATCH:
+            return True
+    return matched >= _TAIL_MIN_MATCH
+
+
+def _composer_holds_prompt_tail(text: str, prompt_text: str) -> bool:
+    """True when the *current* composer block holds this job's prompt tail.
+
+    The prompt-tail fingerprint must hit the current composer block; a tail that
+    only appears in scrollback/history can never match, and generic control lines
+    never form the fingerprint.
+    """
+    block = _current_composer_block(text)
+    if block is None:
+        return False
+    fingerprint = _prompt_tail_fingerprint(prompt_text)
+    if not fingerprint:
+        return False
+    return _wrap_tolerant_match(block, fingerprint)
+
+
 def _maybe_resend_activation_enter(
     submission: ProviderSubmission,
     *,
@@ -451,11 +647,18 @@ def _maybe_resend_activation_enter(
     * the elapsed time since dispatch is at least the grace start and below the
       generous give-up cap (``CCB_CLAUDE_ACTIVATION_MAX_WAIT_S``, default 600s);
     * the pane is not busy (no ``esc to interrupt``) and the current composer
-      still holds *this* job's pending input: either the recognizable
-      prompt/anchor text, or — when the long paste has been folded by the
-      TUI — the collapsed placeholder ``[Pasted text #N +M lines]`` on the
-      current composer row (an empty composer, a different job's text, or a
-      placeholder that only appears in scrollback never matches);
+      still holds *this* job's pending input — any one of three pieces of
+      evidence:
+        * the recognizable prompt/anchor text;
+        * when the long paste has been folded by the TUI, the collapsed
+          placeholder ``[Pasted text #N +M lines]`` on the current composer row;
+        * when the prompt's head (and anchor) has scrolled out of the capture,
+          a wrap-tolerant match of the submitted prompt's tail fingerprint
+          against the current composer block (expanded multi-line / TUI-wrapped
+          rows) — generic control lines never form the fingerprint, and a tail
+          only present in scrollback/history never matches;
+      (an empty composer, a different job's text, or a placeholder / tail that
+      only appears in scrollback never matches);
     * this job has not already re-sent Enter (``activation_enter_count < 1``).
 
     The old ``[grace, 2*grace)`` window (default 6–12s) is removed: a folded
@@ -465,8 +668,9 @@ def _maybe_resend_activation_enter(
     more than one Enter, and that one Enter only ever submits the prompt that is
     still sitting in this job's composer. On a successful ``send_key`` the
     runtime state bumps ``activation_enter_count``, records the evidence kind
-    (``anchor_marker`` | ``pasted_placeholder``) in ``activation_enter_evidence``,
-    and stamps ``activation_enter_at`` so later polls never re-send.
+    (``anchor_marker`` | ``pasted_placeholder`` | ``prompt_tail``) in
+    ``activation_enter_evidence``, and stamps ``activation_enter_at`` so later
+    polls never re-send.
     """
     state = submission.runtime_state
     if not bool(state.get("prompt_sent", False)):
@@ -501,9 +705,16 @@ def _maybe_resend_activation_enter(
     if "esc to interrupt" in pane_text.lower():
         return None
     has_placeholder = _current_composer_holds_pasted_placeholder(pane_text)
-    if not has_placeholder and not _pane_holds_current_job_marker(pane_text, submission):
+    has_anchor = _pane_holds_current_job_marker(pane_text, submission)
+    has_tail = _composer_holds_prompt_tail(pane_text, str(state.get("prompt_text") or ""))
+    if not (has_placeholder or has_anchor or has_tail):
         return None
-    evidence = "pasted_placeholder" if has_placeholder else "anchor_marker"
+    if has_placeholder:
+        evidence = "pasted_placeholder"
+    elif has_anchor:
+        evidence = "anchor_marker"
+    else:
+        evidence = "prompt_tail"
     try:
         sent = send_key(pane_id, "Enter")
     except Exception:

--- a/lib/provider_backends/claude/execution_runtime/polling.py
+++ b/lib/provider_backends/claude/execution_runtime/polling.py
@@ -323,24 +323,32 @@ def _pane_observably_idle(prepared) -> bool:
 
 
 def _activation_grace_s() -> float:
-    """Seconds to wait after dispatch before a lost Enter is retried once."""
+    """Seconds to wait after dispatch before a lost Enter may be retried.
+
+    A retry is never sent before this grace: the initial paste may still be
+    inserting, so an earlier Enter would be eaten again (or become a stray
+    newline). Default 6s.
+    """
     try:
         return max(0.0, float(os.environ.get("CCB_CLAUDE_ACTIVATION_GRACE_S", 6.0)))
     except Exception:
         return 6.0
 
 
-def _activation_retry_window() -> tuple[float, float]:
-    """Bounded retry window ``[start_s, end_s)`` measured from ``prompt_sent_at``.
+def _activation_max_wait_s() -> float:
+    """Generous give-up bound replacing the old tight ``[grace, 2*grace)`` window.
 
-    The retry Enter is only eligible inside this window: not before ``start_s``
-    (the initial paste may still be inserting, so a second Enter could be eaten
-    or become a stray newline) and not after ``end_s`` (give up; an operator
-    intervenes manually). Default ``[6.0, 12.0)`` for
-    ``CCB_CLAUDE_ACTIVATION_GRACE_S=6``.
+    The old default 6–12s window could permanently miss a stuck prompt: a
+    multi-KB paste can keep rendering past 12s, and the polling cadence may never
+    land inside such a narrow slice. Because the retry is at-most-once and gated
+    on current-composer evidence for this job plus a non-busy pane, a wide bound
+    is still safe — it only decides how long a genuinely abandoned job remains
+    auto-recoverable before an operator must intervene. Default 600s (10 min).
     """
-    grace_s = _activation_grace_s()
-    return grace_s, grace_s * 2.0
+    try:
+        return max(0.0, float(os.environ.get("CCB_CLAUDE_ACTIVATION_MAX_WAIT_S", 600.0)))
+    except Exception:
+        return 600.0
 
 
 def _elapsed_since(from_at: str, now: str) -> float | None:
@@ -348,6 +356,50 @@ def _elapsed_since(from_at: str, now: str) -> float | None:
         return (parse_utc_timestamp(now) - parse_utc_timestamp(from_at)).total_seconds()
     except Exception:
         return None
+
+
+# Claude folds a long bracketed paste in the composer into this placeholder:
+# ``❯ [Pasted text #4 +11 lines]``. The raw prompt (and therefore the request
+# anchor) is no longer visible in the pane, so the placeholder on the *current*
+# composer row is the only evidence that this job's prompt is still pending.
+_PASTED_PLACEHOLDER_RE = re.compile(r"\[Pasted text #\d+\s+\+\s*\d+\s+lines?\]")
+
+
+def _current_composer_content(text: str) -> str | None:
+    """Content of the current Claude composer input row, decorations removed.
+
+    The composer is the bottom-most input row in the visible pane tail (arrow
+    ``❯ ...`` or boxed ``│ ... │``); hint/status lines rendered below
+    it (``? for shortcuts``, ``esc to interrupt``) are skipped. Returns ``""``
+    for an empty idle box, or ``None`` when no composer row is found. Only the
+    current input row is inspected, so a marker or placeholder in
+    scrollback/history can never match.
+    """
+    tail = text.splitlines()[-32:]
+    for raw in reversed(tail):
+        line = raw.replace("\xa0", " ").rstrip()
+        if not line.strip():
+            continue
+        arrow = re.match(r"^\s*[❯>]\s?(.*)$", line)
+        if arrow:
+            return arrow.group(1)
+        boxed = re.match(r"^\s*[│|]\s*[❯>]?\s?(.*?)\s*[│|]\s*$", line)
+        if boxed:
+            return boxed.group(1)
+    return None
+
+
+def _current_composer_holds_pasted_placeholder(text: str) -> bool:
+    """True only when the *current* composer row shows a collapsed paste.
+
+    A placeholder that merely appears in the transcript history (a previous
+    turn's folded paste) never matches, because only the bottom-most input row
+    is considered.
+    """
+    content = _current_composer_content(text)
+    if content is None:
+        return False
+    return bool(_PASTED_PLACEHOLDER_RE.search(content))
 
 
 def _pane_holds_current_job_marker(text: str, submission: ProviderSubmission) -> bool:
@@ -396,18 +448,25 @@ def _maybe_resend_activation_enter(
 
     * the prompt was already dispatched (``prompt_sent``) with a timestamp;
     * the current job is not yet activated (no ``prompt_activated``/``anchor_seen``);
-    * the elapsed time since dispatch is inside the bounded grace window;
-    * the pane is not busy (no ``esc to interrupt``) and still holds this job's
-      recognizable prompt/anchor text (an empty composer cannot match);
+    * the elapsed time since dispatch is at least the grace start and below the
+      generous give-up cap (``CCB_CLAUDE_ACTIVATION_MAX_WAIT_S``, default 600s);
+    * the pane is not busy (no ``esc to interrupt``) and the current composer
+      still holds *this* job's pending input: either the recognizable
+      prompt/anchor text, or — when the long paste has been folded by the
+      TUI — the collapsed placeholder ``[Pasted text #N +M lines]`` on the
+      current composer row (an empty composer, a different job's text, or a
+      placeholder that only appears in scrollback never matches);
     * this job has not already re-sent Enter (``activation_enter_count < 1``).
 
-    Any failing guard disables the retry: activated, empty composer, busy pane,
-    text that does not belong to this job, an expired grace window, or a prior
-    re-send. On a successful ``send_key`` the runtime state bumps
-    ``activation_enter_count`` so later polls never re-send. (``_has_idle_input_box``
-    only recognizes the empty ready box and would never fire for the stuck
-    composer that still holds the prompt text, so the marker check is the
-    effective "still this job, still submittable" guard.)
+    The old ``[grace, 2*grace)`` window (default 6–12s) is removed: a folded
+    long paste renders asynchronously for longer than that, so the retry could
+    permanently miss the whole slice. The wide give-up cap plus at-most-once
+    plus current-composer evidence is the safe replacement: it can never send
+    more than one Enter, and that one Enter only ever submits the prompt that is
+    still sitting in this job's composer. On a successful ``send_key`` the
+    runtime state bumps ``activation_enter_count``, records the evidence kind
+    (``anchor_marker`` | ``pasted_placeholder``) in ``activation_enter_evidence``,
+    and stamps ``activation_enter_at`` so later polls never re-send.
     """
     state = submission.runtime_state
     if not bool(state.get("prompt_sent", False)):
@@ -425,8 +484,9 @@ def _maybe_resend_activation_enter(
     elapsed = _elapsed_since(prompt_sent_at, now)
     if elapsed is None:
         return None
-    grace_start, grace_end = _activation_retry_window()
-    if elapsed < grace_start or elapsed >= grace_end:
+    if elapsed < _activation_grace_s():
+        return None
+    if elapsed >= _activation_max_wait_s():
         return None
     pane_id = getattr(prepared, "pane_id", None)
     backend = getattr(prepared, "backend", None)
@@ -440,8 +500,10 @@ def _maybe_resend_activation_enter(
         return None
     if "esc to interrupt" in pane_text.lower():
         return None
-    if not _pane_holds_current_job_marker(pane_text, submission):
+    has_placeholder = _current_composer_holds_pasted_placeholder(pane_text)
+    if not has_placeholder and not _pane_holds_current_job_marker(pane_text, submission):
         return None
+    evidence = "pasted_placeholder" if has_placeholder else "anchor_marker"
     try:
         sent = send_key(pane_id, "Enter")
     except Exception:
@@ -454,6 +516,7 @@ def _maybe_resend_activation_enter(
             **state,
             "activation_enter_count": int(state.get("activation_enter_count", 0) or 0) + 1,
             "activation_enter_at": now,
+            "activation_enter_evidence": evidence,
         },
     )
 

--- a/test/test_claude_activation_enter_retry.py
+++ b/test/test_claude_activation_enter_retry.py
@@ -4,7 +4,10 @@ from types import SimpleNamespace
 
 from completion.models import CompletionSourceKind
 from provider_backends.claude.execution_runtime.polling import (
+    _composer_holds_prompt_tail,
+    _current_composer_block,
     _maybe_resend_activation_enter,
+    _prompt_tail_fingerprint,
     poll_submission,
 )
 from provider_execution.base import ProviderPollResult, ProviderSubmission
@@ -624,3 +627,261 @@ def test_export_runtime_state_absent_evidence_is_none() -> None:
     assert exported["activation_enter_count"] is None
     assert exported["activation_enter_at"] is None
     assert exported["activation_enter_evidence"] is None
+
+
+# ---------------------------------------------------------------------------
+# v3 (PR #305 第三版)：prompt-tail fingerprint —— 展开式多行 composer / TUI wrap
+# ---------------------------------------------------------------------------
+
+TAIL_PROMPT = (
+    "CCB_REQ_ID: job_current\n\n"
+    "当前任务：处理场馆预约草稿金额扩容与充值续充恢复。\n"
+    "第一项：核对 balance_at_save 与 total_pay_amount 的精度透传。\n"
+    "第二项：确认 cancel 在 EXPIRED 终态下明确返回 DRAFT_EXPIRED。"
+)
+
+WRAP_PROMPT = (
+    "CCB_REQ_ID: job_current\n\n"
+    "当前任务：请逐项核对场馆预约草稿金额列、储值余额口径与充值续充恢复路径是否一致。\n"
+    "并按步骤确认每项结果。"
+)
+
+
+def _expanded_tail_pane() -> str:
+    # 展开式多行 composer：anchor 已滚出 capture、无折叠占位符，仅尾部业务行可见。
+    return (
+        "会话历史…\n"
+        "❯ 当前任务：处理场馆预约草稿金额扩容与充值续充恢复。\n"
+        "  第一项：核对 balance_at_save 与 total_pay_amount 的精度透传。\n"
+        "  第二项：确认 cancel 在 EXPIRED 终态下明确返回 DRAFT_EXPIRED。\n"
+        "  ? for shortcuts\n"
+    )
+
+
+# --- fingerprint 直接单元测试 -------------------------------------------------
+
+
+def test_prompt_tail_fingerprint_requires_two_business_lines() -> None:
+    # 只有 1 条非通用业务行（anchor 行已被排除）→ 不足以构成指纹。
+    assert _prompt_tail_fingerprint("CCB_REQ_ID: job_current\n\n只有一行业务") is None
+    fp = _prompt_tail_fingerprint(TAIL_PROMPT)
+    assert fp is not None
+    assert len(fp) >= 2
+    # 通用控制行（CCB_*）绝不进入指纹。
+    assert all("CCB" not in frag for frag in fp)
+
+
+def test_prompt_tail_fingerprint_excludes_generic_control_lines() -> None:
+    # CCB_REPLY_MODE / CCB_REQ_ID 是通用尾行；剔除后只剩 1 条业务行 → 无指纹。
+    fp = _prompt_tail_fingerprint(
+        "CCB_REQ_ID: job_current\n\nCCB_REPLY_MODE: compact\n唯一业务行"
+    )
+    assert fp is None
+    # 控制行落在尾部也不得成为指纹：指纹由控制行之前的业务行构成。
+    fp = _prompt_tail_fingerprint(
+        "CCB_REQ_ID: job_current\n\n"
+        "第一项：核对场馆预约草稿金额扩容的精度透传。\n"
+        "第二项：确认 cancel 在 EXPIRED 终态下的行为。\n"
+        "CCB_REPLY_MODE: compact"
+    )
+    assert fp is not None
+    assert all("CCB_REPLY_MODE" not in frag for frag in fp)
+    assert fp[-1] == "第二项：确认 cancel 在 EXPIRED 终态下的行为。"
+
+
+def test_prompt_tail_fingerprint_uses_tail_of_long_line() -> None:
+    # 长行只贡献尾部片段（≤ _TAIL_FRAGMENT_CHARS=48），短尾行整体保留。
+    fp = _prompt_tail_fingerprint(LONG_UNICODE_PROMPT)
+    assert fp is not None
+    assert all(len(frag) <= 48 for frag in fp)
+    assert fp[-1] == "请逐条确认。"
+
+
+# --- current-composer block 直接单元测试 ------------------------------------
+
+
+def test_current_composer_block_extracts_expanded_multiline() -> None:
+    block = _current_composer_block(_expanded_tail_pane())
+    assert block is not None
+    assert "当前任务：处理场馆预约草稿金额扩容与充值续充恢复。" in block
+    assert "第一项：核对 balance_at_save 与 total_pay_amount 的精度透传。" in block
+    assert "第二项：确认 cancel 在 EXPIRED 终态下明确返回 DRAFT_EXPIRED。" in block
+    assert "会话历史" not in block  # 历史不得混入当前 composer block
+
+
+def test_current_composer_block_empty_when_idle() -> None:
+    block = _current_composer_block("会话历史…\n❯\n  ? for shortcuts\n")
+    assert block is not None
+    assert block.strip() == ""
+
+
+def test_composer_holds_prompt_tail_ignores_history_only_tail() -> None:
+    # 尾部业务行只在历史转录中出现、当前 composer 为空 → 不得命中。
+    pane = (
+        "user 当前任务：处理场馆预约草稿金额扩容与充值续充恢复。\n"
+        "user 第二项：确认 cancel 在 EXPIRED 终态下明确返回 DRAFT_EXPIRED。\n"
+        "❯\n"
+    )
+    assert _composer_holds_prompt_tail(pane, TAIL_PROMPT) is False
+
+
+# --- v3 集成测试：第三种证据 prompt_tail -------------------------------
+
+
+def test_expanded_multiline_prompt_tail_resends_exactly_once() -> None:
+    submission = _submission(prompt_text=TAIL_PROMPT)
+    backend = _RetryBackend(_expanded_tail_pane())
+
+    updated = _maybe_resend_activation_enter(
+        submission,
+        prepared=_prepared(backend),
+        poll=_poll(),
+        now=NOW,
+    )
+
+    assert updated is not None
+    assert backend.keys == [("%1", "Enter")]
+    assert updated.runtime_state["activation_enter_count"] == 1
+    assert updated.runtime_state["activation_enter_at"] == NOW
+    assert updated.runtime_state["activation_enter_evidence"] == "prompt_tail"
+
+
+def test_tui_wrapped_prompt_tail_resends_exactly_once() -> None:
+    # TUI 自动换行：一条逻辑行折成多行 composer 行，指纹跨行仍命中。
+    submission = _submission(prompt_text=WRAP_PROMPT)
+    pane = (
+        "❯ 当前任务：请逐项核对场馆预约草稿金额列、储值余额口径\n"
+        "  与充值续充恢复路径是否一致。并按步骤确认每项结果。\n"
+    )
+    backend = _RetryBackend(pane)
+
+    updated = _maybe_resend_activation_enter(
+        submission,
+        prepared=_prepared(backend),
+        poll=_poll(),
+        now=NOW,
+    )
+
+    assert updated is not None
+    assert backend.keys == [("%1", "Enter")]
+    assert updated.runtime_state["activation_enter_evidence"] == "prompt_tail"
+
+
+def test_tail_in_history_but_current_composer_foreign_does_not_send() -> None:
+    submission = _submission(prompt_text=TAIL_PROMPT)
+    backend = _RetryBackend(
+        "user 当前任务：处理场馆预约草稿金额扩容与充值续充恢复。\n"
+        "user 第二项：确认 cancel 在 EXPIRED 终态下明确返回 DRAFT_EXPIRED。\n"
+        "❯ 完全不同的另一个任务\n"
+    )
+
+    result = _maybe_resend_activation_enter(
+        submission,
+        prepared=_prepared(backend),
+        poll=_poll(),
+        now=NOW,
+    )
+
+    assert result is None
+    assert backend.keys == []
+
+
+def test_tail_in_history_but_current_composer_empty_does_not_send() -> None:
+    submission = _submission(prompt_text=TAIL_PROMPT)
+    backend = _RetryBackend(
+        "user 当前任务：处理场馆预约草稿金额扩容与充值续充恢复。\n"
+        "user 第二项：确认 cancel 在 EXPIRED 终态下明确返回 DRAFT_EXPIRED。\n"
+        "❯\n"
+    )
+
+    result = _maybe_resend_activation_enter(
+        submission,
+        prepared=_prepared(backend),
+        poll=_poll(),
+        now=NOW,
+    )
+
+    assert result is None
+    assert backend.keys == []
+
+
+def test_prompt_tail_evidence_respects_busy_pane() -> None:
+    submission = _submission(prompt_text=TAIL_PROMPT)
+    backend = _RetryBackend(_expanded_tail_pane() + "esc to interrupt")
+
+    result = _maybe_resend_activation_enter(
+        submission,
+        prepared=_prepared(backend),
+        poll=_poll(),
+        now=NOW,
+    )
+
+    assert result is None
+    assert backend.keys == []
+
+
+def test_prompt_tail_evidence_respects_already_activated() -> None:
+    submission = _submission(prompt_text=TAIL_PROMPT)
+    backend = _RetryBackend(_expanded_tail_pane())
+
+    result = _maybe_resend_activation_enter(
+        submission,
+        prepared=_prepared(backend),
+        poll=_poll(prompt_activated=True),
+        now=NOW,
+    )
+
+    assert result is None
+    assert backend.keys == []
+
+
+def test_prompt_tail_evidence_respects_at_most_once() -> None:
+    submission = _submission(prompt_text=TAIL_PROMPT)
+    backend = _RetryBackend(_expanded_tail_pane())
+
+    first = _maybe_resend_activation_enter(
+        submission,
+        prepared=_prepared(backend),
+        poll=_poll(),
+        now=NOW,
+    )
+    assert first is not None
+    assert backend.keys == [("%1", "Enter")]
+
+    second = _maybe_resend_activation_enter(
+        first,
+        prepared=_prepared(backend),
+        poll=_poll(),
+        now=NOW,
+    )
+    assert second is None
+    assert backend.keys == [("%1", "Enter")]
+
+
+def test_prompt_tail_evidence_respects_foreign_composer() -> None:
+    submission = _submission(prompt_text=TAIL_PROMPT)
+    backend = _RetryBackend("❯ 处理退款规则与会员卡订单的另一个任务。\n")
+
+    result = _maybe_resend_activation_enter(
+        submission,
+        prepared=_prepared(backend),
+        poll=_poll(),
+        now=NOW,
+    )
+
+    assert result is None
+    assert backend.keys == []
+
+
+def test_poll_submission_tail_evidence_persists_counter(monkeypatch) -> None:
+    submission = _submission(prompt_text=TAIL_PROMPT)
+    backend = _RetryBackend(_expanded_tail_pane())
+
+    result = _wired_poll_submission(submission, backend, monkeypatch=monkeypatch)
+
+    assert isinstance(result, ProviderPollResult)
+    assert result.decision is None
+    assert backend.keys == [("%1", "Enter")]
+    assert result.submission.runtime_state["activation_enter_count"] == 1
+    assert result.submission.runtime_state["activation_enter_at"] == NOW
+    assert result.submission.runtime_state["activation_enter_evidence"] == "prompt_tail"

--- a/test/test_claude_activation_enter_retry.py
+++ b/test/test_claude_activation_enter_retry.py
@@ -116,6 +116,7 @@ def test_long_unicode_stuck_prompt_resends_enter_exactly_once() -> None:
     assert backend.keys == [("%1", "Enter")]
     assert updated.runtime_state["activation_enter_count"] == 1
     assert updated.runtime_state["activation_enter_at"] == NOW
+    assert updated.runtime_state["activation_enter_evidence"] == "anchor_marker"
 
 
 def test_no_resend_when_anchor_already_seen() -> None:
@@ -209,16 +210,50 @@ def test_no_resend_before_grace_window() -> None:
     assert backend.keys == []
 
 
-def test_no_resend_after_grace_window_passed() -> None:
+def test_resend_after_old_tight_end_bound_within_generous_max_wait() -> None:
     submission = _submission()
     backend = _RetryBackend("CCB_REQ_ID: job_current\n❯\n")
-    late_now = "2026-07-21T08:00:15Z"  # +15s >= grace end 12s
+    # +15s was past the old [6,12)s end bound, but is inside the generous
+    # give-up cap (default 600s): the retry must still fire.
+    late_now = "2026-07-21T08:00:15Z"
 
     result = _maybe_resend_activation_enter(
         submission,
         prepared=_prepared(backend),
         poll=_poll(),
         now=late_now,
+    )
+
+    assert result is not None
+    assert backend.keys == [("%1", "Enter")]
+    assert result.runtime_state["activation_enter_evidence"] == "anchor_marker"
+
+
+def test_no_resend_beyond_max_wait_cap() -> None:
+    submission = _submission(prompt_sent_at="2026-07-21T07:50:00Z")  # 600s before NOW
+    backend = _RetryBackend("CCB_REQ_ID: job_current\n❯\n")
+
+    result = _maybe_resend_activation_enter(
+        submission,
+        prepared=_prepared(backend),
+        poll=_poll(),
+        now=NOW,
+    )
+
+    assert result is None
+    assert backend.keys == []
+
+
+def test_max_wait_cap_env_override(monkeypatch) -> None:
+    monkeypatch.setenv("CCB_CLAUDE_ACTIVATION_MAX_WAIT_S", "10")
+    submission = _submission(prompt_sent_at="2026-07-21T07:59:50Z")  # 10s before NOW
+    backend = _RetryBackend("CCB_REQ_ID: job_current\n❯\n")
+
+    result = _maybe_resend_activation_enter(
+        submission,
+        prepared=_prepared(backend),
+        poll=_poll(),
+        now=NOW,
     )
 
     assert result is None
@@ -339,6 +374,7 @@ def test_no_wrap_raw_prompt_resends_via_anchor_fallback() -> None:
 
     assert updated is not None
     assert backend.keys == [("%1", "Enter")]
+    assert updated.runtime_state["activation_enter_evidence"] == "anchor_marker"
 
 
 # ---------------------------------------------------------------------------
@@ -398,6 +434,7 @@ def test_poll_submission_resends_once_and_persists_counter(monkeypatch) -> None:
     # finalize_poll_result 展开 runtime_state，计数跨轮持久化
     assert result.submission.runtime_state["activation_enter_count"] == 1
     assert result.submission.runtime_state["activation_enter_at"] == NOW
+    assert result.submission.runtime_state["activation_enter_evidence"] == "anchor_marker"
 
 
 def test_poll_submission_does_not_resend_when_events_show_activation(monkeypatch) -> None:
@@ -415,3 +452,175 @@ def test_poll_submission_does_not_resend_when_events_show_activation(monkeypatch
     assert isinstance(result, ProviderPollResult)
     assert result.decision is None
     assert backend.keys == []
+
+
+# ---------------------------------------------------------------------------
+# 真实折叠长粘贴（recurrence）用例：composer 显示 [Pasted text #N +M lines]
+# ---------------------------------------------------------------------------
+
+
+def test_collapsed_pasted_placeholder_resends_exactly_once() -> None:
+    # 初次 Enter 被吞：长提示被 Claude 折叠为占位符，pane 中看不到原始锚文本，
+    # 但当前 composer 行的折叠占位符证明本 job 的提示仍待提交 → 恰一次 retry。
+    submission = _submission(prompt_text=LONG_UNICODE_PROMPT)
+    backend = _RetryBackend("会话历史…\n❯ [Pasted text #4 +11 lines]\n")
+
+    updated = _maybe_resend_activation_enter(
+        submission,
+        prepared=_prepared(backend),
+        poll=_poll(),
+        now=NOW,
+    )
+
+    assert updated is not None
+    assert backend.keys == [("%1", "Enter")]
+    assert updated.runtime_state["activation_enter_count"] == 1
+    assert updated.runtime_state["activation_enter_at"] == NOW
+    assert updated.runtime_state["activation_enter_evidence"] == "pasted_placeholder"
+
+
+def test_collapsed_placeholder_repeated_poll_never_resends() -> None:
+    submission = _submission(prompt_text=LONG_UNICODE_PROMPT)
+    backend = _RetryBackend("会话历史…\n❯ [Pasted text #4 +11 lines]\n")
+
+    first = _maybe_resend_activation_enter(
+        submission,
+        prepared=_prepared(backend),
+        poll=_poll(),
+        now=NOW,
+    )
+    assert first is not None
+    assert backend.keys == [("%1", "Enter")]
+
+    second = _maybe_resend_activation_enter(
+        first,
+        prepared=_prepared(backend),
+        poll=_poll(),
+        now=NOW,
+    )
+    assert second is None
+    assert backend.keys == [("%1", "Enter")]
+
+
+def test_historical_placeholder_with_empty_composer_does_not_send() -> None:
+    # 占位符仅出现在历史输出（上一轮被折叠的粘贴），当前 composer 为空 → 不发。
+    submission = _submission()
+    backend = _RetryBackend("上一轮对话…\nuser [Pasted text #2 +5 lines]\n❯\n")
+
+    result = _maybe_resend_activation_enter(
+        submission,
+        prepared=_prepared(backend),
+        poll=_poll(),
+        now=NOW,
+    )
+
+    assert result is None
+    assert backend.keys == []
+
+
+def test_placeholder_composer_busy_does_not_send() -> None:
+    submission = _submission(prompt_text=LONG_UNICODE_PROMPT)
+    backend = _RetryBackend("❯ [Pasted text #4 +11 lines]\nesc to interrupt")
+
+    result = _maybe_resend_activation_enter(
+        submission,
+        prepared=_prepared(backend),
+        poll=_poll(),
+        now=NOW,
+    )
+
+    assert result is None
+    assert backend.keys == []
+
+
+def test_placeholder_composer_already_activated_does_not_send() -> None:
+    submission = _submission(prompt_text=LONG_UNICODE_PROMPT)
+    backend = _RetryBackend("会话历史…\n❯ [Pasted text #4 +11 lines]\n")
+
+    result = _maybe_resend_activation_enter(
+        submission,
+        prepared=_prepared(backend),
+        poll=_poll(prompt_activated=True),
+        now=NOW,
+    )
+
+    assert result is None
+    assert backend.keys == []
+
+
+def test_composer_holding_different_plaintext_does_not_send() -> None:
+    # composer 内是另一个任务的明文（无本 job 锚、非折叠占位符）→ 不发。
+    submission = _submission()
+    backend = _RetryBackend("❯ CCB_REQ_ID: job_other 别的任务的提示词\n")
+
+    result = _maybe_resend_activation_enter(
+        submission,
+        prepared=_prepared(backend),
+        poll=_poll(),
+        now=NOW,
+    )
+
+    assert result is None
+    assert backend.keys == []
+
+
+def test_placeholder_in_history_with_foreign_composer_text_does_not_send() -> None:
+    # 历史含占位符 + 当前 composer 是其他任务的明文 → 两个证据都不满足 → 不发。
+    submission = _submission()
+    backend = _RetryBackend("user [Pasted text #3 +8 lines]\n❯ 别的任务的明文\n")
+
+    result = _maybe_resend_activation_enter(
+        submission,
+        prepared=_prepared(backend),
+        poll=_poll(),
+        now=NOW,
+    )
+
+    assert result is None
+    assert backend.keys == []
+
+
+def test_placeholder_marker_path_preserved_anchor_still_works() -> None:
+    # 普通（未折叠）marker 路径保持：pane 仍含本 job 原始锚文本 → 照常重发。
+    submission = _submission(prompt_text=LONG_UNICODE_PROMPT)
+    backend = _RetryBackend(f"{LONG_UNICODE_PROMPT}\n❯\n")
+
+    updated = _maybe_resend_activation_enter(
+        submission,
+        prepared=_prepared(backend),
+        poll=_poll(),
+        now=NOW,
+    )
+
+    assert updated is not None
+    assert backend.keys == [("%1", "Enter")]
+    assert updated.runtime_state["activation_enter_evidence"] == "anchor_marker"
+
+
+# ---------------------------------------------------------------------------
+# 观察者字段可见性：export_runtime_state 必须暴露新的 activation 状态
+# ---------------------------------------------------------------------------
+
+
+def test_export_runtime_state_exposes_activation_fields() -> None:
+    from provider_backends.claude.execution import ClaudeProviderAdapter
+
+    submission = _submission(
+        activation_enter_count=1,
+        activation_enter_at=NOW,
+        activation_enter_evidence="pasted_placeholder",
+    )
+    exported = ClaudeProviderAdapter().export_runtime_state(submission)
+    assert exported["activation_enter_count"] == 1
+    assert exported["activation_enter_at"] == NOW
+    assert exported["activation_enter_evidence"] == "pasted_placeholder"
+
+
+def test_export_runtime_state_absent_evidence_is_none() -> None:
+    from provider_backends.claude.execution import ClaudeProviderAdapter
+
+    submission = _submission()
+    exported = ClaudeProviderAdapter().export_runtime_state(submission)
+    assert exported["activation_enter_count"] is None
+    assert exported["activation_enter_at"] is None
+    assert exported["activation_enter_evidence"] is None

--- a/test/test_claude_activation_enter_retry.py
+++ b/test/test_claude_activation_enter_retry.py
@@ -1,0 +1,417 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from completion.models import CompletionSourceKind
+from provider_backends.claude.execution_runtime.polling import (
+    _maybe_resend_activation_enter,
+    poll_submission,
+)
+from provider_execution.base import ProviderPollResult, ProviderSubmission
+
+NOW = "2026-07-21T08:00:00Z"
+SENT_AT = "2026-07-21T07:59:53Z"  # 7s before NOW → inside default grace window [6, 12)
+
+
+def _submission(**runtime_overrides: object) -> ProviderSubmission:
+    runtime_state: dict[str, object] = {
+        "state": {},
+        "mode": "active",
+        "pane_id": "%1",
+        "request_anchor": "job_current",
+        "next_seq": 1,
+        "anchor_seen": False,
+        "prompt_activated": False,
+        "reply_buffer": "",
+        "raw_buffer": "",
+        "session_path": "/tmp/session-one.jsonl",
+        "last_assistant_uuid": "",
+        "prompt_text": "CCB_REQ_ID: job_current\n\n当前任务：请处理以下事项。",
+        "prompt_sent": True,
+        "prompt_sent_at": SENT_AT,
+        "no_wrap": False,
+    }
+    runtime_state.update(runtime_overrides)
+    return ProviderSubmission(
+        job_id="job_current",
+        agent_name="claude1",
+        provider="claude",
+        accepted_at=NOW,
+        ready_at=NOW,
+        source_kind=CompletionSourceKind.SESSION_EVENT_LOG,
+        reply="",
+        runtime_state=runtime_state,
+    )
+
+
+LONG_UNICODE_PROMPT = "CCB_REQ_ID: job_current\n\n" + ("很长的中文提示词" * 400) + "\n请逐条确认。"
+
+
+class _RetryBackend:
+    """Fake pane backend recording every send_key; get_pane_content is injectable."""
+
+    def __init__(self, pane_text: str) -> None:
+        self.pane_text = pane_text
+        self.keys: list[tuple[str, str]] = []
+
+    def get_pane_content(self, pane_id: str, lines: int = 120) -> str:
+        assert pane_id == "%1"
+        return self.pane_text
+
+    def send_key(self, pane_id: str, key: str) -> bool:
+        assert pane_id == "%1"
+        self.keys.append((pane_id, key))
+        return True
+
+
+class _FailingReadBackend:
+    def get_pane_content(self, pane_id: str, lines: int = 120) -> str:
+        raise RuntimeError("capture failed")
+
+    def send_key(self, pane_id: str, key: str) -> bool:
+        raise AssertionError("send_key must not be called")
+
+
+class _NoSendKeyBackend:
+    def get_pane_content(self, pane_id: str, lines: int = 120) -> str:
+        return "CCB_REQ_ID: job_current\n❯\n"
+
+
+def _prepared(backend: object) -> SimpleNamespace:
+    return SimpleNamespace(backend=backend, pane_id="%1")
+
+
+def _poll(*, anchor_seen: bool = False, prompt_activated: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(
+        request_anchor="job_current",
+        anchor_seen=anchor_seen,
+        prompt_activated=prompt_activated,
+        reached_turn_boundary=False,
+        next_seq=1,
+        reply_buffer="",
+        raw_buffer="",
+        session_path="/tmp/session-one.jsonl",
+        last_assistant_uuid="",
+        items=[],
+    )
+
+
+# ---------------------------------------------------------------------------
+# 直接单元测试：_maybe_resend_activation_enter
+# ---------------------------------------------------------------------------
+
+
+def test_long_unicode_stuck_prompt_resends_enter_exactly_once() -> None:
+    submission = _submission(prompt_text=LONG_UNICODE_PROMPT)
+    backend = _RetryBackend(f"{LONG_UNICODE_PROMPT}\n❯\n")
+
+    updated = _maybe_resend_activation_enter(
+        submission,
+        prepared=_prepared(backend),
+        poll=_poll(),
+        now=NOW,
+    )
+
+    assert updated is not None
+    assert backend.keys == [("%1", "Enter")]
+    assert updated.runtime_state["activation_enter_count"] == 1
+    assert updated.runtime_state["activation_enter_at"] == NOW
+
+
+def test_no_resend_when_anchor_already_seen() -> None:
+    submission = _submission()
+    backend = _RetryBackend("CCB_REQ_ID: job_current\ncompleted\n❯\n")
+
+    result = _maybe_resend_activation_enter(
+        submission,
+        prepared=_prepared(backend),
+        poll=_poll(anchor_seen=True),
+        now=NOW,
+    )
+
+    assert result is None
+    assert backend.keys == []
+
+
+def test_no_resend_when_prompt_activated() -> None:
+    submission = _submission()
+    backend = _RetryBackend("CCB_REQ_ID: job_current\n❯\n")
+
+    result = _maybe_resend_activation_enter(
+        submission,
+        prepared=_prepared(backend),
+        poll=_poll(prompt_activated=True),
+        now=NOW,
+    )
+
+    assert result is None
+    assert backend.keys == []
+
+
+def test_no_resend_when_idle_composer_has_no_current_job_marker() -> None:
+    submission = _submission()
+    backend = _RetryBackend("❯\n  ? for shortcuts\n")
+
+    result = _maybe_resend_activation_enter(
+        submission,
+        prepared=_prepared(backend),
+        poll=_poll(),
+        now=NOW,
+    )
+
+    assert result is None
+    assert backend.keys == []
+
+
+def test_no_resend_when_composer_holds_different_job_text() -> None:
+    submission = _submission()
+    backend = _RetryBackend("CCB_REQ_ID: job_other\n别的任务的提示词\n❯\n")
+
+    result = _maybe_resend_activation_enter(
+        submission,
+        prepared=_prepared(backend),
+        poll=_poll(),
+        now=NOW,
+    )
+
+    assert result is None
+    assert backend.keys == []
+
+
+def test_no_resend_when_pane_busy() -> None:
+    submission = _submission()
+    backend = _RetryBackend("CCB_REQ_ID: job_current\nworking…\nesc to interrupt")
+
+    result = _maybe_resend_activation_enter(
+        submission,
+        prepared=_prepared(backend),
+        poll=_poll(),
+        now=NOW,
+    )
+
+    assert result is None
+    assert backend.keys == []
+
+
+def test_no_resend_before_grace_window() -> None:
+    submission = _submission()
+    backend = _RetryBackend("CCB_REQ_ID: job_current\n❯\n")
+    early_now = "2026-07-21T07:59:56Z"  # +3s < grace start 6s
+
+    result = _maybe_resend_activation_enter(
+        submission,
+        prepared=_prepared(backend),
+        poll=_poll(),
+        now=early_now,
+    )
+
+    assert result is None
+    assert backend.keys == []
+
+
+def test_no_resend_after_grace_window_passed() -> None:
+    submission = _submission()
+    backend = _RetryBackend("CCB_REQ_ID: job_current\n❯\n")
+    late_now = "2026-07-21T08:00:15Z"  # +15s >= grace end 12s
+
+    result = _maybe_resend_activation_enter(
+        submission,
+        prepared=_prepared(backend),
+        poll=_poll(),
+        now=late_now,
+    )
+
+    assert result is None
+    assert backend.keys == []
+
+
+def test_env_grace_override_shrinks_window(monkeypatch) -> None:
+    monkeypatch.setenv("CCB_CLAUDE_ACTIVATION_GRACE_S", "2")
+    submission = _submission()
+    backend = _RetryBackend("CCB_REQ_ID: job_current\n❯\n")
+    # +3s → inside [2,4) with grace=2
+    now_3s = "2026-07-21T07:59:56Z"
+
+    updated = _maybe_resend_activation_enter(
+        submission,
+        prepared=_prepared(backend),
+        poll=_poll(),
+        now=now_3s,
+    )
+
+    assert updated is not None
+    assert backend.keys == [("%1", "Enter")]
+
+
+def test_no_resend_after_prior_retry() -> None:
+    submission = _submission(activation_enter_count=1, activation_enter_at=NOW)
+    backend = _RetryBackend("CCB_REQ_ID: job_current\n❯\n")
+
+    result = _maybe_resend_activation_enter(
+        submission,
+        prepared=_prepared(backend),
+        poll=_poll(),
+        now=NOW,
+    )
+
+    assert result is None
+    assert backend.keys == []
+
+
+def test_repeated_polling_never_exceeds_one_send() -> None:
+    submission = _submission()
+    backend = _RetryBackend("CCB_REQ_ID: job_current\n❯\n")
+
+    first = _maybe_resend_activation_enter(
+        submission,
+        prepared=_prepared(backend),
+        poll=_poll(),
+        now=NOW,
+    )
+    assert first is not None
+    assert backend.keys == [("%1", "Enter")]
+
+    second = _maybe_resend_activation_enter(
+        first,
+        prepared=_prepared(backend),
+        poll=_poll(),
+        now=NOW,
+    )
+    assert second is None
+    assert backend.keys == [("%1", "Enter")]
+
+
+def test_no_resend_when_prompt_not_sent() -> None:
+    submission = _submission(prompt_sent=False)
+    backend = _RetryBackend("CCB_REQ_ID: job_current\n❯\n")
+
+    result = _maybe_resend_activation_enter(
+        submission,
+        prepared=_prepared(backend),
+        poll=_poll(),
+        now=NOW,
+    )
+
+    assert result is None
+    assert backend.keys == []
+
+
+def test_no_resend_when_pane_read_fails() -> None:
+    submission = _submission()
+
+    result = _maybe_resend_activation_enter(
+        submission,
+        prepared=_prepared(_FailingReadBackend()),
+        poll=_poll(),
+        now=NOW,
+    )
+
+    assert result is None
+
+
+def test_no_resend_when_backend_lacks_send_key() -> None:
+    submission = _submission()
+
+    result = _maybe_resend_activation_enter(
+        submission,
+        prepared=_prepared(_NoSendKeyBackend()),
+        poll=_poll(),
+        now=NOW,
+    )
+
+    assert result is None
+
+
+def test_no_wrap_raw_prompt_resends_via_anchor_fallback() -> None:
+    submission = _submission(
+        no_wrap=True,
+        prompt_text="raw task body without wrap",
+        request_anchor="job_current",
+    )
+    backend = _RetryBackend("job_current\nraw task body\n❯\n")
+
+    updated = _maybe_resend_activation_enter(
+        submission,
+        prepared=_prepared(backend),
+        poll=_poll(),
+        now=NOW,
+    )
+
+    assert updated is not None
+    assert backend.keys == [("%1", "Enter")]
+
+
+# ---------------------------------------------------------------------------
+# poll_submission 接线测试：重发发生且计数经 finalize 持久化
+# ---------------------------------------------------------------------------
+
+
+def _wired_poll_submission(
+    submission: ProviderSubmission,
+    backend: object,
+    *,
+    poll: SimpleNamespace | None = None,
+    monkeypatch,
+) -> ProviderPollResult:
+    poll = poll if poll is not None else _poll()
+    prepared = SimpleNamespace(reader=object(), backend=backend, pane_id="%1")
+    monkeypatch.setattr(
+        "provider_backends.claude.execution_runtime.polling.prepare_active_poll_without_liveness",
+        lambda submission, now: prepared,
+    )
+    monkeypatch.setattr(
+        "provider_backends.claude.execution_runtime.polling.poll_exact_hook",
+        lambda submission, now: None,
+    )
+    monkeypatch.setattr(
+        "provider_backends.claude.execution_runtime.polling.ensure_active_pane_alive",
+        lambda submission, backend, pane_id, now: None,
+    )
+    monkeypatch.setattr(
+        "provider_backends.claude.execution_runtime.polling.build_poll_state",
+        lambda submission: poll,
+    )
+    monkeypatch.setattr(
+        "provider_backends.claude.execution_runtime.polling.read_events",
+        lambda reader, state: ([], state),
+    )
+    monkeypatch.setattr(
+        "provider_backends.claude.execution_runtime.polling.state_session_path",
+        lambda state: "",
+    )
+    monkeypatch.setattr(
+        "provider_backends.claude.execution_runtime.polling.apply_session_rotation",
+        lambda submission, poll, new_session_path, now: None,
+    )
+    return poll_submission(None, submission, now=NOW)
+
+
+def test_poll_submission_resends_once_and_persists_counter(monkeypatch) -> None:
+    submission = _submission(prompt_text=LONG_UNICODE_PROMPT)
+    backend = _RetryBackend(f"{LONG_UNICODE_PROMPT}\n❯\n")
+
+    result = _wired_poll_submission(submission, backend, monkeypatch=monkeypatch)
+
+    assert isinstance(result, ProviderPollResult)
+    assert result.decision is None
+    assert backend.keys == [("%1", "Enter")]
+    # finalize_poll_result 展开 runtime_state，计数跨轮持久化
+    assert result.submission.runtime_state["activation_enter_count"] == 1
+    assert result.submission.runtime_state["activation_enter_at"] == NOW
+
+
+def test_poll_submission_does_not_resend_when_events_show_activation(monkeypatch) -> None:
+    submission = _submission(prompt_text=LONG_UNICODE_PROMPT)
+    backend = _RetryBackend(f"{LONG_UNICODE_PROMPT}\n❯\n")
+
+    # 事件已观察到 anchor → poll.anchor_seen=True → 不得重发
+    result = _wired_poll_submission(
+        submission,
+        backend,
+        poll=_poll(anchor_seen=True),
+        monkeypatch=monkeypatch,
+    )
+
+    assert isinstance(result, ProviderPollResult)
+    assert result.decision is None
+    assert backend.keys == []


### PR DESCRIPTION
## Problem

When a long prompt (especially multi-KB Unicode / Chinese text) is sent to a
managed Claude TUI over tmux, the job can hang in `delivering` forever with no
request anchor ever appearing. Pressing Enter manually in the pane recovers it.

**Root cause:** tmux `paste-buffer` returning only means bytes were written to
the pty. The Claude TUI consumes/renders a bracketed-paste stream
asynchronously, so for a long payload the initial Enter (sent after
`CCB_TMUX_ENTER_DELAY`) can land while the composer is still inserting and be
swallowed — the prompt stays in the composer, the request anchor never appears,
and nothing in the polling layer ever re-submits it. The TUI has no paste ACK,
so the request anchor is the only real activation proof.

Related reports: #282 (Claude TUI stuck at a missed request anchor), #287
(stuck `delivering`), #178 (delivery reliability gaps). This is a targeted fix
for the Enter-swallow case, not a claim those are identical.

## Change (minimal, Claude polling layer only)

Adds a bounded, one-time "activation Enter" retry in
`provider_backends/claude/execution_runtime/polling.py`. It re-sends `Enter`
**at most once**, and only when **all** of these hold:

- the prompt was already dispatched (`prompt_sent`) with a timestamp;
- the current job is not yet activated (no `prompt_activated` / `anchor_seen`);
- the elapsed time since dispatch is inside a bounded grace window
  (`CCB_CLAUDE_ACTIVATION_GRACE_S`, default 6s → window `[6, 12)s`);
- the pane is not busy (no `esc to interrupt`) and still holds this job's
  recognizable prompt/anchor text (an empty composer cannot match);
- this job has not already re-sent Enter (`activation_enter_count < 1`).

**Anti-double-submit:** the retry is disabled when the prompt is already
activated, the composer is empty, the pane is busy, the visible text does not
belong to this job, the grace window has passed, or a retry was already sent.
The counter is persisted via `export_runtime_state` and across poll rounds, so
repeated polling can never send more than one extra Enter. The vendored tmux
sender is untouched and the prompt is never re-pasted.

## Tests

Adds `test/test_claude_activation_enter_retry.py` (17 deterministic cases):

- long Unicode / multi-KB prompt in an idle composer with no anchor → exactly
  one `send_key(..., "Enter")` after the grace window;
- already anchored / already activated / idle composer without this job's text /
  composer holding a different job's text / busy pane / grace not reached /
  grace passed / already re-sent / prompt not sent / pane read failure / backend
  without `send_key` → 0 sends;
- repeated polling never exceeds one send;
- `CCB_CLAUDE_ACTIVATION_GRACE_S` override and `no_wrap` anchor fallback;
- `poll_submission` wiring persists the counter across rounds.

Existing Claude polling tests (164), tmux sender tests, and the new tests pass
locally. The full default suite also needs the project's normal runtime deps /
environment (tmux, Docker, network), which are exercised in CI.

## Reproduction (manual)

Send a long (multi-KB) Chinese prompt to a managed Claude pane; the job stays
in `delivering`, the pane shows the prompt still sitting in the input box, and
pressing Enter manually makes the anchor appear and the job proceed.
