### PR TITLE
Fix shell wrapper, pane authority, and Windows subprocess output handling

### DIFF
--- a/lib/cli/kill_runtime/zombies.py
+++ b/lib/cli/kill_runtime/zombies.py
@@ -35,6 +35,8 @@ def _list_tmux_sessions() -> list[str]:
             ["tmux", "list-sessions", "-F", "#{session_name}"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=5,
         )
     except Exception:

--- a/lib/cli/render_runtime/common.py
+++ b/lib/cli/render_runtime/common.py
@@ -93,6 +93,10 @@ def render_worktree_retirements(items: Sequence[object]) -> tuple[str, ...]:
             f'reason={getattr(item, "reason", "")} '
             f'branch={branch_name} '
             f'removed_agent_state={_tri_state(getattr(item, "removed_agent_state", None))} '
+            f'cleanup_deferred={_tri_state(getattr(item, "cleanup_deferred", None))} '
+            f'cleanup_deferred_persisted={_tri_state(getattr(item, "cleanup_deferred_persisted", None))} '
+            f'cleanup_marker_cleared={_tri_state(getattr(item, "cleanup_marker_cleared", None))} '
+            f'cleanup_reason={cleanup_field(getattr(item, "cleanup_reason", None), default="-")} '
             f'path={workspace_path}'
         )
     return tuple(lines)

--- a/lib/cli/services/runtime_launch_runtime/tmux_runtime.py
+++ b/lib/cli/services/runtime_launch_runtime/tmux_runtime.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from time import monotonic_ns
+from time import monotonic_ns, time_ns
 
 from terminal_runtime.tmux_identity import apply_ccb_pane_identity
 from project_command_trust import require_runtime_provider_command_approval
@@ -179,11 +179,10 @@ def launch_runtime(
 
         stage_started_ns = monotonic_ns()
         try:
-            _report_runtime_pane_agent(
+            _release_runtime_pane_agent(
                 backend,
                 pane,
                 provider_kind=spec.provider,
-                session_id=launch_session_id,
             )
         finally:
             _record_elapsed_ms(timings_ms, 'pane_agent_report', stage_started_ns)
@@ -286,24 +285,34 @@ def _apply_runtime_pane_identity(
     )
 
 
-def _report_runtime_pane_agent(
+def _release_runtime_pane_agent(
     backend,
     pane,
     *,
     provider_kind: str,
-    session_id: str,
 ) -> None:
+    """方案 A：启动时释放 CCB 对该面板生命周期状态的“权威”，交还 Herdr 原生检测。
+
+    历史上 CCB 会 `report-agent --source ccb --state unknown` 夺取权威且此后不再更新，
+    导致侧栏 agents 面板状态冻结在 unknown（`state_change_seq` 不再前进）。改为在启动/
+    respawn 时释放权威：对全新面板是无害 no-op；对被夺权过的存量面板（respawn 复用同一
+    pane_id）则清掉陈旧 ccb 记录，让原生检测重新接管状态。best-effort，绝不因此中断启动。
+    """
     if not (isinstance(pane, dict) and str(pane.get('backend_impl') or '').strip() == 'herdr'):
         return
-    reporter = getattr(backend, 'report_pane_agent', None)
-    if not callable(reporter):
-        raise RuntimeError('Herdr backend does not support report_pane_agent')
-    reporter(
-        dict(pane),
-        provider_kind=provider_kind,
-        state='unknown',
-        session_id=session_id,
-    )
+    releaser = getattr(backend, 'release_pane_agent', None)
+    if not callable(releaser):
+        return
+    try:
+        # seq 用启动时的墙钟毫秒：跨 CCB 重启仍单调递增，确保能盖过此前小 seq 的陈旧上报。
+        releaser(
+            dict(pane),
+            provider_kind=provider_kind,
+            seq=time_ns() // 1_000_000,
+        )
+    except Exception:
+        # 释放失败（例如该面板本就无 ccb 权威记录）不影响启动；原生检测仍会接管新进程。
+        return
 
 
 def _runtime_backend_family(pane, namespace_ref: dict[str, object] | None) -> str:

--- a/lib/platforms/windows/herdr/backend.py
+++ b/lib/platforms/windows/herdr/backend.py
@@ -213,6 +213,22 @@ class HerdrBackend(TerminalBackend):
             session_path=session_path,
         )
 
+    def release_pane_agent(
+        self,
+        pane: MuxPaneRefV2,
+        *,
+        provider_kind: str,
+        seq: int | None = None,
+    ) -> MuxOperationEvidenceV2:
+        pane_ref = self._pane_ref(pane, operation="release_pane_agent")
+        self._capability_gate.require_supported("release_pane_agent")
+        self._client.server_info()
+        return self._client.release_pane_agent(
+            pane_ref,
+            provider_kind=provider_kind,
+            seq=seq,
+        )
+
     def describe_pane(
         self,
         pane_id: str,

--- a/lib/platforms/windows/herdr/runtime/capabilities.py
+++ b/lib/platforms/windows/herdr/runtime/capabilities.py
@@ -34,6 +34,7 @@ _OPERATION_REQUIRED_CAPABILITIES = {
     "window_root_pane": ("workspace_list", "pane_list"),
     "set_pane_identity": ("pane_list", "pane_metadata"),
     "report_pane_agent": ("pane_list", "pane_metadata"),
+    "release_pane_agent": ("pane_list", "pane_metadata"),
     "describe_pane": ("pane_list",),
     "list_panes_by_user_options": ("pane_list",),
     "create_pane": ("pane_list", "pane_split", "pane_run"),

--- a/lib/platforms/windows/herdr/runtime/cli.py
+++ b/lib/platforms/windows/herdr/runtime/cli.py
@@ -75,6 +75,8 @@ class HerdrCliRequestAdapter:
             return self._set_pane_identity(payload)
         if operation == "report_pane_agent":
             return self._report_pane_agent(payload)
+        if operation == "release_pane_agent":
+            return self._release_pane_agent(payload)
         if operation == "respawn_pane":
             return self._respawn_pane(payload)
         if operation == "pane_process_info":
@@ -573,6 +575,40 @@ class HerdrCliRequestAdapter:
             "pane_id": pane_id,
             "provider_kind": provider_kind,
             "state": state,
+        }
+
+    def _release_pane_agent(self, payload: Mapping[str, object]) -> Mapping[str, object]:
+        # 释放 CCB 对该面板生命周期状态的“权威”，把状态判定交还 Herdr 原生检测。
+        # 用于方案 A：CCB 不再用 report-agent 钉死 state，避免侧栏冻结在陈旧状态。
+        pane_id = str(payload.get("pane_id") or "").strip()
+        session_name = _session_name_from_payload(payload, fallback_session_name=self._session_name)
+        provider_kind = str(payload.get("provider_kind") or "").strip()
+        if not pane_id:
+            raise self._failed("release_pane_agent", "requires pane_id", session_name=session_name)
+        if not provider_kind:
+            raise self._failed("release_pane_agent", "requires provider_kind", session_name=session_name)
+        args = [
+            "pane",
+            "release-agent",
+            pane_id,
+            "--source",
+            _METADATA_SOURCE,
+            "--agent",
+            provider_kind,
+        ]
+        seq = payload.get("seq")
+        if seq is not None and str(seq).strip():
+            args.extend(["--seq", str(seq).strip()])
+        self._command(
+            "release_pane_agent",
+            args,
+            expect_json=False,
+            session_name=session_name,
+        )
+        return {
+            "status": "ok",
+            "pane_id": pane_id,
+            "provider_kind": provider_kind,
         }
 
     def _respawn_pane(self, payload: Mapping[str, object]) -> Mapping[str, object]:

--- a/lib/platforms/windows/herdr/runtime/client.py
+++ b/lib/platforms/windows/herdr/runtime/client.py
@@ -517,6 +517,27 @@ class HerdrSocketClient:
         )
         return _operation_evidence("report_pane_agent", pane, response, detail="pane agent reported")
 
+    def release_pane_agent(
+        self,
+        pane: MuxPaneRefV2,
+        *,
+        provider_kind: str,
+        seq: int | None = None,
+    ) -> MuxOperationEvidenceV2:
+        payload: dict[str, object] = {
+            "pane_id": pane["pane_id"],
+            "session_name": pane["session_name"],
+            "provider_kind": provider_kind,
+        }
+        if seq is not None:
+            payload["seq"] = seq
+        response = self._request(
+            "release_pane_agent",
+            payload,
+            require_status=True,
+        )
+        return _operation_evidence("release_pane_agent", pane, response, detail="pane agent released")
+
     def select_window(
         self,
         namespace: MuxNamespaceRefV2,

--- a/lib/provider_backends/claude/launcher_runtime/service.py
+++ b/lib/provider_backends/claude/launcher_runtime/service.py
@@ -148,6 +148,13 @@ def build_start_cmd(
     cmd_parts.extend(spec.startup_args)
 
     cmd = ' '.join(shlex.quote(str(part)) for part in cmd_parts)
+    # Herdr starts a PowerShell wrapper which invokes sh.exe. Replace that
+    # shell from inside the POSIX command so Herdr sees Claude as the pane's
+    # foreground process. Apply this before a provider template is expanded:
+    # e.g. `sandbox=1 {command}` becomes `sandbox=1 exec claude ...`, not
+    # `exec sandbox=1 claude ...`.
+    if str(launch_context.get('ccb_backend_impl') or '').strip() == 'herdr':
+        cmd = f'exec {cmd}'
     cmd = apply_provider_command_template(cmd, spec.provider_command_template)
     if env_prefix:
         return f'{env_prefix}; {cmd}'

--- a/lib/provider_backends/gemini/launcher_runtime/service.py
+++ b/lib/provider_backends/gemini/launcher_runtime/service.py
@@ -82,6 +82,13 @@ def build_start_cmd(
         cmd_parts.extend(["--resume", "latest"])
     cmd_parts.extend(spec.startup_args)
     cmd = " ".join(shlex.quote(str(part)) for part in cmd_parts)
+    # Herdr starts a PowerShell wrapper which invokes sh.exe. Replace that
+    # shell from inside the POSIX command so Herdr sees Gemini as the pane's
+    # foreground process. Apply this before a provider template is expanded:
+    # e.g. `sandbox=1 {command}` becomes `sandbox=1 exec gemini`, not
+    # `exec sandbox=1 gemini`.
+    if str(launch_context.get('ccb_backend_impl') or '').strip() == 'herdr':
+        cmd = f'exec {cmd}'
     cmd = apply_provider_command_template(cmd, spec.provider_command_template)
     env_prefix = join_env_prefix(
         build_gemini_env_prefix(profile=profile, extra_env=spec.env),

--- a/lib/runtime_accelerator/ownership.py
+++ b/lib/runtime_accelerator/ownership.py
@@ -465,6 +465,8 @@ def _read_process_start_token(pid: int) -> str:
             check=False,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
         )
     except Exception:
         return ""
@@ -479,6 +481,8 @@ def _read_process_cwd_via_lsof(pid: int) -> Path | None:
             check=False,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
         )
     except Exception:
         return None
@@ -497,6 +501,8 @@ def _read_process_executable_via_lsof(pid: int) -> Path | None:
             check=False,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
         )
     except Exception:
         return None

--- a/lib/storage/paths_agents.py
+++ b/lib/storage/paths_agents.py
@@ -49,6 +49,10 @@ class AgentRuntimePathMixin:
     def agent_events_path(self, agent_name: str) -> Path:
         return self.agent_dir(agent_name) / 'events.jsonl'
 
+    def agent_cleanup_deferred_path(self, agent_name: str) -> Path:
+        normalized = normalize_agent_name(agent_name)
+        return self.runtime_state_root / 'state' / 'agent-cleanup' / f'{normalized}.json'
+
     def agent_provider_runtime_dir(self, agent_name: str, provider: str) -> Path:
         normalized_provider = str(provider or '').strip().lower()
         if not normalized_provider:

--- a/lib/workspace/reconcile.py
+++ b/lib/workspace/reconcile.py
@@ -1,16 +1,21 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timezone
+import json
 import os
 from pathlib import Path
 import shutil
 import stat
 import sys
+import time
 
-from agents.models import AgentSpec, WorkspaceMode
-from agents.store import AgentSpecStore
+from agents.models import AgentRuntime, AgentSpec, AgentState, WorkspaceMode, normalize_agent_name
+from agents.store import AgentRuntimeStore, AgentSpecStore
+from cli.kill_runtime.processes import is_pid_alive
 from project.ids import compute_project_id
 from project.resolver import ProjectContext
+from storage.atomic import atomic_write_json
 from storage.paths import PathLayout
 
 from .git_worktree import (
@@ -22,6 +27,10 @@ from .git_worktree import (
     workspace_is_dirty,
 )
 from .planner import WorkspacePlanner
+
+
+_RMTREE_RETRY_DELAYS_S = (0.05, 0.1, 0.2)
+_CLEANUP_DEFERRED_SCHEMA_VERSION = 1
 
 
 @dataclass(frozen=True)
@@ -47,6 +56,27 @@ class WorkspaceRetirement:
     workspace_path: str
     reason: str
     removed_agent_state: bool = False
+    cleanup_deferred: bool = False
+    cleanup_reason: str | None = None
+    cleanup_deferred_persisted: bool | None = None
+    cleanup_marker_cleared: bool | None = None
+
+
+@dataclass(frozen=True)
+class AgentStateCleanupResult:
+    removed: bool
+    deferred: bool = False
+    reason: str | None = None
+    deferred_persisted: bool | None = None
+    marker_cleared: bool | None = None
+
+
+@dataclass(frozen=True)
+class _AgentStateCleanupDecision:
+    can_remove: bool
+    reason: str | None = None
+    runtime_state: str | None = None
+    live_pids: tuple[int, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -62,11 +92,13 @@ def reconcile_start_workspaces(project_root: Path, config) -> WorkspaceGuardSumm
     project_ctx = _project_context(root)
     persisted_specs = _load_persisted_specs(paths)
     desired_specs = dict(config.agents)
+    deferred_cleanup = _load_deferred_cleanup(paths)
 
     warnings: list[WorktreeAlert] = []
     blockers: list[WorktreeAlert] = []
     pending_worktree_retirements: list[tuple[AgentSpec, str, bool, bool]] = []
     pending_state_cleanup: list[tuple[str, str]] = []
+    pending_state_cleanup_names: set[str] = set()
 
     for agent_name, persisted_spec in persisted_specs.items():
         desired_spec = desired_specs.get(agent_name)
@@ -78,6 +110,7 @@ def reconcile_start_workspaces(project_root: Path, config) -> WorkspaceGuardSumm
             if persisted_plan.workspace_scope == 'external':
                 if desired_spec is None:
                     pending_state_cleanup.append((agent_name, 'removed_from_config'))
+                    pending_state_cleanup_names.add(agent_name)
                 continue
             alert = _inspect_worktree(root, project_ctx, persisted_spec, reason=reason)
             if alert.needs_merge:
@@ -92,6 +125,13 @@ def reconcile_start_workspaces(project_root: Path, config) -> WorkspaceGuardSumm
             continue
         if desired_spec is None:
             pending_state_cleanup.append((agent_name, 'removed_from_config'))
+            pending_state_cleanup_names.add(agent_name)
+
+    for agent_name in deferred_cleanup:
+        if agent_name in desired_specs or agent_name in pending_state_cleanup_names:
+            continue
+        pending_state_cleanup.append((agent_name, 'deferred_cleanup_retry'))
+        pending_state_cleanup_names.add(agent_name)
 
     for spec in desired_specs.values():
         if spec.workspace_mode is not WorkspaceMode.GIT_WORKTREE:
@@ -122,14 +162,18 @@ def reconcile_start_workspaces(project_root: Path, config) -> WorkspaceGuardSumm
             )
         )
     for agent_name, reason in pending_state_cleanup:
-        _remove_agent_state(paths, agent_name)
+        cleanup = _remove_agent_state(paths, agent_name)
         retired.append(
             WorkspaceRetirement(
                 agent_name=agent_name,
                 branch_name=None,
                 workspace_path='',
                 reason=reason,
-                removed_agent_state=True,
+                removed_agent_state=cleanup.removed,
+                cleanup_deferred=cleanup.deferred,
+                cleanup_reason=cleanup.reason,
+                cleanup_deferred_persisted=cleanup.deferred_persisted,
+                cleanup_marker_cleared=cleanup.marker_cleared,
             )
         )
 
@@ -290,41 +334,224 @@ def _retire_worktree_spec(
         if plan.branch_name:
             delete_branch(project_root, plan.branch_name)
     if remove_agent_state:
-        _remove_agent_state(paths, spec.name)
+        cleanup = _remove_agent_state(paths, spec.name)
+    else:
+        cleanup = AgentStateCleanupResult(removed=False)
     return WorkspaceRetirement(
         agent_name=spec.name,
         branch_name=plan.branch_name,
         workspace_path=str(plan.workspace_path),
         reason=reason,
-        removed_agent_state=remove_agent_state,
+        removed_agent_state=cleanup.removed,
+        cleanup_deferred=cleanup.deferred,
+        cleanup_reason=cleanup.reason,
+        cleanup_deferred_persisted=cleanup.deferred_persisted,
+        cleanup_marker_cleared=cleanup.marker_cleared,
     )
 
 
-def _remove_agent_state(paths: PathLayout, agent_name: str) -> None:
-    for target in (paths.agent_dir(agent_name), paths.agent_mailbox_dir(agent_name)):
-        if target.is_symlink() or target.is_file():
-            target.unlink()
+def _remove_agent_state(paths: PathLayout, agent_name: str) -> AgentStateCleanupResult:
+    decision = _agent_state_cleanup_decision(paths, agent_name)
+    if not decision.can_remove:
+        deferred_persisted = _write_cleanup_deferred(paths, agent_name, decision)
+        return AgentStateCleanupResult(
+            removed=False,
+            deferred=True,
+            reason=decision.reason,
+            deferred_persisted=deferred_persisted,
+        )
+
+    try:
+        for target in (paths.agent_dir(agent_name), paths.agent_mailbox_dir(agent_name)):
+            if target.is_symlink() or target.is_file():
+                target.unlink()
+                continue
+            if target.is_dir():
+                _rmtree_agent_state(target)
+    except PermissionError as exc:
+        if not _is_file_in_use_error(exc):
+            raise
+        decision = _AgentStateCleanupDecision(
+            can_remove=False,
+            reason='file_in_use',
+        )
+        deferred_persisted = _write_cleanup_deferred(paths, agent_name, decision)
+        return AgentStateCleanupResult(
+            removed=False,
+            deferred=True,
+            reason=decision.reason,
+            deferred_persisted=deferred_persisted,
+        )
+
+    marker_cleared = _clear_cleanup_deferred(paths, agent_name)
+    return AgentStateCleanupResult(
+        removed=True,
+        reason=None if marker_cleared else 'deferred_marker_clear_failed',
+        marker_cleared=marker_cleared,
+    )
+
+
+def _agent_state_cleanup_decision(
+    paths: PathLayout,
+    agent_name: str,
+) -> _AgentStateCleanupDecision:
+    runtime_path = paths.agent_runtime_path(agent_name)
+    if not runtime_path.exists():
+        return _AgentStateCleanupDecision(can_remove=True)
+
+    try:
+        runtime = AgentRuntimeStore(paths).load(agent_name)
+    except Exception:
+        return _AgentStateCleanupDecision(
+            can_remove=False,
+            reason='runtime_unreadable',
+        )
+    if runtime is None:
+        return _AgentStateCleanupDecision(
+            can_remove=False,
+            reason='runtime_unknown',
+        )
+
+    live_pids = _live_runtime_pids(runtime)
+    if live_pids:
+        return _AgentStateCleanupDecision(
+            can_remove=False,
+            reason='runtime_process_alive',
+            runtime_state=runtime.state.value,
+            live_pids=live_pids,
+        )
+    if runtime.state is not AgentState.STOPPED:
+        return _AgentStateCleanupDecision(
+            can_remove=False,
+            reason=f'runtime_state_{runtime.state.value}',
+            runtime_state=runtime.state.value,
+        )
+    return _AgentStateCleanupDecision(
+        can_remove=True,
+        runtime_state=runtime.state.value,
+    )
+
+
+def _live_runtime_pids(runtime: AgentRuntime) -> tuple[int, ...]:
+    live: list[int] = []
+    for value in (runtime.pid, runtime.runtime_pid):
+        try:
+            pid = int(value or 0)
+        except (TypeError, ValueError):
             continue
-        if target.is_dir():
-            _rmtree_agent_state(target)
+        if pid <= 0 or pid in live:
+            continue
+        if is_pid_alive(pid):
+            live.append(pid)
+    return tuple(live)
+
+
+def _write_cleanup_deferred(
+    paths: PathLayout,
+    agent_name: str,
+    decision: _AgentStateCleanupDecision,
+) -> bool:
+    payload = {
+        'schema_version': _CLEANUP_DEFERRED_SCHEMA_VERSION,
+        'record_type': 'agent_cleanup_deferred',
+        'agent_name': agent_name,
+        'reason': decision.reason or 'unknown',
+        'runtime_state': decision.runtime_state,
+        'live_pids': list(decision.live_pids),
+        'created_at': _utc_now(),
+    }
+    try:
+        atomic_write_json(paths.agent_cleanup_deferred_path(agent_name), payload)
+    except OSError:
+        # Cleanup must remain non-destructive even if the marker cannot be written.
+        return False
+    return True
+
+
+def _clear_cleanup_deferred(paths: PathLayout, agent_name: str) -> bool:
+    try:
+        paths.agent_cleanup_deferred_path(agent_name).unlink()
+    except FileNotFoundError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _load_deferred_cleanup(paths: PathLayout) -> dict[str, str]:
+    root = paths.runtime_state_root / 'state' / 'agent-cleanup'
+    if not root.is_dir():
+        return {}
+    deferred: dict[str, str] = {}
+    for marker in sorted(root.glob('*.json')):
+        try:
+            payload = json.loads(marker.read_text(encoding='utf-8'))
+            if not isinstance(payload, dict):
+                continue
+            if payload.get('schema_version') != _CLEANUP_DEFERRED_SCHEMA_VERSION:
+                continue
+            agent_name = normalize_agent_name(str(payload.get('agent_name') or marker.stem))
+            if agent_name != marker.stem:
+                continue
+            if payload.get('record_type') != 'agent_cleanup_deferred':
+                continue
+        except (OSError, UnicodeError, ValueError, TypeError):
+            continue
+        deferred[agent_name] = str(payload.get('reason') or 'deferred_cleanup_retry')
+    return deferred
 
 
 def _rmtree_agent_state(target: Path) -> None:
-    if sys.version_info >= (3, 12):
-        shutil.rmtree(target, onexc=_retry_remove_readonly)
-        return
+    attempts = len(_RMTREE_RETRY_DELAYS_S) + 1
+    for attempt in range(attempts):
+        try:
+            if sys.version_info >= (3, 12):
+                shutil.rmtree(target, onexc=_retry_remove_readonly)
+            else:
+                def onerror(function, path, exc_info) -> None:
+                    _retry_remove_readonly(function, path, exc_info[1])
 
-    def onerror(function, path, exc_info) -> None:
-        _retry_remove_readonly(function, path, exc_info[1])
-
-    shutil.rmtree(target, onerror=onerror)
+                shutil.rmtree(target, onerror=onerror)
+            return
+        except PermissionError as exc:
+            if not _is_file_in_use_error(exc) or attempt >= attempts - 1:
+                raise
+            time.sleep(_RMTREE_RETRY_DELAYS_S[attempt])
 
 
 def _retry_remove_readonly(function, path, excinfo) -> None:
     if not isinstance(excinfo, PermissionError):
         raise excinfo
+    if _is_file_in_use_error(excinfo):
+        _retry_file_in_use(function, path, excinfo)
+        return
     os.chmod(path, stat.S_IREAD | stat.S_IWRITE | stat.S_IEXEC)
     function(path)
+
+
+def _retry_file_in_use(function, path, exc: PermissionError) -> None:
+    last_error = exc
+    for delay in _RMTREE_RETRY_DELAYS_S:
+        time.sleep(delay)
+        try:
+            function(path)
+            return
+        except PermissionError as retry_error:
+            if not _is_file_in_use_error(retry_error):
+                raise
+            last_error = retry_error
+    raise last_error
+
+
+def _is_file_in_use_error(exc: PermissionError) -> bool:
+    if int(getattr(exc, 'winerror', 0) or 0) == 32:
+        return True
+    message = str(exc).lower()
+    return 'being used' in message or 'used by another process' in message
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
 
 
 def _workspace_binding_authority(plan) -> WorkspaceBindingAuthority:
@@ -430,6 +657,7 @@ def _state_text(value: bool | None) -> str:
 
 
 __all__ = [
+    'AgentStateCleanupResult',
     'WorkspaceGuardSummary',
     'WorkspaceRetirement',
     'WorktreeAlert',

--- a/test/test_ccbd_stop_flow_runtime.py
+++ b/test/test_ccbd_stop_flow_runtime.py
@@ -253,12 +253,6 @@ def test_terminate_runtime_pids_reaps_helper_group_from_manifest(tmp_path: Path,
     removed: list[tuple[Path, ...]] = []
 
     monkeypatch.setattr('provider_runtime.helper_cleanup._kill_helper_group', lambda pgid, sig: killed.append((pgid, int(sig))) or True)
-    monkeypatch.setattr('provider_runtime.helper_cleanup.os.killpg', lambda pgid, sig: killed.append((pgid, int(sig))) or None)
-    monkeypatch.setattr('provider_runtime.helper_cleanup.os.getpgrp', lambda: 999)
-    monkeypatch.setattr(
-        'provider_runtime.helper_cleanup.os.kill',
-        lambda pid, sig: (_ for _ in ()).throw(ProcessLookupError()) if sig == 0 else None,
-    )
 
     terminate_runtime_pids_impl(
         project_root=project_root,

--- a/test/test_cli_kill_runtime_zombies.py
+++ b/test/test_cli_kill_runtime_zombies.py
@@ -85,6 +85,24 @@ def test_find_all_zombie_sessions_filters_dead_parents() -> None:
     ]
 
 
+def test_list_tmux_sessions_uses_utf8_replacement(monkeypatch) -> None:
+    os_proxy = SimpleNamespace(name='posix')
+    calls: list[dict] = []
+
+    monkeypatch.setattr(zombies, 'os', os_proxy)
+    monkeypatch.setattr(zombies.shutil, 'which', lambda name: 'tmux')
+
+    def fake_run(*args, **kwargs):
+        calls.append(kwargs)
+        return SimpleNamespace(returncode=0, stdout='gemini-123-worker\n')
+
+    monkeypatch.setattr(zombies.subprocess, 'run', fake_run)
+
+    assert zombies._list_tmux_sessions() == ['gemini-123-worker']
+    assert calls[0]['encoding'] == 'utf-8'
+    assert calls[0]['errors'] == 'replace'
+
+
 def test_kill_global_zombies_reports_partial_failures(capsys) -> None:
     code = zombies.kill_global_zombies(
         yes=True,

--- a/test/test_herdr_backend_client.py
+++ b/test/test_herdr_backend_client.py
@@ -4153,6 +4153,53 @@ def test_herdr_cli_request_adapter_reports_pane_agent() -> None:
     ]
 
 
+def test_herdr_cli_request_adapter_releases_pane_agent() -> None:
+    commands: list[list[str]] = []
+
+    def run_fn(command, **kwargs):
+        commands.append(list(command))
+        return _completed("")
+
+    adapter = HerdrCliRequestAdapter(
+        session_name="ccb-demo",
+        herdr_executable="herdr",
+        run_fn=run_fn,
+        which_fn=lambda name: "herdr",
+    )
+
+    result = adapter(
+        "release_pane_agent",
+        {
+            "pane_id": "w1:p2",
+            "session_name": "ccb-demo",
+            "provider_kind": "claude",
+            "seq": 1234,
+        },
+    )
+
+    assert result == {
+        "status": "ok",
+        "pane_id": "w1:p2",
+        "provider_kind": "claude",
+    }
+    assert commands == [
+        [
+            "herdr",
+            "--session",
+            "ccb-demo",
+            "pane",
+            "release-agent",
+            "w1:p2",
+            "--source",
+            "ccb",
+            "--agent",
+            "claude",
+            "--seq",
+            "1234",
+        ]
+    ]
+
+
 def test_herdr_cli_request_adapter_is_alive_maps_command_not_found_to_false() -> None:
     def run_fn(command, **kwargs):
         raise _called_process_error(command, stderr="pane not found")

--- a/test/test_provider_helper_cleanup.py
+++ b/test/test_provider_helper_cleanup.py
@@ -20,6 +20,16 @@ def _write_helper(path, *, runtime_generation: int = 1, leader_pid: int = 777, p
     )
 
 
+def _patch_posix_os(monkeypatch, killed: list[tuple[int, int]]) -> None:
+    os_proxy = SimpleNamespace(
+        name='posix',
+        getpgrp=lambda: 999,
+        killpg=lambda pgid, sig: killed.append((pgid, int(sig))) or None,
+        kill=lambda pid, sig: (_ for _ in ()).throw(ProcessLookupError()) if sig == 0 else None,
+    )
+    monkeypatch.setattr('provider_runtime.helper_cleanup.os', os_proxy)
+
+
 def test_save_helper_manifest_skips_identical_atomic_rewrite(tmp_path) -> None:
     path = tmp_path / 'helper.json'
     manifest = ProviderHelperManifest(
@@ -46,13 +56,7 @@ def test_cleanup_stale_runtime_helper_reaps_superseded_manifest(tmp_path, monkey
     _write_helper(helper_path, runtime_generation=1, leader_pid=777, pgid=888)
     killed: list[tuple[int, int]] = []
 
-    monkeypatch.setattr('provider_runtime.helper_cleanup.os.name', 'posix')
-    monkeypatch.setattr('provider_runtime.helper_cleanup.os.getpgrp', lambda: 999)
-    monkeypatch.setattr('provider_runtime.helper_cleanup.os.killpg', lambda pgid, sig: killed.append((pgid, int(sig))) or None)
-    monkeypatch.setattr(
-        'provider_runtime.helper_cleanup.os.kill',
-        lambda pid, sig: (_ for _ in ()).throw(ProcessLookupError()) if sig == 0 else None,
-    )
+    _patch_posix_os(monkeypatch, killed)
 
     reaped = cleanup_stale_runtime_helper(
         layout,
@@ -96,13 +100,7 @@ def test_cleanup_stale_runtime_helper_requires_canonical_runtime_generation(tmp_
     _write_helper(helper_path, runtime_generation=3, leader_pid=777, pgid=888)
     killed: list[tuple[int, int]] = []
 
-    monkeypatch.setattr('provider_runtime.helper_cleanup.os.name', 'posix')
-    monkeypatch.setattr('provider_runtime.helper_cleanup.os.getpgrp', lambda: 999)
-    monkeypatch.setattr('provider_runtime.helper_cleanup.os.killpg', lambda pgid, sig: killed.append((pgid, int(sig))) or None)
-    monkeypatch.setattr(
-        'provider_runtime.helper_cleanup.os.kill',
-        lambda pid, sig: (_ for _ in ()).throw(ProcessLookupError()) if sig == 0 else None,
-    )
+    _patch_posix_os(monkeypatch, killed)
 
     reaped = cleanup_stale_runtime_helper(
         layout,
@@ -127,13 +125,7 @@ def test_terminate_helper_manifest_path_clears_file_when_leader_is_gone(tmp_path
     _write_helper(helper_path, leader_pid=501, pgid=601)
     killed: list[tuple[int, int]] = []
 
-    monkeypatch.setattr('provider_runtime.helper_cleanup.os.name', 'posix')
-    monkeypatch.setattr('provider_runtime.helper_cleanup.os.getpgrp', lambda: 999)
-    monkeypatch.setattr('provider_runtime.helper_cleanup.os.killpg', lambda pgid, sig: killed.append((pgid, int(sig))) or None)
-    monkeypatch.setattr(
-        'provider_runtime.helper_cleanup.os.kill',
-        lambda pid, sig: (_ for _ in ()).throw(ProcessLookupError()) if sig == 0 else None,
-    )
+    _patch_posix_os(monkeypatch, killed)
 
     assert terminate_helper_manifest_path(helper_path) is True
     assert helper_path.exists() is False

--- a/test/test_runtime_accelerator_ownership.py
+++ b/test/test_runtime_accelerator_ownership.py
@@ -138,6 +138,38 @@ def test_lsof_executable_reader_ignores_non_accelerator_text_mappings(monkeypatc
     )
 
 
+@pytest.mark.parametrize(
+    ('reader_name', 'expected'),
+    (
+        ('_read_process_start_token', 'ps:Tue Jul 14 16:00:00 2026'),
+        ('_read_process_cwd_via_lsof', None),
+        ('_read_process_executable_via_lsof', None),
+    ),
+)
+def test_process_identity_subprocess_readers_use_utf8_replacement(
+    monkeypatch,
+    reader_name: str,
+    expected,
+) -> None:
+    calls: list[dict] = []
+
+    def fake_run(*args, **kwargs):
+        calls.append(kwargs)
+        return SimpleNamespace(
+            returncode=0 if reader_name == '_read_process_start_token' else 1,
+            stdout='Tue Jul 14 16:00:00 2026' if reader_name == '_read_process_start_token' else '',
+        )
+
+    monkeypatch.setattr("runtime_accelerator.ownership.subprocess.run", fake_run)
+
+    from runtime_accelerator import ownership
+
+    assert getattr(ownership, reader_name)(999999999) == expected
+    assert calls
+    assert calls[0]['encoding'] == 'utf-8'
+    assert calls[0]['errors'] == 'replace'
+
+
 def test_recorded_owner_waits_through_pre_exec_identity(monkeypatch, tmp_path: Path) -> None:
     project_root = tmp_path / "project"
     project_root.mkdir()

--- a/test/test_runtime_launch_timings.py
+++ b/test/test_runtime_launch_timings.py
@@ -165,8 +165,8 @@ def test_launch_tmux_runtime_uses_herdr_assigned_pane_ref_without_tmux_fallback(
         def set_pane_identity(self, pane, **kwargs):
             calls.append(('set_pane_identity', (dict(pane), dict(kwargs))))
 
-        def report_pane_agent(self, pane, **kwargs):
-            calls.append(('report_pane_agent', (dict(pane), dict(kwargs))))
+        def release_pane_agent(self, pane, **kwargs):
+            calls.append(('release_pane_agent', (dict(pane), dict(kwargs))))
 
         def capture_pane(self, pane, *, lines):
             calls.append(('capture_pane', (dict(pane), lines)))
@@ -228,13 +228,14 @@ def test_launch_tmux_runtime_uses_herdr_assigned_pane_ref_without_tmux_fallback(
     assert calls[2][0] == 'set_pane_identity'
     assert calls[2][1][0] == pane_ref
     assert calls[2][1][1]['project_id'] == 'project-test'
-    assert calls[3][0] == 'report_pane_agent'
+    # 方案 A：启动时释放 CCB 生命周期权威（交还原生检测），不再 report 钉死 state。
+    assert calls[3][0] == 'release_pane_agent'
     assert calls[3][1][0] == pane_ref
-    assert calls[3][1][1] == {
-        'provider_kind': 'codex',
-        'state': 'unknown',
-        'session_id': 'ccb-demo-session',
-    }
+    release_kwargs = calls[3][1][1]
+    assert release_kwargs['provider_kind'] == 'codex'
+    # seq 用启动时墙钟毫秒，保证能盖过此前小 seq 的陈旧上报；仅校验类型/正数。
+    assert isinstance(release_kwargs['seq'], int) and release_kwargs['seq'] > 0
+    assert 'state' not in release_kwargs
     assert ('build_session_payload', 'herdr-pane-1') in calls
     assert ('write_session_file', 'herdr-pane-1') in calls
 

--- a/test/test_v2_runtime_launch.py
+++ b/test/test_v2_runtime_launch.py
@@ -3347,6 +3347,40 @@ def test_claude_launcher_provider_command_template_wraps_command_after_env_prefi
     assert 'sandbox=1 unset ANTHROPIC_BASE_URL' not in start_cmd
 
 
+def test_claude_launcher_uses_exec_inside_herdr_shell_wrapper(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    runtime_dir = tmp_path / 'runtime-claude-herdr-exec'
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    spec = _spec(
+        'reviewer',
+        provider='claude',
+        provider_command_template='sandbox=1 {command} omx',
+    )
+    command = ParsedStartCommand(project=None, agent_names=('reviewer',), restore=False, auto_permission=False)
+    prepared_state = _claude_prepared_state(runtime_dir)
+    prepared_state['ccb_backend_impl'] = 'herdr'
+
+    monkeypatch.setattr(claude_launcher, 'is_root_user', lambda: False)
+    monkeypatch.setattr(
+        claude_launcher,
+        '_resolve_claude_restore_target',
+        lambda **kwargs: ProviderRestoreTarget(run_cwd=runtime_dir, has_history=False),
+    )
+
+    start_cmd = claude_launcher.build_start_cmd(
+        command,
+        spec,
+        runtime_dir,
+        'claude-sess-herdr-exec',
+        prepared_state=prepared_state,
+    )
+
+    assert '; sandbox=1 exec claude --setting-sources user,project,local omx' in start_cmd
+    assert 'exec sandbox=1' not in start_cmd
+
+
 def test_claude_launcher_build_start_cmd_forks_linked_continuation(
     monkeypatch,
     tmp_path: Path,
@@ -5006,6 +5040,44 @@ def test_gemini_launcher_build_start_cmd_uses_isolated_profile_api_env(tmp_path:
     assert 'unset GEMINI_API_KEY' in start_cmd
     assert f'GEMINI_API_KEY={shlex.quote("gemini-key")}' in start_cmd
     assert start_cmd.endswith('gemini')
+
+
+@pytest.mark.parametrize(
+    ('backend_impl', 'expects_exec'),
+    (
+        ('herdr', True),
+        (None, False),
+    ),
+)
+def test_gemini_launcher_uses_exec_only_inside_herdr_shell_wrapper(
+    backend_impl: str | None,
+    expects_exec: bool,
+    tmp_path: Path,
+) -> None:
+    runtime_dir = tmp_path / 'runtime-gemini-herdr-exec'
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    spec = _spec(
+        'reviewer',
+        provider='gemini',
+        provider_command_template='sandbox=1 {command} omx',
+    )
+    command = ParsedStartCommand(project=None, agent_names=('reviewer',), restore=False, auto_permission=False)
+    prepared_state: dict[str, object] = {'project_root': tmp_path}
+    if backend_impl is not None:
+        prepared_state['ccb_backend_impl'] = backend_impl
+
+    start_cmd = gemini_launcher.build_start_cmd(
+        command,
+        spec,
+        runtime_dir,
+        'gemini-sess-herdr-exec',
+        prepared_state=prepared_state,
+    )
+
+    expected_command = '; sandbox=1 exec gemini omx' if expects_exec else '; sandbox=1 gemini omx'
+    assert expected_command in start_cmd
+    assert ('exec gemini' in start_cmd) is expects_exec
+    assert 'exec sandbox=1' not in start_cmd
 
 
 def test_gemini_launcher_build_start_cmd_exports_user_session_transport_without_runtime_leaks(

--- a/test/test_v2_workspace_manager.py
+++ b/test/test_v2_workspace_manager.py
@@ -9,14 +9,16 @@ import subprocess
 
 import pytest
 
-from agents.models import AgentSpec, PermissionMode, QueuePolicy, RestoreMode, RuntimeMode, WorkspaceMode
-from agents.store import AgentSpecStore
+from agents.models import AgentRuntime, AgentSpec, AgentState, PermissionMode, QueuePolicy, RestoreMode, RuntimeMode, WorkspaceMode
+from agents.store import AgentRuntimeStore, AgentSpecStore
+from cli.render_runtime.common import render_worktree_retirements
+from project.identity import normalize_work_dir
 from project.resolver import bootstrap_project
 from storage.paths import PathLayout
 from workspace.binding import WorkspaceBindingStore
 from workspace.materializer import WorkspaceMaterializer
 from workspace.planner import WorkspacePlanner
-from workspace.reconcile import reconcile_start_workspaces
+from workspace.reconcile import WorkspaceRetirement, reconcile_start_workspaces
 from workspace.validator import WorkspaceValidator
 
 
@@ -374,7 +376,15 @@ def test_workspace_materializer_recovers_missing_registered_git_worktree(tmp_pat
         stderr=subprocess.PIPE,
         text=True,
     ).stdout
-    assert str(plan.workspace_path) in listing_before
+    worktree_paths = [
+        line[len('worktree ') :].strip()
+        for line in listing_before.splitlines()
+        if line.startswith('worktree ')
+    ]
+    assert any(
+        normalize_work_dir(path) == normalize_work_dir(plan.workspace_path)
+        for path in worktree_paths
+    )
     assert 'prunable ' in listing_before
 
     result = materializer.materialize(plan)
@@ -439,6 +449,9 @@ def test_reconcile_removes_retired_agent_state_with_readonly_files(tmp_path: Pat
     readonly_file.parent.mkdir(parents=True)
     readonly_file.write_text('readonly\n', encoding='utf-8')
     readonly_file.chmod(stat.S_IREAD)
+    mailbox_file = paths.agent_mailbox_dir('retired') / 'mailbox.json'
+    mailbox_file.parent.mkdir(parents=True)
+    mailbox_file.write_text('{}\n', encoding='utf-8')
 
     try:
         summary = reconcile_start_workspaces(project_root, type('Config', (), {'agents': {}})())
@@ -447,9 +460,315 @@ def test_reconcile_removes_retired_agent_state_with_readonly_files(tmp_path: Pat
             os.chmod(readonly_file, stat.S_IREAD | stat.S_IWRITE)
 
     assert paths.agent_dir('retired').exists() is False
+    assert paths.agent_mailbox_dir('retired').exists() is False
     assert len(summary.retired) == 1
     assert summary.retired[0].agent_name == 'retired'
     assert summary.retired[0].removed_agent_state is True
+
+
+@pytest.mark.parametrize(
+    ('pid', 'runtime_pid', 'live_pid'),
+    (
+        (123, None, 123),
+        (None, 456, 456),
+    ),
+)
+def test_reconcile_defers_retired_agent_state_while_runtime_is_alive(
+    tmp_path: Path,
+    monkeypatch,
+    pid: int | None,
+    runtime_pid: int | None,
+    live_pid: int,
+) -> None:
+    project_root = tmp_path / 'repo'
+    project_root.mkdir()
+    context = bootstrap_project(project_root)
+    paths = PathLayout(project_root)
+    spec = _spec(name='retired', workspace_mode=WorkspaceMode.INPLACE)
+    AgentSpecStore(paths).save(spec)
+    AgentRuntimeStore(paths).save(
+        AgentRuntime(
+            agent_name='retired',
+            state=AgentState.IDLE,
+            pid=pid,
+            started_at=None,
+            last_seen_at=None,
+            runtime_ref='mux:w1:p1',
+            session_ref=None,
+            workspace_path=str(project_root),
+            project_id=context.project_id,
+            backend_type='pane-backed',
+            queue_depth=0,
+            socket_path=None,
+            health='healthy',
+            runtime_pid=runtime_pid,
+        )
+    )
+    (paths.agent_dir('retired') / 'provider-state' / 'codex' / 'home').mkdir(parents=True)
+    monkeypatch.setattr('workspace.reconcile.is_pid_alive', lambda pid: pid == live_pid)
+
+    summary = reconcile_start_workspaces(project_root, type('Config', (), {'agents': {}})())
+
+    assert paths.agent_dir('retired').exists() is True
+    assert summary.retired[0].removed_agent_state is False
+    assert summary.retired[0].cleanup_deferred is True
+    assert summary.retired[0].cleanup_reason == 'runtime_process_alive'
+    marker = paths.agent_cleanup_deferred_path('retired')
+    assert marker.exists()
+    payload = json.loads(marker.read_text(encoding='utf-8'))
+    assert payload['reason'] == 'runtime_process_alive'
+    assert payload['live_pids'] == [live_pid]
+
+
+def test_reconcile_defers_retired_agent_state_when_file_is_in_use(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    project_root = tmp_path / 'repo'
+    project_root.mkdir()
+    context = bootstrap_project(project_root)
+    paths = PathLayout(project_root)
+    spec = _spec(name='retired', workspace_mode=WorkspaceMode.INPLACE)
+    AgentSpecStore(paths).save(spec)
+    AgentRuntimeStore(paths).save(
+        AgentRuntime(
+            agent_name='retired',
+            state=AgentState.STOPPED,
+            pid=None,
+            started_at=None,
+            last_seen_at=None,
+            runtime_ref=None,
+            session_ref=None,
+            workspace_path=None,
+            project_id=context.project_id,
+            backend_type='pane-backed',
+            queue_depth=0,
+            socket_path=None,
+            health='stopped',
+        )
+    )
+    state_file = paths.agent_dir('retired') / 'provider-state' / 'codex' / 'home' / 'goals.sqlite'
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text('locked\n', encoding='utf-8')
+
+    def locked_rmtree(*args, **kwargs):
+        del args, kwargs
+        raise PermissionError('file is being used by another process')
+
+    monkeypatch.setattr('workspace.reconcile.shutil.rmtree', locked_rmtree)
+    monkeypatch.setattr('workspace.reconcile.time.sleep', lambda _delay: None)
+
+    summary = reconcile_start_workspaces(project_root, type('Config', (), {'agents': {}})())
+
+    assert paths.agent_dir('retired').exists() is True
+    assert summary.retired[0].removed_agent_state is False
+    assert summary.retired[0].cleanup_deferred is True
+    assert summary.retired[0].cleanup_reason == 'file_in_use'
+    assert paths.agent_cleanup_deferred_path('retired').exists()
+
+
+def test_reconcile_retries_mailbox_cleanup_from_deferred_marker(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    project_root = tmp_path / 'repo'
+    project_root.mkdir()
+    paths = PathLayout(project_root)
+    AgentSpecStore(paths).save(_spec(name='retired', workspace_mode=WorkspaceMode.INPLACE))
+    mailbox_file = paths.agent_mailbox_dir('retired') / 'mailbox.json'
+    mailbox_file.parent.mkdir(parents=True)
+    mailbox_file.write_text('{}\n', encoding='utf-8')
+    original_rmtree = shutil.rmtree
+
+    def remove_agent_then_lock_mailbox(target, *args, **kwargs):
+        if Path(target) == paths.agent_mailbox_dir('retired'):
+            raise PermissionError('file is being used by another process')
+        return original_rmtree(target, *args, **kwargs)
+
+    monkeypatch.setattr('workspace.reconcile.shutil.rmtree', remove_agent_then_lock_mailbox)
+    monkeypatch.setattr('workspace.reconcile.time.sleep', lambda _delay: None)
+
+    first = reconcile_start_workspaces(project_root, type('Config', (), {'agents': {}})())
+
+    assert paths.agent_dir('retired').exists() is False
+    assert paths.agent_mailbox_dir('retired').exists() is True
+    assert first.retired[0].cleanup_deferred is True
+    assert paths.agent_cleanup_deferred_path('retired').exists()
+
+    monkeypatch.setattr('workspace.reconcile.shutil.rmtree', original_rmtree)
+    second = reconcile_start_workspaces(project_root, type('Config', (), {'agents': {}})())
+
+    assert paths.agent_mailbox_dir('retired').exists() is False
+    assert paths.agent_cleanup_deferred_path('retired').exists() is False
+    assert second.retired[0].reason == 'deferred_cleanup_retry'
+    assert second.retired[0].removed_agent_state is True
+
+
+def test_reconcile_reports_deferred_marker_write_failure(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    project_root = tmp_path / 'repo'
+    project_root.mkdir()
+    context = bootstrap_project(project_root)
+    paths = PathLayout(project_root)
+    AgentSpecStore(paths).save(_spec(name='retired', workspace_mode=WorkspaceMode.INPLACE))
+    AgentRuntimeStore(paths).save(
+        AgentRuntime(
+            agent_name='retired',
+            state=AgentState.IDLE,
+            pid=123,
+            started_at=None,
+            last_seen_at=None,
+            runtime_ref='mux:w1:p1',
+            session_ref=None,
+            workspace_path=str(project_root),
+            project_id=context.project_id,
+            backend_type='pane-backed',
+            queue_depth=0,
+            socket_path=None,
+            health='healthy',
+        )
+    )
+    monkeypatch.setattr('workspace.reconcile.is_pid_alive', lambda _pid: True)
+
+    def fail_marker_write(*args, **kwargs):
+        del args, kwargs
+        raise OSError('marker directory unavailable')
+
+    monkeypatch.setattr('workspace.reconcile.atomic_write_json', fail_marker_write)
+
+    summary = reconcile_start_workspaces(project_root, type('Config', (), {'agents': {}})())
+
+    retirement = summary.retired[0]
+    assert retirement.cleanup_deferred is True
+    assert retirement.cleanup_deferred_persisted is False
+    assert retirement.cleanup_reason == 'runtime_process_alive'
+    assert paths.agent_cleanup_deferred_path('retired').exists() is False
+
+
+def test_reconcile_reports_deferred_marker_clear_failure(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    project_root = tmp_path / 'repo'
+    project_root.mkdir()
+    paths = PathLayout(project_root)
+    marker = paths.agent_cleanup_deferred_path('retired')
+    marker.parent.mkdir(parents=True)
+    marker.write_text(
+        json.dumps(
+            {
+                'schema_version': 1,
+                'record_type': 'agent_cleanup_deferred',
+                'agent_name': 'retired',
+                'reason': 'file_in_use',
+            }
+        ),
+        encoding='utf-8',
+    )
+    mailbox_file = paths.agent_mailbox_dir('retired') / 'mailbox.json'
+    mailbox_file.parent.mkdir(parents=True)
+    mailbox_file.write_text('{}\n', encoding='utf-8')
+    original_unlink = Path.unlink
+
+    def fail_marker_unlink(path, *args, **kwargs):
+        if path == marker:
+            raise OSError('marker is locked')
+        return original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, 'unlink', fail_marker_unlink)
+
+    summary = reconcile_start_workspaces(project_root, type('Config', (), {'agents': {}})())
+
+    retirement = summary.retired[0]
+    assert retirement.removed_agent_state is True
+    assert retirement.cleanup_deferred is False
+    assert retirement.cleanup_reason == 'deferred_marker_clear_failed'
+    assert retirement.cleanup_marker_cleared is False
+    assert marker.exists() is True
+
+
+def test_reconcile_ignores_unknown_deferred_marker_schema(tmp_path: Path) -> None:
+    project_root = tmp_path / 'repo'
+    project_root.mkdir()
+    paths = PathLayout(project_root)
+    marker = paths.agent_cleanup_deferred_path('retired')
+    marker.parent.mkdir(parents=True)
+    marker.write_text(
+        json.dumps(
+            {
+                'schema_version': 999,
+                'record_type': 'agent_cleanup_deferred',
+                'agent_name': 'retired',
+                'reason': 'file_in_use',
+            }
+        ),
+        encoding='utf-8',
+    )
+    mailbox_file = paths.agent_mailbox_dir('retired') / 'mailbox.json'
+    mailbox_file.parent.mkdir(parents=True)
+    mailbox_file.write_text('{}\n', encoding='utf-8')
+
+    summary = reconcile_start_workspaces(project_root, type('Config', (), {'agents': {}})())
+
+    assert summary.retired == ()
+    assert mailbox_file.exists() is True
+    assert marker.exists() is True
+
+
+def test_reconcile_retries_file_in_use_until_cleanup_succeeds(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    project_root = tmp_path / 'repo'
+    project_root.mkdir()
+    paths = PathLayout(project_root)
+    AgentSpecStore(paths).save(_spec(name='retired', workspace_mode=WorkspaceMode.INPLACE))
+    state_file = paths.agent_dir('retired') / 'provider-state' / 'codex' / 'home' / 'goals.sqlite'
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text('state\n', encoding='utf-8')
+    original_rmtree = shutil.rmtree
+    failed = False
+
+    def fail_once(target, *args, **kwargs):
+        nonlocal failed
+        if not failed and Path(target) == paths.agent_dir('retired'):
+            failed = True
+            raise PermissionError('file is being used by another process')
+        return original_rmtree(target, *args, **kwargs)
+
+    monkeypatch.setattr('workspace.reconcile.shutil.rmtree', fail_once)
+    monkeypatch.setattr('workspace.reconcile.time.sleep', lambda _delay: None)
+
+    summary = reconcile_start_workspaces(project_root, type('Config', (), {'agents': {}})())
+
+    assert failed is True
+    assert paths.agent_dir('retired').exists() is False
+    assert summary.retired[0].removed_agent_state is True
+    assert summary.retired[0].cleanup_deferred is False
+    assert paths.agent_cleanup_deferred_path('retired').exists() is False
+
+
+def test_render_worktree_retirements_includes_cleanup_persistence_state() -> None:
+    item = WorkspaceRetirement(
+        agent_name='retired',
+        branch_name=None,
+        workspace_path='',
+        reason='file_in_use',
+        removed_agent_state=False,
+        cleanup_deferred=True,
+        cleanup_reason='file_in_use',
+        cleanup_deferred_persisted=False,
+        cleanup_marker_cleared=None,
+    )
+
+    assert render_worktree_retirements((item,)) == (
+        'worktree_retired: agent=retired reason=file_in_use branch=<none> '
+        'removed_agent_state=false cleanup_deferred=true '
+        'cleanup_deferred_persisted=false cleanup_marker_cleared=unknown '
+        'cleanup_reason=file_in_use path=<none>',
+    )
 
 
 def _init_git_repo(project_root: Path) -> None:

--- a/test/test_workspace_git_worktree.py
+++ b/test/test_workspace_git_worktree.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 import subprocess
 
@@ -84,6 +85,7 @@ def test_workspace_status_keeps_other_untracked_file_dirty_even_with_owned_bindi
     assert workspace_is_dirty(plan.workspace_path, binding_authority=authority) is True
 
 
+@pytest.mark.skipif(os.name == 'nt', reason='Windows does not permit newline in file names')
 def test_workspace_status_handles_unusual_untracked_filename_without_losing_it(tmp_path: Path) -> None:
     _project_root, plan, authority = _managed_worktree(tmp_path)
     (plan.workspace_path / 'user\nartifact.txt').write_text('keep me\n', encoding='utf-8')


### PR DESCRIPTION
Includes the latest three commits from main:\n\n- fix(herdr): exec provider command inside shell wrapper\n- fix(herdr): release pane agent authority instead of pinning state\n- fix: handle non-UTF-8 subprocess output on Windows