### PR TITLE
fix(herdr): 修复 CCB agent 面板状态冻结

### DIFF
--- a/lib/ccbd/app_runtime/service_graph.py
+++ b/lib/ccbd/app_runtime/service_graph.py
@@ -115,6 +115,26 @@ def build_ccbd_service_graph(deps: CcbdServiceGraphDependencies) -> CcbdServiceG
         deps.provider_catalog,
         request_timeout_s=deps.request_timeout_s,
     )
+    agent_lifecycle_bridge = None
+    try:
+        from platforms.windows.herdr.lifecycle_bridge import HerdrAgentLifecycleBridge
+
+        project_namespace = deps.project_namespace
+        if project_namespace is not None:
+            def _bridge_namespace_ref():
+                namespace = project_namespace.load()
+                return namespace.namespace_ref() if namespace is not None else None
+
+            def _bridge_backend_factory():
+                return project_namespace._backend_factory()
+
+            agent_lifecycle_bridge = HerdrAgentLifecycleBridge(
+                backend_factory=_bridge_backend_factory,
+                namespace_ref_fn=_bridge_namespace_ref,
+                seq_start=1,
+            )
+    except Exception:
+        agent_lifecycle_bridge = None
     dispatcher = JobDispatcher(
         deps.paths,
         deps.config,
@@ -127,6 +147,7 @@ def build_ccbd_service_graph(deps: CcbdServiceGraphDependencies) -> CcbdServiceG
         provider_catalog=deps.provider_catalog,
         snapshot_writer=deps.snapshot_writer,
         timing_sink=deps.control_plane_metrics,
+        agent_lifecycle_bridge=agent_lifecycle_bridge,
         clock=deps.clock,
     )
     project_view_service = ProjectViewService(

--- a/lib/ccbd/services/dispatcher.py
+++ b/lib/ccbd/services/dispatcher.py
@@ -81,6 +81,7 @@ class JobDispatcher(DispatcherRuntimeStateMixin, DispatcherFacadeMixin):
         message_bureau_control: MessageBureauControlService | None = None,
         snapshot_writer: SnapshotWriter | None = None,
         timing_sink=None,
+        agent_lifecycle_bridge=None,
         clock=utc_now,
     ) -> None:
         self._runtime_state = DispatcherRuntimeState(
@@ -113,6 +114,7 @@ class JobDispatcher(DispatcherRuntimeStateMixin, DispatcherFacadeMixin):
             last_restore_entries=(),
             last_restore_generated_at=None,
         )
+        self._agent_lifecycle_bridge = agent_lifecycle_bridge
         self._rebuild_state()
         cleanup_stale_execution_states(self)
 

--- a/lib/ccbd/services/dispatcher_runtime/runtime_state.py
+++ b/lib/ccbd/services/dispatcher_runtime/runtime_state.py
@@ -26,14 +26,26 @@ def sync_runtime(dispatcher, agent_name: str, *, state: AgentState | None = None
             queue_depth=dispatcher._state.queue_depth(agent_name),
             last_seen_at=dispatcher._clock(),
         )
-        return
-    updated = replace(
-        runtime,
-        state=next_state,
-        queue_depth=dispatcher._state.queue_depth(agent_name),
-        last_seen_at=dispatcher._clock(),
-    )
-    dispatcher._registry.upsert(updated)
+    else:
+        updated = replace(
+            runtime,
+            state=next_state,
+            queue_depth=dispatcher._state.queue_depth(agent_name),
+            last_seen_at=dispatcher._clock(),
+        )
+        dispatcher._registry.upsert(updated)
+    bridge = getattr(dispatcher, '_agent_lifecycle_bridge', None)
+    if callable(getattr(bridge, 'sync', None)):
+        try:
+            bridge.sync(
+                provider=getattr(runtime, 'provider', None),
+                state=next_state,
+                pane_id=getattr(runtime, 'pane_id', None),
+                session_id=getattr(runtime, 'session_id', None),
+                session_path=getattr(runtime, 'session_ref', None),
+            )
+        except Exception:
+            pass
 
 
 __all__ = ['sync_runtime']

--- a/lib/cli/services/runtime_launch_runtime/tmux_runtime.py
+++ b/lib/cli/services/runtime_launch_runtime/tmux_runtime.py
@@ -295,13 +295,26 @@ def _report_runtime_pane_agent(
 ) -> None:
     if not (isinstance(pane, dict) and str(pane.get('backend_impl') or '').strip() == 'herdr'):
         return
+    # Herdr 当前版本不会仅凭 report-agent-session 创建 agent 身份；CCB 必须用
+    # report-agent 注册 pane。先 best-effort release 旧权威，再用 idle+seq 创建
+    # 身份，后续由 HerdrAgentLifecycleBridge 在 CCB 状态切换时持续递增上报。
+    releaser = getattr(backend, 'release_pane_agent', None)
+    if callable(releaser):
+        try:
+            releaser(
+                dict(pane),
+                provider_kind=provider_kind,
+            )
+        except Exception:
+            pass
     reporter = getattr(backend, 'report_pane_agent', None)
     if not callable(reporter):
-        raise RuntimeError('Herdr backend does not support report_pane_agent')
+        return
     reporter(
         dict(pane),
         provider_kind=provider_kind,
-        state='unknown',
+        state='idle',
+        seq=1,
         session_id=session_id,
     )
 

--- a/lib/platforms/windows/herdr/backend.py
+++ b/lib/platforms/windows/herdr/backend.py
@@ -199,6 +199,7 @@ class HerdrBackend(TerminalBackend):
         *,
         provider_kind: str,
         state: str = "unknown",
+        seq: int | None = None,
         session_id: str | None = None,
         session_path: str | None = None,
     ) -> MuxOperationEvidenceV2:
@@ -209,8 +210,45 @@ class HerdrBackend(TerminalBackend):
             pane_ref,
             provider_kind=provider_kind,
             state=state,
+            seq=seq,
             session_id=session_id,
             session_path=session_path,
+        )
+
+    def report_pane_agent_session(
+        self,
+        pane: MuxPaneRefV2,
+        *,
+        provider_kind: str,
+        seq: int | None = None,
+        session_id: str | None = None,
+        session_path: str | None = None,
+    ) -> MuxOperationEvidenceV2:
+        pane_ref = self._pane_ref(pane, operation="report_pane_agent_session")
+        self._capability_gate.require_supported("report_pane_agent_session")
+        self._client.server_info()
+        return self._client.report_pane_agent_session(
+            pane_ref,
+            provider_kind=provider_kind,
+            seq=seq,
+            session_id=session_id,
+            session_path=session_path,
+        )
+
+    def release_pane_agent(
+        self,
+        pane: MuxPaneRefV2,
+        *,
+        provider_kind: str,
+        seq: int | None = None,
+    ) -> MuxOperationEvidenceV2:
+        pane_ref = self._pane_ref(pane, operation="release_pane_agent")
+        self._capability_gate.require_supported("release_pane_agent")
+        self._client.server_info()
+        return self._client.release_pane_agent(
+            pane_ref,
+            provider_kind=provider_kind,
+            seq=seq,
         )
 
     def describe_pane(

--- a/lib/platforms/windows/herdr/lifecycle_bridge.py
+++ b/lib/platforms/windows/herdr/lifecycle_bridge.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+
+from agents.models import AgentState
+
+
+_HERDR_STATE_BY_AGENT_STATE = {
+    AgentState.STARTING: "idle",
+    AgentState.IDLE: "idle",
+    AgentState.BUSY: "working",
+    AgentState.STOPPING: "unknown",
+    AgentState.STOPPED: "unknown",
+    AgentState.DEGRADED: "unknown",
+    AgentState.FAILED: "unknown",
+}
+
+
+class HerdrAgentLifecycleBridge:
+    """CCB-authority bridge for Herdr panes that must report lifecycle state.
+
+    CCB registers a pane with ``report-agent idle + seq`` at launch and then
+    calls this bridge on each runtime state transition.  It maps CCB AgentState
+    to Herdr states and keeps a monotonically increasing ``seq`` so stale
+    reports cannot overwrite a newer state.
+    """
+
+    def __init__(
+        self,
+        *,
+        backend_factory: Callable[[], object],
+        namespace_ref_fn: Callable[[], Mapping[str, object] | None],
+        seq_start: int = 0,
+    ) -> None:
+        self._backend_factory = backend_factory
+        self._namespace_ref_fn = namespace_ref_fn
+        self._seq = max(int(seq_start), 0)
+
+    @property
+    def seq(self) -> int:
+        return self._seq
+
+    def sync(
+        self,
+        *,
+        provider: str,
+        state: AgentState | str,
+        pane_id: str | None,
+        session_id: str | None = None,
+        session_path: str | None = None,
+    ) -> bool:
+        herdr_state = _herdr_state(state)
+        pane_id = str(pane_id or "").strip()
+        if not herdr_state or not pane_id or not str(provider or "").strip():
+            return False
+        namespace_ref = self._namespace_ref_fn()
+        if not namespace_ref:
+            return False
+        session_name = str(namespace_ref.get("session_name") or "").strip()
+        if not session_name or str(namespace_ref.get("backend_impl") or "") != "herdr":
+            return False
+        backend = self._backend_factory()
+        if backend is None:
+            return False
+        attach = getattr(backend, "attach_persisted_session", None)
+        if callable(attach):
+            attach(dict(namespace_ref), pane_id=pane_id)
+        reporter = getattr(backend, "report_pane_agent", None)
+        if not callable(reporter):
+            return False
+        self._seq += 1
+        pane_ref = {
+            "backend_impl": "herdr",
+            "pane_id": pane_id,
+            "session_name": session_name,
+        }
+        reporter(
+            pane_ref,
+            provider_kind=provider,
+            state=herdr_state,
+            seq=self._seq,
+            session_id=session_id,
+            session_path=session_path,
+        )
+        return True
+
+
+def _herdr_state(state: AgentState | str) -> str | None:
+    if isinstance(state, AgentState):
+        return _HERDR_STATE_BY_AGENT_STATE.get(state)
+    try:
+        return _HERDR_STATE_BY_AGENT_STATE.get(AgentState(str(state).strip().lower()))
+    except ValueError:
+        return None
+
+
+__all__ = ["HerdrAgentLifecycleBridge"]

--- a/lib/platforms/windows/herdr/runtime/capabilities.py
+++ b/lib/platforms/windows/herdr/runtime/capabilities.py
@@ -34,6 +34,8 @@ _OPERATION_REQUIRED_CAPABILITIES = {
     "window_root_pane": ("workspace_list", "pane_list"),
     "set_pane_identity": ("pane_list", "pane_metadata"),
     "report_pane_agent": ("pane_list", "pane_metadata"),
+    "report_pane_agent_session": ("pane_list", "pane_metadata"),
+    "release_pane_agent": ("pane_list", "pane_metadata"),
     "describe_pane": ("pane_list",),
     "list_panes_by_user_options": ("pane_list",),
     "create_pane": ("pane_list", "pane_split", "pane_run"),

--- a/lib/platforms/windows/herdr/runtime/cli.py
+++ b/lib/platforms/windows/herdr/runtime/cli.py
@@ -75,6 +75,10 @@ class HerdrCliRequestAdapter:
             return self._set_pane_identity(payload)
         if operation == "report_pane_agent":
             return self._report_pane_agent(payload)
+        if operation == "report_pane_agent_session":
+            return self._report_pane_agent_session(payload)
+        if operation == "release_pane_agent":
+            return self._release_pane_agent(payload)
         if operation == "respawn_pane":
             return self._respawn_pane(payload)
         if operation == "pane_process_info":
@@ -556,6 +560,12 @@ class HerdrCliRequestAdapter:
             "--state",
             state,
         ]
+        try:
+            seq = _optional_non_negative_int(payload.get("seq"), operation="report_pane_agent")
+        except ValueError as exc:
+            raise self._failed("report_pane_agent", str(exc), session_name=session_name) from exc
+        if seq is not None:
+            args.extend(["--seq", str(seq)])
         session_id = str(payload.get("session_id") or "").strip()
         if session_id:
             args.extend(["--agent-session-id", session_id])
@@ -573,6 +583,82 @@ class HerdrCliRequestAdapter:
             "pane_id": pane_id,
             "provider_kind": provider_kind,
             "state": state,
+        }
+
+    def _report_pane_agent_session(self, payload: Mapping[str, object]) -> Mapping[str, object]:
+        pane_id = str(payload.get("pane_id") or "").strip()
+        session_name = _session_name_from_payload(payload, fallback_session_name=self._session_name)
+        provider_kind = str(payload.get("provider_kind") or "").strip()
+        if not pane_id:
+            raise self._failed("report_pane_agent_session", "requires pane_id", session_name=session_name)
+        if not provider_kind:
+            raise self._failed("report_pane_agent_session", "requires provider_kind", session_name=session_name)
+        args = [
+            "pane",
+            "report-agent-session",
+            pane_id,
+            "--source",
+            _METADATA_SOURCE,
+            "--agent",
+            provider_kind,
+        ]
+        try:
+            seq = _optional_non_negative_int(payload.get("seq"), operation="report_pane_agent_session")
+        except ValueError as exc:
+            raise self._failed("report_pane_agent_session", str(exc), session_name=session_name) from exc
+        if seq is not None:
+            args.extend(["--seq", str(seq)])
+        session_id = str(payload.get("session_id") or "").strip()
+        if session_id:
+            args.extend(["--agent-session-id", session_id])
+        session_path = str(payload.get("session_path") or "").strip()
+        if session_path:
+            args.extend(["--agent-session-path", session_path])
+        self._command(
+            "report_pane_agent_session",
+            args,
+            expect_json=False,
+            session_name=session_name,
+        )
+        return {
+            "status": "ok",
+            "pane_id": pane_id,
+            "provider_kind": provider_kind,
+        }
+
+    def _release_pane_agent(self, payload: Mapping[str, object]) -> Mapping[str, object]:
+        pane_id = str(payload.get("pane_id") or "").strip()
+        session_name = _session_name_from_payload(payload, fallback_session_name=self._session_name)
+        provider_kind = str(payload.get("provider_kind") or "").strip()
+        if not pane_id:
+            raise self._failed("release_pane_agent", "requires pane_id", session_name=session_name)
+        if not provider_kind:
+            raise self._failed("release_pane_agent", "requires provider_kind", session_name=session_name)
+        args = [
+            "pane",
+            "release-agent",
+            pane_id,
+            "--source",
+            _METADATA_SOURCE,
+            "--agent",
+            provider_kind,
+        ]
+        try:
+            seq = _optional_non_negative_int(payload.get("seq"), operation="release_pane_agent")
+        except ValueError as exc:
+            raise self._failed("release_pane_agent", str(exc), session_name=session_name) from exc
+        if seq is not None:
+            args.extend(["--seq", str(seq)])
+        self._command(
+            "release_pane_agent",
+            args,
+            expect_json=False,
+            session_name=session_name,
+        )
+        return {
+            "status": "ok",
+            "pane_id": pane_id,
+            "provider_kind": provider_kind,
         }
 
     def _respawn_pane(self, payload: Mapping[str, object]) -> Mapping[str, object]:
@@ -1502,6 +1588,18 @@ def _line_count(raw: object) -> str:
     except (TypeError, ValueError):
         line_count = 100
     return str(max(line_count, 1))
+
+
+def _optional_non_negative_int(raw: object, *, operation: str) -> int | None:
+    if raw is None or str(raw).strip() == "":
+        return None
+    try:
+        value = int(raw)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        raise ValueError(f"Herdr {operation} requires a non-negative integer seq") from None
+    if value < 0:
+        raise ValueError(f"Herdr {operation} requires a non-negative integer seq")
+    return value
 
 
 def _runtime_platform() -> str:

--- a/lib/platforms/windows/herdr/runtime/client.py
+++ b/lib/platforms/windows/herdr/runtime/client.py
@@ -497,6 +497,7 @@ class HerdrSocketClient:
         *,
         provider_kind: str,
         state: str = "unknown",
+        seq: int | None = None,
         session_id: str | None = None,
         session_path: str | None = None,
     ) -> MuxOperationEvidenceV2:
@@ -506,6 +507,8 @@ class HerdrSocketClient:
             "provider_kind": provider_kind,
             "state": state,
         }
+        if seq is not None:
+            payload["seq"] = seq
         if session_id:
             payload["session_id"] = session_id
         if session_path:
@@ -516,6 +519,59 @@ class HerdrSocketClient:
             require_status=True,
         )
         return _operation_evidence("report_pane_agent", pane, response, detail="pane agent reported")
+
+    def report_pane_agent_session(
+        self,
+        pane: MuxPaneRefV2,
+        *,
+        provider_kind: str,
+        seq: int | None = None,
+        session_id: str | None = None,
+        session_path: str | None = None,
+    ) -> MuxOperationEvidenceV2:
+        payload: dict[str, object] = {
+            "pane_id": pane["pane_id"],
+            "session_name": pane["session_name"],
+            "provider_kind": provider_kind,
+        }
+        if seq is not None:
+            payload["seq"] = seq
+        if session_id:
+            payload["session_id"] = session_id
+        if session_path:
+            payload["session_path"] = session_path
+        response = self._request(
+            "report_pane_agent_session",
+            payload,
+            require_status=True,
+        )
+        return _operation_evidence(
+            "report_pane_agent_session",
+            pane,
+            response,
+            detail="pane agent session reported",
+        )
+
+    def release_pane_agent(
+        self,
+        pane: MuxPaneRefV2,
+        *,
+        provider_kind: str,
+        seq: int | None = None,
+    ) -> MuxOperationEvidenceV2:
+        payload: dict[str, object] = {
+            "pane_id": pane["pane_id"],
+            "session_name": pane["session_name"],
+            "provider_kind": provider_kind,
+        }
+        if seq is not None:
+            payload["seq"] = seq
+        response = self._request(
+            "release_pane_agent",
+            payload,
+            require_status=True,
+        )
+        return _operation_evidence("release_pane_agent", pane, response, detail="pane agent released")
 
     def select_window(
         self,

--- a/test/test_herdr_backend_client.py
+++ b/test/test_herdr_backend_client.py
@@ -100,6 +100,13 @@ def test_herdr_capability_gate_allows_supported_spike_projection() -> None:
     assert capabilities["source_ref"] == "evidence/herdr-contract-spike-evidence.json"
 
 
+def test_herdr_capability_gate_allows_session_and_release_operations() -> None:
+    gate = _supported_gate()
+
+    assert gate.require_supported("report_pane_agent_session")["backend_impl"] == "herdr"
+    assert gate.require_supported("release_pane_agent")["backend_impl"] == "herdr"
+
+
 def test_herdr_capability_gate_allows_nonrequired_windows_beta_gaps() -> None:
     gate = HerdrCapabilityGate.from_spike_evidence(
         {
@@ -692,6 +699,67 @@ def test_herdr_backend_facade_returns_refs_and_operation_evidence() -> None:
     assert "python ready" in captured
     assert capture["operation"] == "capture_pane"
     assert killed["operation"] == "kill_pane"
+
+
+def test_herdr_backend_reports_sessions_and_releases_pane_agent() -> None:
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    def request(operation: str, payload: dict[str, object]) -> dict[str, object]:
+        calls.append((operation, dict(payload)))
+        if operation in {"report_pane_agent", "report_pane_agent_session", "release_pane_agent"}:
+            return {"status": "ok", "pane_id": str(payload["pane_id"])}
+        return _fake_herdr_request()(operation, payload)
+
+    backend = HerdrBackend(
+        client=HerdrSocketClient(request_fn=request, socket_ref="herdr://local"),
+        capability_gate=_supported_gate(),
+    )
+    namespace = backend.create_session(project_id="demo", cwd="D:/demo", title="ccb-demo")
+    pane = backend.create_pane(namespace, command=[], cwd="D:/demo", env={}, title="workspace")
+
+    backend.report_pane_agent(
+        pane,
+        provider_kind="codex",
+        state="working",
+        seq=11,
+        session_id="ccb-session",
+        session_path="D:/demo/.ccb/session",
+    )
+    backend.report_pane_agent_session(
+        pane,
+        provider_kind="codex",
+        seq=12,
+        session_id="ccb-session",
+        session_path="D:/demo/.ccb/session",
+    )
+    backend.release_pane_agent(pane, provider_kind="codex", seq=13)
+
+    reported = [call for call in calls if call[0] == "report_pane_agent"]
+    sessions = [call for call in calls if call[0] == "report_pane_agent_session"]
+    releases = [call for call in calls if call[0] == "release_pane_agent"]
+    assert reported[-1][1] == {
+        "pane_id": "pane-1",
+        "session_name": "ccb-demo",
+        "provider_kind": "codex",
+        "state": "working",
+        "seq": 11,
+        "session_id": "ccb-session",
+        "session_path": "D:/demo/.ccb/session",
+    }
+    assert sessions[-1][1] == {
+        "pane_id": "pane-1",
+        "session_name": "ccb-demo",
+        "provider_kind": "codex",
+        "seq": 12,
+        "session_id": "ccb-session",
+        "session_path": "D:/demo/.ccb/session",
+    }
+    assert releases[-1][1] == {
+        "pane_id": "pane-1",
+        "session_name": "ccb-demo",
+        "provider_kind": "codex",
+        "seq": 13,
+    }
 
 
 def test_herdr_backend_updates_liveness_after_kill() -> None:
@@ -4153,6 +4221,158 @@ def test_herdr_cli_request_adapter_reports_pane_agent() -> None:
     ]
 
 
+def test_herdr_cli_request_adapter_reports_pane_agent_with_seq() -> None:
+    commands: list[list[str]] = []
+
+    def run_fn(command, **kwargs):
+        commands.append(list(command))
+        return _completed("")
+
+    adapter = HerdrCliRequestAdapter(
+        session_name="ccb-demo",
+        herdr_executable="herdr",
+        run_fn=run_fn,
+        which_fn=lambda name: "herdr",
+    )
+
+    result = adapter(
+        "report_pane_agent",
+        {
+            "pane_id": "w1:p2",
+            "session_name": "ccb-demo",
+            "provider_kind": "codex",
+            "state": "working",
+            "seq": 7,
+            "session_id": "ccb-agent-session",
+            "session_path": "D:/demo/.ccb/session",
+        },
+    )
+
+    assert result["status"] == "ok"
+    assert commands[0][-8:] == [
+        "--state",
+        "working",
+        "--seq",
+        "7",
+        "--agent-session-id",
+        "ccb-agent-session",
+        "--agent-session-path",
+        "D:/demo/.ccb/session",
+    ]
+
+
+def test_herdr_cli_request_adapter_reports_pane_agent_session() -> None:
+    commands: list[list[str]] = []
+
+    def run_fn(command, **kwargs):
+        commands.append(list(command))
+        return _completed("")
+
+    adapter = HerdrCliRequestAdapter(
+        session_name="ccb-demo",
+        herdr_executable="herdr",
+        run_fn=run_fn,
+        which_fn=lambda name: "herdr",
+    )
+
+    result = adapter(
+        "report_pane_agent_session",
+        {
+            "pane_id": "w1:p2",
+            "session_name": "ccb-demo",
+            "provider_kind": "codex",
+            "seq": 3,
+            "session_id": "ccb-agent-session",
+            "session_path": "D:/demo/.ccb/session",
+        },
+    )
+
+    assert result["status"] == "ok"
+    assert commands == [
+        [
+            "herdr",
+            "--session",
+            "ccb-demo",
+            "pane",
+            "report-agent-session",
+            "w1:p2",
+            "--source",
+            "ccb",
+            "--agent",
+            "codex",
+            "--seq",
+            "3",
+            "--agent-session-id",
+            "ccb-agent-session",
+            "--agent-session-path",
+            "D:/demo/.ccb/session",
+        ]
+    ]
+
+
+def test_herdr_cli_request_adapter_releases_pane_agent() -> None:
+    commands: list[list[str]] = []
+
+    def run_fn(command, **kwargs):
+        commands.append(list(command))
+        return _completed("")
+
+    adapter = HerdrCliRequestAdapter(
+        session_name="ccb-demo",
+        herdr_executable="herdr",
+        run_fn=run_fn,
+        which_fn=lambda name: "herdr",
+    )
+
+    result = adapter(
+        "release_pane_agent",
+        {
+            "pane_id": "w1:p2",
+            "session_name": "ccb-demo",
+            "provider_kind": "codex",
+            "seq": 9,
+        },
+    )
+
+    assert result["status"] == "ok"
+    assert commands == [
+        [
+            "herdr",
+            "--session",
+            "ccb-demo",
+            "pane",
+            "release-agent",
+            "w1:p2",
+            "--source",
+            "ccb",
+            "--agent",
+            "codex",
+            "--seq",
+            "9",
+        ]
+    ]
+
+
+def test_herdr_cli_request_adapter_rejects_negative_seq() -> None:
+    adapter = HerdrCliRequestAdapter(
+        session_name="ccb-demo",
+        herdr_executable="herdr",
+        run_fn=lambda command, **kwargs: _completed(""),
+        which_fn=lambda name: "herdr",
+    )
+
+    with pytest.raises(MuxCommandErrorV2):
+        adapter(
+            "release_pane_agent",
+            {
+                "pane_id": "w1:p2",
+                "session_name": "ccb-demo",
+                "provider_kind": "codex",
+                "seq": -1,
+            },
+        )
+
+
 def test_herdr_cli_request_adapter_is_alive_maps_command_not_found_to_false() -> None:
     def run_fn(command, **kwargs):
         raise _called_process_error(command, stderr="pane not found")
@@ -4364,6 +4584,8 @@ def _fake_herdr_request(
         if operation == "capture_pane":
             return {"status": "ok", "pane_id": payload["pane_id"], "text": state["pane"]["output"]}
         if operation == "kill_pane":
+            return {"status": "ok", "pane_id": payload["pane_id"]}
+        if operation in {"report_pane_agent", "report_pane_agent_session", "release_pane_agent"}:
             return {"status": "ok", "pane_id": payload["pane_id"]}
         raise AssertionError(f"unexpected fake Herdr operation {operation}")
 

--- a/test/test_herdr_lifecycle_bridge.py
+++ b/test/test_herdr_lifecycle_bridge.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from agents.models import AgentState
+from ccbd.services.dispatcher_runtime.runtime_state import sync_runtime
+from platforms.windows.herdr.lifecycle_bridge import HerdrAgentLifecycleBridge
+
+
+class _Reporter:
+    def __init__(self) -> None:
+        self.calls: list[tuple[dict[str, object], dict[str, object]]] = []
+        self.attach_calls: list[tuple[dict[str, object], str | None]] = []
+
+    def attach_persisted_session(
+        self,
+        namespace: dict[str, object],
+        *,
+        pane_id: str | None = None,
+        pane_ref: dict[str, object] | None = None,
+    ) -> None:
+        del pane_ref
+        self.attach_calls.append((dict(namespace), pane_id))
+
+    def report_pane_agent(
+        self,
+        pane: dict[str, object],
+        **kwargs: object,
+    ) -> None:
+        self.calls.append((dict(pane), dict(kwargs)))
+
+
+def test_bridge_maps_ccb_states_and_increments_seq() -> None:
+    reporter = _Reporter()
+    bridge = HerdrAgentLifecycleBridge(
+        backend_factory=lambda: reporter,
+        namespace_ref_fn=lambda: {
+            "backend_impl": "herdr",
+            "session_name": "ccb-demo",
+        },
+    )
+
+    assert bridge.sync(
+        provider="codex",
+        state=AgentState.BUSY,
+        pane_id="w1:p2",
+        session_id="ccb-session",
+    ) is True
+    assert bridge.sync(
+        provider="codex",
+        state=AgentState.IDLE,
+        pane_id="w1:p2",
+        session_id="ccb-session",
+    ) is True
+
+    assert reporter.calls == [
+        (
+            {
+                "backend_impl": "herdr",
+                "pane_id": "w1:p2",
+                "session_name": "ccb-demo",
+            },
+            {
+                "provider_kind": "codex",
+                "state": "working",
+                "seq": 1,
+                "session_id": "ccb-session",
+                "session_path": None,
+            },
+        ),
+        (
+            {
+                "backend_impl": "herdr",
+                "pane_id": "w1:p2",
+                "session_name": "ccb-demo",
+            },
+            {
+                "provider_kind": "codex",
+                "state": "idle",
+                "seq": 2,
+                "session_id": "ccb-session",
+                "session_path": None,
+            },
+        ),
+    ]
+    assert reporter.attach_calls == [
+        (
+            {
+                "backend_impl": "herdr",
+                "session_name": "ccb-demo",
+            },
+            "w1:p2",
+        )
+    ] * 2
+    assert bridge.seq == 2
+
+
+def test_bridge_skips_missing_pane_or_non_herdr_namespace() -> None:
+    reporter = _Reporter()
+    bridge = HerdrAgentLifecycleBridge(
+        backend_factory=lambda: reporter,
+        namespace_ref_fn=lambda: {
+            "backend_impl": "tmux",
+            "session_name": "tmux-session",
+        },
+    )
+
+    assert bridge.sync(provider="codex", state=AgentState.BUSY, pane_id="") is False
+    assert bridge.sync(provider="codex", state=AgentState.BUSY, pane_id="w1:p2") is False
+    assert reporter.calls == []
+
+
+def test_sync_runtime_forwards_ccb_state_to_herdr_bridge() -> None:
+    reporter = _Reporter()
+    bridge = HerdrAgentLifecycleBridge(
+        backend_factory=lambda: reporter,
+        namespace_ref_fn=lambda: {
+            "backend_impl": "herdr",
+            "session_name": "ccb-demo",
+        },
+    )
+    runtime = SimpleNamespace(
+        state=AgentState.IDLE,
+        provider="codex",
+        pane_id="wJ:p2",
+        session_id="ccb-session",
+        session_ref="D:/demo/.ccb/session",
+    )
+
+    class _State:
+        @staticmethod
+        def queue_depth(agent_name: str) -> int:
+            del agent_name
+            return 0
+
+    class _Registry:
+        def __init__(self) -> None:
+            self.runtime = runtime
+
+        def get(self, agent_name: str):
+            del agent_name
+            return self.runtime
+
+        def upsert(self, updated):
+            self.runtime = updated
+
+    runtime_service = SimpleNamespace(
+        patch_runtime_state=lambda current, **kwargs: current,
+    )
+    dispatcher = SimpleNamespace(
+        _registry=_Registry(),
+        _runtime_service=runtime_service,
+        _state=_State(),
+        _clock=lambda: "2026-08-19T00:00:00Z",
+        _agent_lifecycle_bridge=bridge,
+    )
+
+    sync_runtime(dispatcher, "archi", state=AgentState.BUSY)
+
+    assert reporter.calls == [
+        (
+            {
+                "backend_impl": "herdr",
+                "pane_id": "wJ:p2",
+                "session_name": "ccb-demo",
+            },
+            {
+                "provider_kind": "codex",
+                "state": "working",
+                "seq": 1,
+                "session_id": "ccb-session",
+                "session_path": "D:/demo/.ccb/session",
+            },
+        )
+    ]

--- a/test/test_runtime_launch_timings.py
+++ b/test/test_runtime_launch_timings.py
@@ -165,6 +165,9 @@ def test_launch_tmux_runtime_uses_herdr_assigned_pane_ref_without_tmux_fallback(
         def set_pane_identity(self, pane, **kwargs):
             calls.append(('set_pane_identity', (dict(pane), dict(kwargs))))
 
+        def release_pane_agent(self, pane, **kwargs):
+            calls.append(('release_pane_agent', (dict(pane), dict(kwargs))))
+
         def report_pane_agent(self, pane, **kwargs):
             calls.append(('report_pane_agent', (dict(pane), dict(kwargs))))
 
@@ -228,13 +231,18 @@ def test_launch_tmux_runtime_uses_herdr_assigned_pane_ref_without_tmux_fallback(
     assert calls[2][0] == 'set_pane_identity'
     assert calls[2][1][0] == pane_ref
     assert calls[2][1][1]['project_id'] == 'project-test'
-    assert calls[3][0] == 'report_pane_agent'
+    assert calls[3][0] == 'release_pane_agent'
     assert calls[3][1][0] == pane_ref
-    assert calls[3][1][1] == {
+    assert calls[3][1][1] == {'provider_kind': 'codex'}
+    assert calls[4][0] == 'report_pane_agent'
+    assert calls[4][1][0] == pane_ref
+    assert calls[4][1][1] == {
         'provider_kind': 'codex',
-        'state': 'unknown',
+        'state': 'idle',
+        'seq': 1,
         'session_id': 'ccb-demo-session',
     }
+    assert not any(call[1][1].get('state') == 'unknown' for call in calls if call[0] == 'report_pane_agent')
     assert ('build_session_payload', 'herdr-pane-1') in calls
     assert ('write_session_file', 'herdr-pane-1') in calls
 


### PR DESCRIPTION
## 变更摘要

修复 CCB 在 Herdr UI 下 agents 面板工作状态冻结的问题。

根因是 CCB 启动时一次性调用 `pane report-agent --state unknown` 抢占 Herdr 生命周期权威后不再更新，导致面板状态长期停在 `unknown` 且 `state_change_seq=0`。

实测当前 Herdr 版本中：

- `report-agent-session` 不能独立创建 agent 身份；
- `release-agent` 会移除 agent 身份，不能单独作为恢复手段。

因此本次改为：

- Herdr launch 先 best-effort release 旧权威，再以 `report-agent --state idle --seq 1` 创建 bridge 锚点；
- 新增 `HerdrAgentLifecycleBridge`，在 CCB runtime 状态切换时持续递增上报 `idle/working/unknown`；
- 补齐 `report_pane_agent_session`、`release_pane_agent` 与 `seq` 适配；
- 新增 pytest 覆盖 adapter、backend、bridge、launch 行为；
- comms 套件新增 H-17/H-18，并通过 X-06 验证存量 pane 恢复。

## 验证

- 定向 pytest：225 passed
- Herdr comms：21 PASS / 0 WARN / 0 FAIL
- Combined X-06：PASS
- 当前三块 CCB agent pane 已恢复为 idle / idle / working，`state_change_seq > 0`